### PR TITLE
Fogl 3747: c++ PiServer North plugin does not properly manage the change of an OMF type

### DIFF
--- a/C/plugins/common/omf.cpp
+++ b/C/plugins/common/omf.cpp
@@ -1875,7 +1875,7 @@ void OMF::setTypeId()
  */
 void OMF::clearCreatedTypes(const string& key)
 {
-	// FIXME_I: test
+	// FIXME_I: test - v2
 	if (m_OMFDataTypes)
 	{
 		auto it = m_OMFDataTypes->find(key);

--- a/C/plugins/common/omf.cpp
+++ b/C/plugins/common/omf.cpp
@@ -1875,6 +1875,7 @@ void OMF::setTypeId()
  */
 void OMF::clearCreatedTypes(const string& key)
 {
+	// FIXME_I: test
 	if (m_OMFDataTypes)
 	{
 		auto it = m_OMFDataTypes->find(key);


### PR DESCRIPTION
initial stage