### PR TITLE
FOGL-3756: Repo name for sqlite pkg has changed and hence its static …

### DIFF
--- a/C/plugins/storage/sqlite/CMakeLists.txt
+++ b/C/plugins/storage/sqlite/CMakeLists.txt
@@ -6,8 +6,8 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(STORAGE_COMMON_LIB storage-common-lib)
 
-# Path of compiled libsqlite3.a and .h files: /tmp/fledge-sqlite3-pkg/src
-set(FLEDGE_SQLITE3_LIBS "/tmp/fledge-sqlite3-pkg/src" CACHE INTERNAL "")
+# Path of compiled libsqlite3.a and .h files: /tmp/sqlite3-pkg/src
+set(FLEDGE_SQLITE3_LIBS "/tmp/sqlite3-pkg/src" CACHE INTERNAL "")
 
 # Find source files
 file(GLOB SOURCES ./common/*.cpp *.cpp)

--- a/C/plugins/storage/sqlitememory/CMakeLists.txt
+++ b/C/plugins/storage/sqlitememory/CMakeLists.txt
@@ -6,8 +6,8 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(STORAGE_COMMON_LIB storage-common-lib)
 
-# Path of compiled libsqlite3.a and .h files: /tmp/fledge-sqlite3-pkg/src
-set(FLEDGE_SQLITE3_LIBS "/tmp/fledge-sqlite3-pkg/src" CACHE INTERNAL "")
+# Path of compiled libsqlite3.a and .h files: /tmp/sqlite3-pkg/src
+set(FLEDGE_SQLITE3_LIBS "/tmp/sqlite3-pkg/src" CACHE INTERNAL "")
 
 # Find source files
 # Add sqlite plugin common files

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ AUTH_CERTIFICATES_SCRIPT_SRC := scripts/auth_certificates
 PACKAGE_UPDATE_SCRIPT_SRC   := scripts/package
 
 # Custom location of SQLite3 library
-FLEDGE_HAS_SQLITE3_PATH    := /tmp/fledge-sqlite3-pkg/src
+FLEDGE_HAS_SQLITE3_PATH    := /tmp/sqlite3-pkg/src
 
 # EXTRA SCRIPTS
 EXTRAS_SCRIPTS_SRC_DIR      := extras/scripts

--- a/tests/unit/C/cmake_sqlite/CMakeLists.txt
+++ b/tests/unit/C/cmake_sqlite/CMakeLists.txt
@@ -6,8 +6,8 @@ set(CMAKE_CXX_FLAGS "-std=c++11 -O3")
 
 set(STORAGE_COMMON_LIB storage-common-lib)
 
-# Path of compiled libsqlite3.a and .h files: /tmp/fledge-sqlite3-pkg/src
-set(FLEDGE_SQLITE3_LIBS "/tmp/fledge-sqlite3-pkg/src" CACHE INTERNAL "")
+# Path of compiled libsqlite3.a and .h files: /tmp/sqlite3-pkg/src
+set(FLEDGE_SQLITE3_LIBS "/tmp/sqlite3-pkg/src" CACHE INTERNAL "")
 
 ## sqlitememory plugin
 include_directories(../../../../C/thirdparty/rapidjson/include)

--- a/tests/unit/C/plugins/storage/sqlitememory/CMakeLists.txt
+++ b/tests/unit/C/plugins/storage/sqlitememory/CMakeLists.txt
@@ -31,7 +31,7 @@ file(GLOB COMMON_SOURCES ../sqlitememory/*.cpp)
 file(GLOB test_sources tests.cpp)
 
 # Check for SQLite3 source tree in specific location
-set(FLEDGE_SQLITE3_LIBS "/tmp/fledge-sqlite3-pkg/src" CACHE INTERNAL "")
+set(FLEDGE_SQLITE3_LIBS "/tmp/sqlite3-pkg/src" CACHE INTERNAL "")
 if(EXISTS ${FLEDGE_SQLITE3_LIBS})
 	message(STATUS "Using SLITE3 source files in ${FLEDGE_SQLITE3_LIBS}")
 	include_directories(${FLEDGE_SQLITE3_LIBS})


### PR DESCRIPTION
…library gets created in a different directory now in /tmp. Updated the same in related cmake files.

Signed-off-by: Amandeep Singh Arora <aman@dianomic.com>