### PR TITLE
Fogl 3814: Implement the 'Name Map' functionality as outlined in the Google document 'Hierarchies, PI Server and FogLAMP'

### DIFF
--- a/C/plugins/common/include/omf.h
+++ b/C/plugins/common/include/omf.h
@@ -252,7 +252,6 @@ class OMF
 			// {"",         ""}
 		};
 
-
 		map<std::string, std::string>  m_MetadataRulesExist={
 
 			// Property   - Asset Framework path

--- a/C/plugins/common/include/omf.h
+++ b/C/plugins/common/include/omf.h
@@ -15,6 +15,7 @@
 #include <reading.h>
 #include <http_sender.h>
 #include <zlib.h>
+#include <rapidjson/document.h>
 
 #define TYPE_ID_DEFAULT 1
 #define FAKE_ASSET_KEY		"_default_start_id_"
@@ -24,6 +25,7 @@
 #define OMF_TYPE_UNSUPPORTED	"unsupported"
 
 using namespace std;
+using namespace rapidjson;
 
 /**
  * Per asset dataTypes
@@ -212,6 +214,7 @@ class OMF
 
 		bool handleAFHierarchy();
 		bool handleAFHierarchySystemWide();
+		bool handleAFHierarchiesNamesMap();
 		bool handleAFHierarchiesMetadataMap();
 		bool sendAFHierarchy(std::string AFHierarchy);
 
@@ -222,9 +225,12 @@ class OMF
 		bool AFHierarchySendMessage(const std::string& msgType, std::string& jsonData);
 
 		std::string generateUniquePrefixId(const std::string &path);
-		void evaluateAFHierarchyMetadataRules(const string& assetName, const Reading& reading);
+		void evaluateAFHierarchyRules(const string& assetName, const Reading& reading);
 		void retrieveAFHierarchyPrefix(const Reading& reading, string& prefix, string& AFHierarchyLevel);
 		void retrieveAFHierarchyPrefixAssetName(string assetName, string& prefix, string& AFHierarchyLevel);
+
+		bool HandleAFMapNames(Document& JSon);
+		bool HandleAFMapMetedata(Document& JSon);
 
 	private:
 		const std::string	m_path;
@@ -235,9 +241,17 @@ class OMF
 
 		// AF hierarchies handling - Metadata MAP
 		std::string		m_AFMap;
-		bool            m_AFMapEmpty;  // true if there are norules to manage
+		bool            m_AFMapEmptyNames;  // true if there are norules to manage
+		bool            m_AFMapEmptyMetadata;
 		std::string		m_AFHierarchyLevel;
 		std::string		m_prefixAFAsset;
+
+		map<std::string, std::string>  m_NamesRules={
+
+			// Asset_name   - Asset Framework path
+			// {"",         ""}
+		};
+
 
 		map<std::string, std::string>  m_MetadataRulesExist={
 

--- a/C/plugins/common/include/omf.h
+++ b/C/plugins/common/include/omf.h
@@ -136,6 +136,13 @@ class OMF
 
 		void generateAFHierarchyPrefixLevel(string& path, string& prefix, string& AFHierarchyLevel);
 
+		// Retrieve private objects
+		map<std::string, std::string> getNamesRules() const { return m_NamesRules; };
+		map<std::string, std::string> getMetadataRulesExist() const { return m_MetadataRulesExist; };
+
+		bool getAFMapEmptyNames() const { return m_AFMapEmptyNames; };
+		bool getAFMapEmptyMetadata() const { return m_AFMapEmptyMetadata; };
+
 	private:
 		/**
 		 * Builds the HTTP header to send

--- a/C/plugins/common/omf.cpp
+++ b/C/plugins/common/omf.cpp
@@ -2109,7 +2109,11 @@ void OMF::setDefaultAFLocation(const string &DefaultAFLocation)
 	m_DefaultAFLocation = StringSlashFix(DefaultAFLocation);
 }
 
-// FIXME_I:
+/**
+ * Set the rules to address where assets should be placed in the AF hierarchy.
+ * Decodes the JSON and assign to the structures the values about the Names rulues
+ *
+ */
 bool OMF::HandleAFMapNames(Document& JSon)
 {
 	bool success = true;
@@ -2134,7 +2138,11 @@ bool OMF::HandleAFMapNames(Document& JSon)
 	return success;
 }
 
-// FIXME_I:
+/**
+ * Set the rules to address where assets should be placed in the AF hierarchy.
+ * Decodes the JSON and assign to the structures the values about the Metadata rulues
+ *
+ */
 bool OMF::HandleAFMapMetedata(Document& JSon)
 {
 	bool success = true;
@@ -2240,8 +2248,7 @@ bool OMF::HandleAFMapMetedata(Document& JSon)
 }
 
 /**
- * Set the rules to address where assets should be placed in the AF hierarchy.
- * Decodes the JSON and assign to the structures the values about the Metadata rulues
+ * Set the Names and Metadata rules to address where assets should be placed in the AF hierarchy.
  *
  */
 bool OMF::setAFMap(const string &AFMap)
@@ -2263,7 +2270,6 @@ bool OMF::setAFMap(const string &AFMap)
 	if (JSon.HasMember("names"))
 	{
 		HandleAFMapNames(JSon);
-
 	}
 	if (JSon.HasMember("metadata"))
 	{
@@ -2272,7 +2278,6 @@ bool OMF::setAFMap(const string &AFMap)
 
 	return success;
 }
-
 
 /**
  * Set the first level of hierarchy in Asset Framework in which the assets will be created, PI Web API only.

--- a/C/plugins/common/omf.cpp
+++ b/C/plugins/common/omf.cpp
@@ -790,6 +790,32 @@ bool OMF::sendAFHierarchyLevels(string parentPath, string path, std::string &las
 }
 
 /**
+ * Creates all the hierarcies defined in the Names map rules
+ *
+ * @param out		true if succeded
+ */
+bool OMF::handleAFHierarchiesNamesMap() {
+
+	bool success = true;
+	string asset_name;
+	string hierarchy;
+
+	for (auto itr = m_NamesRules.begin(); itr != m_NamesRules.end(); ++itr)
+	{
+		asset_name = itr->first.c_str();
+		hierarchy = itr->second.c_str();
+
+		Logger::getLogger()->debug("handleAFHierarchiesNamesMap - asset_name :%s: hierarchy :%s:",
+								   asset_name.c_str(),
+								   hierarchy.c_str());
+
+		success = sendAFHierarchy(hierarchy.c_str());
+	}
+
+	return success;
+}
+
+/**
  * Handle the AF hierarchies for the Metadata Map
  *
  * @param out		true if succeded
@@ -899,6 +925,11 @@ bool OMF::handleAFHierarchy()
 	{
 
 		success = handleAFHierarchySystemWide();
+
+		if (success)
+		{
+			success = handleAFHierarchiesNamesMap();
+		}
 		if (success)
 		{
 			success = handleAFHierarchiesMetadataMap();
@@ -990,7 +1021,7 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 		long typeId = OMF::getAssetTypeId((**elem).getAssetName());
 		string key((**elem).getAssetName());
 
-		evaluateAFHierarchyMetadataRules (key, **elem);
+		evaluateAFHierarchyRules(key, **elem);
 
 		if (! AFHierarchySent)
 		{
@@ -1726,18 +1757,49 @@ void OMF::retrieveAFHierarchyPrefixAssetName(string assetName, string& prefix, s
 }
 
 /**
- * Evaluated the maps containing the Metadata rules to fill the map m_AssetNamePrefix
+ * Evaluated the maps containing the Named and Metadata rules to fill the map m_AssetNamePrefix
  * containing for each assetname the related prefix and hierarchy name
  *
  * @param path                   assetName to evaluate
  * @param reading		         reading row from which will be extracted the datapoint for the evaluation of the rules
  */
-void OMF::evaluateAFHierarchyMetadataRules(const string& assetName, const Reading& reading)
+void OMF::evaluateAFHierarchyRules(const string& assetName, const Reading& reading)
 {
 	bool ruleMatched = false;
+	bool ruleMatchedNames = false;
 
-	// Check if there are any rules defined or not
-	if (! m_AFMapEmpty)
+	// names rules - Check if there are any rules defined or not
+	if (! m_AFMapEmptyNames)
+	{
+		if (m_NamesRules.size() > 0)
+		{
+			string path;
+			string prefix;
+			string AFHierarchyLevel;
+
+			auto it = m_NamesRules.find(assetName);
+			if (it != m_NamesRules.end())
+			{
+				path = it->second;
+
+				if (path.at(0) != '/')
+				{
+					// relative  path
+					path = m_DefaultAFLocation + "/" + path;
+				}
+				generateAFHierarchyPrefixLevel(path, prefix, AFHierarchyLevel);
+				ruleMatched = true;
+				ruleMatchedNames = true;
+
+				auto item = make_pair(AFHierarchyLevel, prefix);
+				m_AssetNamePrefix[assetName].push_back(item);
+			}
+		}
+	}
+
+
+	// Metata rules - Check if there are any rules defined or not
+	if (! m_AFMapEmptyMetadata && ! ruleMatchedNames)
 	{
 		auto values = reading.getReadingData();
 
@@ -1908,8 +1970,6 @@ void OMF::evaluateAFHierarchyMetadataRules(const string& assetName, const Readin
 				}
 			}
 		}
-
-
 	}
 
 	// If no rules matched se the AF default location
@@ -2049,34 +2109,38 @@ void OMF::setDefaultAFLocation(const string &DefaultAFLocation)
 	m_DefaultAFLocation = StringSlashFix(DefaultAFLocation);
 }
 
-/**
- * Set the rules to address where assets should be placed in the AF hierarchy.
- * Decodes the JSON and assign to the structures the values about the Metadata rulues
- *
- */
-bool OMF::setAFMap(const string &AFMap)
+// FIXME_I:
+bool OMF::HandleAFMapNames(Document& JSon)
 {
 	bool success = true;
-	Document JSon;
 	string name;
 	string value;
 
-	m_AFMapEmpty = true;
+	Value &JsonNames = JSon["names"];
 
-	m_AFMap = AFMap;
-
-	ParseResult ok = JSon.Parse(m_AFMap.c_str());
-	if (!ok)
+	for (Value::ConstMemberIterator itr = JsonNames.MemberBegin(); itr != JsonNames.MemberEnd(); ++itr)
 	{
-		Logger::getLogger()->error("setAFMap - Invalid Asset Framework Map, error :%s:", GetParseError_En(JSon.GetParseError()));
-		return false;
+		name = itr->name.GetString();
+		value = itr->value.GetString();
+		Logger::getLogger()->debug("HandleAFMapNames - Exist name :%s: value :%s:", name.c_str(), value.c_str());
+
+		auto newMapValue = make_pair(name,value);
+
+		m_NamesRules.insert (newMapValue);
+
+		m_AFMapEmptyNames = false;
 	}
 
-	if (!JSon.HasMember("metadata"))
-	{
-		Logger::getLogger()->debug("setAFMap - metadata section not defined");
-		return true;
-	}
+	return success;
+}
+
+// FIXME_I:
+bool OMF::HandleAFMapMetedata(Document& JSon)
+{
+	bool success = true;
+	string name;
+	string value;
+
 	Value &JsonMetadata = JSon["metadata"];
 
 	// --- Handling Exist section
@@ -2088,13 +2152,13 @@ bool OMF::setAFMap(const string &AFMap)
 		{
 			name = itr->name.GetString();
 			value = itr->value.GetString();
-			Logger::getLogger()->debug("setAFMap - Exist name :%s: value :%s:", name.c_str(), value.c_str());
+			Logger::getLogger()->debug("HandleAFMapMetedata - Exist name :%s: value :%s:", name.c_str(), value.c_str());
 
 			auto newMapValue = make_pair(name,value);
 
 			m_MetadataRulesExist.insert (newMapValue);
 
-			m_AFMapEmpty = false;
+			m_AFMapEmptyMetadata = false;
 		}
 	}
 
@@ -2107,13 +2171,13 @@ bool OMF::setAFMap(const string &AFMap)
 		{
 			name = itr->name.GetString();
 			value = itr->value.GetString();
-			Logger::getLogger()->debug("setAFMap - Non Exist name :%s: value :%s:", name.c_str(), value.c_str());
+			Logger::getLogger()->debug("HandleAFMapMetedata - Non Exist name :%s: value :%s:", name.c_str(), value.c_str());
 
 			auto newMapValue = make_pair(name,value);
 
 			m_MetadataRulesNonExist.insert (newMapValue);
 
-			m_AFMapEmpty = false;
+			m_AFMapEmptyMetadata = false;
 		}
 	}
 
@@ -2136,12 +2200,12 @@ bool OMF::setAFMap(const string &AFMap)
 			{
 				value = itrL2->name.GetString();
 				path  = itrL2->value.GetString();
-				Logger::getLogger()->debug("setAFMap - equal property :%s: name :%s: value :%s:", property.c_str() , value.c_str(), path.c_str());
+				Logger::getLogger()->debug("HandleAFMapMetedata - equal property :%s: name :%s: value :%s:", property.c_str() , value.c_str(), path.c_str());
 
 				auto item = make_pair(value,path);
 				m_MetadataRulesEqual[property].push_back(item);
 
-				m_AFMapEmpty = false;
+				m_AFMapEmptyMetadata = false;
 			}
 		}
 	}
@@ -2163,15 +2227,49 @@ bool OMF::setAFMap(const string &AFMap)
 			{
 				value = itrL2->name.GetString();
 				path  = itrL2->value.GetString();
-				Logger::getLogger()->debug("setAFMap - Not equal property :%s: name :%s: value :%s:", property.c_str() , value.c_str(), path.c_str());
+				Logger::getLogger()->debug("HandleAFMapMetedata - Not equal property :%s: name :%s: value :%s:", property.c_str() , value.c_str(), path.c_str());
 
 				auto item = make_pair(value,path);
 				m_MetadataRulesNotEqual[property].push_back(item);
 
-				m_AFMapEmpty = false;
+				m_AFMapEmptyMetadata = false;
 			}
 		}
 	}
+	return success;
+}
+
+/**
+ * Set the rules to address where assets should be placed in the AF hierarchy.
+ * Decodes the JSON and assign to the structures the values about the Metadata rulues
+ *
+ */
+bool OMF::setAFMap(const string &AFMap)
+{
+	bool success = true;
+	Document JSon;
+
+	m_AFMapEmptyNames = true;
+	m_AFMapEmptyMetadata = true;
+	m_AFMap = AFMap;
+
+	ParseResult ok = JSon.Parse(m_AFMap.c_str());
+	if (!ok)
+	{
+		Logger::getLogger()->error("setAFMap - Invalid Asset Framework Map, error :%s:", GetParseError_En(JSon.GetParseError()));
+		return false;
+	}
+
+	if (JSon.HasMember("names"))
+	{
+		HandleAFMapNames(JSon);
+
+	}
+	if (JSon.HasMember("metadata"))
+	{
+		HandleAFMapMetedata(JSon);
+	}
+
 	return success;
 }
 

--- a/C/plugins/common/omf.cpp
+++ b/C/plugins/common/omf.cpp
@@ -911,7 +911,6 @@ bool OMF::handleAFHierarchiesMetadataMap() {
 	return success;
 }
 
-
 /**
  * Handle the creation of AF hierarchies
  *
@@ -926,11 +925,11 @@ bool OMF::handleAFHierarchy()
 
 		success = handleAFHierarchySystemWide();
 
-		if (success)
+		if (success and ! m_AFMapEmptyNames)
 		{
 			success = handleAFHierarchiesNamesMap();
 		}
-		if (success)
+		if (success and ! m_AFMapEmptyMetadata)
 		{
 			success = handleAFHierarchiesMetadataMap();
 		}

--- a/tests/unit/C/plugins/common/test_omf_translation.cpp
+++ b/tests/unit/C/plugins/common/test_omf_translation.cpp
@@ -21,6 +21,52 @@ using namespace rapidjson;
 #define TYPE_ID 1234
 
 // 2 readings JSON text
+const char *af_hierarchy_test01 = R"(
+{
+	"names" :
+			{
+					"3814_asset2" : "/Building1/EastWing/GroundFloor/Room4",
+					"3814_asset3" : "Room14",
+					"3814_asset4" : "names_asset4"
+			},
+	"metadata" : {
+		"exist" : {
+			"sinusoid4"     : "md_asset4",
+			"sinusoid4_1"   : "md_asset4_1",
+			"sinusoid2"     : "md_asset5"
+		}
+	}
+}
+)";
+
+const char *af_hierarchy_test02 = R"(
+{
+}
+)";
+
+map<std::string, std::string> af_hierarchy_check01 ={
+	// Asset_name   - Asset Framework path
+	{"3814_asset2",         "/Building1/EastWing/GroundFloor/Room4"},
+	{"3814_asset3",         "Room14"},
+	{"3814_asset4",         "names_asset4"}
+};
+
+map<std::string, std::string> af_hierarchy_check02 ={
+
+	// Asset_name   - Asset Framework path
+	{"sinusoid4",         "md_asset4"},
+	{"sinusoid4_1",       "md_asset4_1"},
+	{"sinusoid2",         "md_asset5"}
+};
+
+map<std::string, std::string> af_hierarchy_check03 ={
+
+	// Asset_name   - Asset Framework path
+	{"sinusoid4",         "md_asset4"}
+};
+
+
+// 2 readings JSON text
 const char *two_readings = R"(
     {
         "count" : 2, "rows" : [
@@ -314,4 +360,76 @@ TEST(OMF_transation, ReadingsWithUnsupportedTypes)
 		// Array size is 1
 		ASSERT_EQ(doc.Size(), 2);
 	}
+}
+
+// Test the Asset Framework hierarchy fucntionlities
+TEST(OMF_AfHierarchy, HandleAFMapNamesGood)
+{
+	Document JSon;
+
+	map<std::string, std::string> NamesRules;
+	map<std::string, std::string> MetadataRulesExist;
+
+	bool AFMapEmptyNames;
+	bool AFMapEmptyMetadata;
+
+	// Dummy initializations
+	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
+	OMF omf(sender, "/", 1, "ABC");
+
+	omf.setAFMap(af_hierarchy_test01);
+
+	NamesRules = omf.getNamesRules();
+	MetadataRulesExist = omf.getMetadataRulesExist();
+
+	// Test
+	ASSERT_EQ(NamesRules,         af_hierarchy_check01);
+	ASSERT_EQ(MetadataRulesExist, af_hierarchy_check02);
+
+	AFMapEmptyNames = omf.getAFMapEmptyNames();
+	AFMapEmptyMetadata = omf.getAFMapEmptyMetadata();
+
+	ASSERT_EQ(AFMapEmptyNames, false);
+	ASSERT_EQ(AFMapEmptyMetadata, false);
+}
+
+TEST(OMF_AfHierarchy, HandleAFMapEmpty)
+{
+	Document JSon;
+
+	map<std::string, std::string> NamesRules;
+	map<std::string, std::string> MetadataRulesExist;
+
+	bool AFMapEmptyNames;
+	bool AFMapEmptyMetadata;
+
+	// Dummy initializations
+	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
+	OMF omf(sender, "/", 1, "ABC");
+	
+	// Test
+	omf.setAFMap(af_hierarchy_test02);
+
+	AFMapEmptyNames = omf.getAFMapEmptyNames();
+	AFMapEmptyMetadata = omf.getAFMapEmptyMetadata();
+
+	ASSERT_EQ(AFMapEmptyNames, true);
+	ASSERT_EQ(AFMapEmptyMetadata, true);
+}
+
+TEST(OMF_AfHierarchy, HandleAFMapNamesBad)
+{
+	Document JSon;
+
+	map<std::string, std::string> MetadataRulesExist;
+	
+	// Dummy initializations
+	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
+	OMF omf(sender, "/", 1, "ABC");
+
+	omf.setAFMap(af_hierarchy_test01);
+	MetadataRulesExist = omf.getMetadataRulesExist();
+
+	// Test 02
+	ASSERT_NE(MetadataRulesExist, af_hierarchy_check03);
 }


### PR DESCRIPTION
Signed-off-by: Stefano <stefano@dianomic.com>

Tests

assets:
```
curl  -s -S  -i -X POST http://localhost:${storage_port}/storage/reading  -d  @- << EOF

{
  "readings" : [

    { "user_ts" : "2020-03-05 10:01:01",           "asset_code": "3814_asset1",  "reading" : {"sinusoid1":100}},
    { "user_ts" : "2020-03-05 10:02:01",           "asset_code": "3814_asset2",  "reading" : {"sinusoid2":200}},
    { "user_ts" : "2020-03-05 10:02:01",           "asset_code": "3814_asset3",  "reading" : {"sinusoid3":300}},
    { "user_ts" : "2020-03-05 10:02:01",           "asset_code": "3814_asset4",  "reading" : {"sinusoid4":400}},
    { "user_ts" : "2020-03-05 10:02:01",           "asset_code": "3814_asset4_1",  "reading" : {"sinusoid4_1":400}},
    { "user_ts" : "2020-03-05 10:02:01",           "asset_code": "3814_asset5",  "reading" : {"sinusoid2":500}}
  ]
}

EOF
```
rules:
```
curl  -s -S  -i -X  PUT http://localhost:8081/fledge/category/North_Readings_to_PI/AFMap   -d  @- << EOF
{
    "value" :
	{
        "names" :
                {
                        "3814_asset2" : "/Building1/EastWing/GroundFloor/Room4",
                        "3814_asset3" : "Room14",
                        "3814_asset4" : "names_asset4"
                },
		"metadata" : {
			"exist" : {
			    "sinusoid4"     : "md_asset4",
			    "sinusoid4_1"   : "md_asset4_1",
			    "sinusoid2"     : "md_asset5"
			}
		}
	}
}
EOF
```

outcomes, Ubuntu :
 
![image](https://user-images.githubusercontent.com/4919069/76398722-aba4fd80-637d-11ea-8ecf-9173c67e54a8.png)


Buster: 
![image](https://user-images.githubusercontent.com/4919069/76404120-430e4e80-6386-11ea-8fa9-041dbd8b6454.png)
