### PR TITLE
FOGL-3283: asset tracker updated on sent not on load

### DIFF
--- a/C/tasks/north/sending_process/sending_process.cpp
+++ b/C/tasks/north/sending_process/sending_process.cpp
@@ -292,19 +292,6 @@ static void loadDataThread(SendingProcess *loadData)
 					loadData->m_buffer.at(readIdx) = readings;
 				}
 
-				// Update asset tracker table/cache, if required
-				vector<Reading *> *vec = loadData->m_buffer.at(readIdx)->getAllReadingsPtr();
-				for (vector<Reading *>::iterator it = vec->begin(); it != vec->end(); ++it)
-				{
-					Reading *reading = *it;
-					AssetTrackingTuple tuple(loadData->getName(), loadData->getPluginName(), reading->getAssetName(), "Egress");
-					if (!AssetTracker::getAssetTracker()->checkAssetTrackingCache(tuple))
-					{
-						AssetTracker::getAssetTracker()->addAssetTrackingTuple(tuple);
-						Logger::getLogger()->info("loadDataThread(): Adding new asset tracking tuple seen during readings' egress: %s", tuple.assetToString().c_str());
-					}
-				}
-
 				readMutex.unlock();
 
 				readIdx++;
@@ -462,6 +449,21 @@ static void sendDataThread(SendingProcess *sendData)
 				{
 					processUpdate = true;
 					exitCode = 0;
+
+					// Update asset tracker table/cache, if required
+					vector<Reading *> *vec = sendData->m_buffer.at(sendIdx)->getAllReadingsPtr();
+
+					for (vector<Reading *>::iterator it = vec->begin(); it != vec->end(); ++it)
+					{
+						Reading *reading = *it;
+
+						AssetTrackingTuple tuple(sendData->getName(), sendData->getPluginName(), reading->getAssetName(), "Egress");
+						if (!AssetTracker::getAssetTracker()->checkAssetTrackingCache(tuple))
+						{
+							AssetTracker::getAssetTracker()->addAssetTrackingTuple(tuple);
+							Logger::getLogger()->info("sendDataThread:  Adding new asset tracking tuple - egress: %s", tuple.assetToString().c_str());
+						}
+					}
 				}
 			}
 			else


### PR DESCRIPTION
Signed-off-by: Stefano <stefano@dianomic.com>
data not sent:
```
{
  "track": [
    {
      "asset": "sinusoid",
      "event": "Ingest",
      "service": "sinusoid1",
      "fledge": "Fledge",
      "plugin": "sinusoid",
      "timestamp": "2020-03-12 15:43:51.729"
    }
  ]
}
{
  "uptime": 62,
  "dataRead": 2,
  "dataSent": 0,
  "dataPurged": 0,
  "authenticationOptional": true,
  "serviceName": "Fledge",
  "hostName": "ihsdev",
  "ipAddresses": [
    "192.168.1.50"
  ],
  "health": "green",
  "safeMode": false
}
```

data sent:
```
{
  "track": [
    {
      "asset": "sinusoid",
      "event": "Ingest",
      "service": "sinusoid1",
      "fledge": "Fledge",
      "plugin": "sinusoid",
      "timestamp": "2020-03-12 15:47:28.007"
    },
    {
      "asset": "sinusoid",
      "event": "Egress",
      "service": "North_Readings_to_PI",
      "fledge": "Fledge",
      "plugin": "PI_Server_V2",
      "timestamp": "2020-03-12 15:47:30.097"
    }
  ]
}
{
  "uptime": 110,
  "dataRead": 2,
  "dataSent": 2,
  "dataPurged": 0,
  "authenticationOptional": true,
  "serviceName": "Fledge",
  "hostName": "ihsdev",
  "ipAddresses": [
    "192.168.1.50"
  ],
  "health": "green",
  "safeMode": false
}
```
