### PR TITLE
FOGL-3867 - UTC Zulu time added in python sending process

### DIFF
--- a/python/fledge/tasks/north/sending_process.py
+++ b/python/fledge/tasks/north/sending_process.py
@@ -137,7 +137,7 @@ def apply_date_format(in_data):
     # Look for timezone start with '-' a the end of the date (-XY:WZ)
     zone_index = in_data.rfind("-")
     # If index is less than 10 we don't have the trailing zone with -
-    if (zone_index < 10):
+    if zone_index < 10:
         #  Look for timezone start with '+' (+XY:ZW)
         zone_index = in_data.rfind("+")
     if zone_index == -1:
@@ -154,7 +154,9 @@ def apply_date_format(in_data):
     else:
         # Replace space with T (i.e b/w date & time) and UTC Zulu time
         timestamp = in_data[:zone_index].replace(" ", "T") + "Z"
-        _LOGGER.warning(" {} datetime with timezone is found. Hence replaced with Zulu time: {}".format(in_data, timestamp))
+        if in_data[zone_index:] not in ('+00', '+00:00'):
+            _LOGGER.warning("Non-UTC {} timezone is found. Hence no date conversion is done at the time being "
+                            "this routine expects UTC date time values".format(in_data[zone_index:]))
     return timestamp
 
 

--- a/python/fledge/tasks/north/sending_process.py
+++ b/python/fledge/tasks/north/sending_process.py
@@ -115,18 +115,20 @@ class InvalidCommandLineParameters(RuntimeError):
 
 
 def apply_date_format(in_data):
-    """ This routine adds the default UTC zone format to the input date time string
-    If a timezone (strting with + or -) is found, all the following chars
-    are replaced by +00, otherwise +00 is added.
+    """ This routine adds the UTC Zulu time to the input date time string
+    a) Space in datetime string is replaced with "T"
+    b) If a timezone (strting with + or -) is found, all the following chars
+    are replaced by "Z", otherwise Z is added.
     Note: if the input zone is +02:00 no date conversion is done,
           at the time being this routine expects UTC date time values.
     Examples:
-        2018-05-28 16:56:55              ==> 2018-05-28 16:56:55.000000+00
-        2018-05-28 13:42:28.84           ==> 2018-05-28 13:42:28.840000+00
-        2018-03-22 17:17:17.166347       ==> 2018-03-22 17:17:17.166347+00
-        2018-03-22 17:17:17.166347+00:00 ==> 2018-03-22 17:17:17.166347+00
-        2018-03-22 17:17:17.166347+00    ==> 2018-03-22 17:17:17.166347+00
-        2018-03-22 17:17:17.166347+02:00 ==> 2018-03-22 17:17:17.166347+00
+        2018-05-28 16:56:55              ==> 2018-05-28T16:56:55.000000Z
+        2018-05-28 13:42:28.84           ==> 2018-05-28T13:42:28.840000Z
+        2018-03-22 17:17:17.166347       ==> 2018-03-22T17:17:17.166347Z
+        2020-03-30 05:35:24.066553Z      ==> 2020-03-30T05:35:24.066553Z
+        2018-03-22 17:17:17.166347+00:00 ==> 2018-03-22T17:17:17.166347Z
+        2018-03-22 17:17:17.166347+00    ==> 2018-03-22T17:17:17.166347Z
+        2018-03-22 17:17:17.166347+02:00 ==> 2018-03-22T17:17:17.166347Z
     Args:
         the date time string to format
     Returns:
@@ -144,11 +146,15 @@ def apply_date_format(in_data):
             in_data += ".000000"
         # Pads with 0 if needed
         in_data = in_data.ljust(26, '0')
-        # Just add +00
-        timestamp = in_data + "+00"
+        # Replace space with T (i.e b/w date & time)
+        timestamp = in_data.replace(" ", "T")
+        # Just add UTC Zulu time if Z not present in in_data
+        if 'Z' not in in_data:
+            timestamp = timestamp + "Z"
     else:
-        # Remove everything after - or + and add +00
-        timestamp = in_data[:zone_index] + "+00"
+        # Replace space with T (i.e b/w date & time) and UTC Zulu time
+        timestamp = in_data[:zone_index].replace(" ", "T") + "Z"
+        _LOGGER.warning(" {} datetime with timezone is found. Hence replaced with Zulu time: {}".format(in_data, timestamp))
     return timestamp
 
 


### PR DESCRIPTION
**Before:** - Http north python plugin is always sending with timestamp ends with **+00**

```
[{'readings': {'sinusoid': 0.0}, 'asset': 'sinusoid', 'timestamp': '2020-03-30 11:23:30.943848+00'}, {'readings': {'sinusoid': 0.104528463}, 'asset': 'sinusoid', 'timestamp': '2020-03-30 11:23:31.943831+00'}, {'readings': {'sinusoid': 0.207911691}, 'asset': 'sinusoid', 'timestamp': '2020-03-30 11:23:32.943834+00'}, {'readings': {'sinusoid': 0.309016994}, 'asset': 'sinusoid', 'timestamp': '2020-03-30 11:23:33.943837+00'}, {'readings': {'sinusoid': 0.406736643}, 'asset': 'sinusoid', 'timestamp': '2020-03-30 11:23:34.943831+00'}]#012NoneType: None
```
And with HTTP-north C-Plugin it always sends with **Zulu** timestamp Z
```
 [{"timestamp":"2020-03-30T11:02:24.185683Z","asset":"sinusoid","readings":{"sinusoid":0}},{"timestamp":"2020-03-30T11:02:25.185661Z","asset":"sinusoid","readings":{"sinusoid":0.104528463}},{"timestamp":"2020-03-30T11:02:26.185661Z","asset":"sinusoid","readings":{"sinusoid":0.207911691}},{"timestamp":"2020-03-30T11:02:27.185688Z","asset":"sinusoid","readings":{"sinusoid":0.309016994}},{"timestamp":"2020-03-30T11:02:28.185737Z","asset":"sinusoid","readings":{"sinusoid":0.406736643}}]
```

And **now** with changes made in Python sending process; HTTP north python plugins sends with **UTC Zulu time**.

```
 [{'asset': 'sinusoid', 'readings': {'sinusoid': 0.0}, 'timestamp': '2020-03-30T11:02:24.185683Z'}, {'asset': 'sinusoid', 'readings': {'sinusoid': 0.104528463}, 'timestamp': '2020-03-30T11:02:25.185661Z'}, {'asset': 'sinusoid', 'readings': {'sinusoid': 0.207911691}, 'timestamp': '2020-03-30T11:02:26.185661Z'}, {'asset': 'sinusoid', 'readings': {'sinusoid': 0.309016994}, 'timestamp': '2020-03-30T11:02:27.185688Z'}, {'asset': 'sinusoid', 'readings': {'sinusoid': 0.406736643}, 'timestamp': '2020-03-30T11:02:28.185737Z'}]#012NoneType: None

```

**HTTP-Pair Test Results**
Used FOGL-3751 - http_south branch
```
Fog1: Core (FOGL-3867), Sinusoid (develop) & HTTP-north (develop) is running
       Local time: Tue 2020-03-31 11:47:23 IST
       Universal time: Tue 2020-03-31 06:17:23 UTC
       Time zone: Asia/Kolkata (IST, +0530)
Readings:
sqlite> select * from readings;
id|asset_code|reading|user_ts|ts
1|sinusoid|{"sinusoid":0.0}|2020-03-31 06:14:13.385958+00:00|2020-03-31 06:14:16.132+00:00
2|sinusoid|{"sinusoid":0.104528463}|2020-03-31 06:14:14.385916+00:00|2020-03-31 06:14:16.132+00:00
sqlite> select * from asset_tracker;
id|asset|event|service|fledge|plugin|ts
1|sinusoid|Ingest|Sine|Fledge|sinusoid|2020-03-31 11:44:16.185
2|sinusoid|Egress|Htp|Fledge|http_north|2020-03-31 11:44:41.976
Fog2: Core (develop), HTTP-south (FOGL-3751) is running
      Local time: Tue 2020-03-31 07:20:18 BST
      Universal time: Tue 2020-03-31 06:20:18 UTC
      Time zone: Europe/London (BST, +0100)
Readings:
sqlite> select * from readings;
id|asset_code|reading|user_ts|ts
1|http-sinusoid|{"sinusoid":0.0}|2020-03-31 06:14:13.385958+00:00|2020-03-31 06:14:43.607+00:00
2|http-sinusoid|{"sinusoid":0.104528463}|2020-03-31 06:14:14.385916+00:00|2020-03-31 06:14:43.608+00:00
sqlite> select * from asset_tracker;
id|asset|event|service|fledge|plugin|ts
1|http-sinusoid|Ingest|HTS|Fledge|http_south|2020-03-31 07:14:43.636
```