### PR TITLE
FOGL-3905 - upgrade fixes

### DIFF
--- a/scripts/package/debian/package_update.sh
+++ b/scripts/package/debian/package_update.sh
@@ -49,7 +49,7 @@ if [ "${ret_code}" -eq "0" ]; then
 	for upgrade_file in `ls -1 ${UPGRADE_SCRIPTS_DIR}/*.sh | sort -V`
 		do
 			# Extract script version file from name
-			update_file_ver=`basename -s '.sh' $upgrade_file)`
+			update_file_ver=`basename -s '.sh' $upgrade_file`
 			# Check update_file_ver is less than previous_version
 			discard_out=`dpkg --compare-versions ${update_file_ver} le ${previous_version}`
 			file_check=$?

--- a/scripts/package/debian/upgrade/1.8.sh
+++ b/scripts/package/debian/upgrade/1.8.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+pi_server_v2_directory="/usr/local/foglamp/plugins/north/PI_Server_V2"
+if [[ -d ${pi_server_v2_directory} ]]; then
+	echo "Removing 'PI_Server_V2' North plugin"
+	rm -rf ${pi_server_v2_directory}
+fi
+
+ocs_v2_directory="/usr/local/foglamp/plugins/north/ocs_V2"
+if [[ -d ${ocs_v2_directory} ]]; then
+	echo "Removing 'ocs_V2' North plugin"
+	rm -rf ${ocs_v2_directory}
+fi

--- a/scripts/plugins/storage/sqlite/downgrade/33.sql
+++ b/scripts/plugins/storage/sqlite/downgrade/33.sql
@@ -1,0 +1,3 @@
+-- NOTE -once you are up with fledge_schema=34, Downgrade is NOT possible as we removed C-source binaries.
+--       There is no way to get these back with current support.
+-- See scripts/package/debian/upgrade/1.8.sh

--- a/scripts/plugins/storage/sqlite/upgrade/34.sql
+++ b/scripts/plugins/storage/sqlite/upgrade/34.sql
@@ -62,7 +62,7 @@ UPDATE configuration SET value =
             '$.ServerHostname.value',
             substr(json_extract(value, '$.URL.value'),
                    instr(json_extract(value, '$.URL.value'), '://') + 3,
-                   instr(replace(json_extract(value, '$.URL.value'), '://', 'xxx'), ':') -
+                   instr(REPLACE(json_extract(value, '$.URL.value'), '://', 'xxx'), ':') -
                    instr(json_extract(value, '$.URL.value'), '://') - 3)
     )
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
@@ -93,9 +93,9 @@ UPDATE configuration SET value =
              value,
              '$.ServerPort.value',
              substr(json_extract(value, '$.URL.value'),
-                    instr(replace(json_extract(value, '$.URL.value'), '://', 'xxx'), ':') + 1,
-                    instr(replace(json_extract(value, '$.URL.value'), '://', 'xxx'), '/') -
-                    instr(replace(json_extract(value, '$.URL.value'), '://', 'xxx'), ':') - 1
+                    instr(REPLACE(json_extract(value, '$.URL.value'), '://', 'xxx'), ':') + 1,
+                    instr(REPLACE(json_extract(value, '$.URL.value'), '://', 'xxx'), '/') -
+                    instr(REPLACE(json_extract(value, '$.URL.value'), '://', 'xxx'), ':') - 1
                  )
     )
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
@@ -366,7 +366,7 @@ WHERE json_extract(value, '$.plugin.value') = 'OMF';
 --- plugin_data -------------------------------------------------------------------------------------------------------
 -- plugin_data
 --
-UPDATE plugin_data SET key = replace(key,'PI_Server_V2','OMF')
+UPDATE plugin_data SET key = REPLACE(key,'PI_Server_V2','OMF')
 WHERE instr(key, 'PI_Server_V2') > 0;
 
 --- asset_tracker -------------------------------------------------------------------------------------------------------

--- a/scripts/plugins/storage/sqlite/upgrade/34.sql
+++ b/scripts/plugins/storage/sqlite/upgrade/34.sql
@@ -1,35 +1,42 @@
 
 --- configuration -------------------------------------------------------------------------------------------------------
 
--- configuration - PIServerEndpoint
+-- plugin
 --
-UPDATE configuration SET
-    value = json_set(value, '$.PIServerEndpoint.options', json_array('PI Web API','Connector Relay','OSIsoft Cloud Services','Edge Data Store') )
-WHERE json_extract(value, '$.plugin.value') = 'PI_Server_V2';
-
-UPDATE configuration SET
-    value = json_set(value, '$.PIServerEndpoint.description', 'Select the endpoint among PI Web API, Connector Relay, OSIsoft Cloud Services or Edge Data Store')
-WHERE json_extract(value, '$.plugin.value') = 'PI_Server_V2';
-
-UPDATE configuration SET
-    value = json_set(value, '$.PIServerEndpoint.order', '1')
-WHERE json_extract(value, '$.plugin.value') = 'PI_Server_V2';
-
-UPDATE configuration SET
-    value = json_set(value, '$.PIServerEndpoint.displayName', 'Endpoint')
-WHERE json_extract(value, '$.plugin.value') = 'PI_Server_V2';
-
-UPDATE configuration SET value = json_set(value, '$.PIServerEndpoint.value', 'Connector Relay')
-WHERE json_extract(value, '$.plugin.value') = 'PI_Server_V2' AND
-        json_extract(value, '$.PIServerEndpoint.value') = 'Auto Discovery';
-
 UPDATE configuration SET value = json_set(value, '$.plugin.default', 'OMF')
 WHERE json_extract(value, '$.plugin.value') = 'PI_Server_V2';
 
 UPDATE configuration SET value = json_set(value, '$.plugin.value', 'OMF')
 WHERE json_extract(value, '$.plugin.value') = 'PI_Server_V2';
 
--- configuration - ServerHostname
+-- PIServerEndpoint
+--
+UPDATE configuration SET value = json_set(value, '$.PIServerEndpoint.options', json_array('PI Web API','Connector Relay','OSIsoft Cloud Services','Edge Data Store') )
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.PIServerEndpoint.description', 'Select the endpoint among PI Web API, Connector Relay, OSIsoft Cloud Services or Edge Data Store')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.PIServerEndpoint.order', '1')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.PIServerEndpoint.displayName', 'Endpoint')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.PIServerEndpoint.default', 'Connector Relay')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.PIServerEndpoint.value', 'Connector Relay')
+WHERE json_extract(value, '$.plugin.value') = 'OMF' AND json_extract(value, '$.PIServerEndpoint.value') = 'discovery';
+
+UPDATE configuration SET value = json_set(value, '$.PIServerEndpoint.value', 'Connector Relay')
+WHERE json_extract(value, '$.plugin.value') = 'OMF' AND json_extract(value, '$.PIServerEndpoint.value') = 'cr';
+
+UPDATE configuration SET value = json_set(value, '$.PIServerEndpoint.value', 'PI Web API')
+WHERE json_extract(value, '$.plugin.value') = 'OMF' AND json_extract(value, '$.PIServerEndpoint.value') = 'piwebapi';
+
+-- ServerHostname
+-- Note: This is a new config item and its value extract from old URL config item
 --
 UPDATE configuration SET value = json_set(value, '$.ServerHostname.description', 'Hostname of the server running the endpoint either PI Web API or Connector Relay or Edge Data Store')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
@@ -55,12 +62,13 @@ UPDATE configuration SET value =
             '$.ServerHostname.value',
             substr(json_extract(value, '$.URL.value'),
                    instr(json_extract(value, '$.URL.value'), '://') + 3,
-                   instr(REPLACE(json_extract(value, '$.URL.value'), '://', 'xxx'), ':') -
+                   instr(replace(json_extract(value, '$.URL.value'), '://', 'xxx'), ':') -
                    instr(json_extract(value, '$.URL.value'), '://') - 3)
     )
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - ServerPort
+-- ServerPort
+-- Note: This is a new config item and its value extract from old URL config item
 --
 UPDATE configuration SET value = json_set(value, '$.ServerPort.description', 'Port on which the endpoint either PI Web API or Connector Relay or Edge Data Store is listening, 0 will use the default one')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
@@ -85,21 +93,20 @@ UPDATE configuration SET value =
              value,
              '$.ServerPort.value',
              substr(json_extract(value, '$.URL.value'),
-                    instr(REPLACE(json_extract(value, '$.URL.value'), '://', 'xxx'), ':') + 1,
-                    instr(REPLACE(json_extract(value, '$.URL.value'), '://', 'xxx'), '/') -
-                    instr(REPLACE(json_extract(value, '$.URL.value'), '://', 'xxx'), ':') - 1
+                    instr(replace(json_extract(value, '$.URL.value'), '://', 'xxx'), ':') + 1,
+                    instr(replace(json_extract(value, '$.URL.value'), '://', 'xxx'), '/') -
+                    instr(replace(json_extract(value, '$.URL.value'), '://', 'xxx'), ':') - 1
                  )
     )
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
-
--- configuration - URL
+-- URL
+-- Note: Removed URL config item as it is replaced by ServerHostname & ServerPort
 --
 UPDATE configuration SET value = json_remove(value, '$.URL')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
-
--- configuration - producerToken
+-- producerToken
 --
 UPDATE configuration SET value = json_set(value, '$.producerToken.order', '4')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
@@ -107,63 +114,101 @@ WHERE json_extract(value, '$.plugin.value') = 'OMF';
 UPDATE configuration SET value = json_set(value, '$.producerToken.validity', 'PIServerEndpoint == "Connector Relay"')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - source
+-- source
 --
 UPDATE configuration SET value = json_set(value, '$.source.order', '5')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - StaticData
+-- StaticData
 --
 UPDATE configuration SET value = json_set(value, '$.StaticData.order', '6')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - OMFRetrySleepTime
+-- OMFRetrySleepTime
 --
 UPDATE configuration SET value = json_set(value, '$.OMFRetrySleepTime.order', '7')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - OMFMaxRetry
+-- OMFMaxRetry
 --
 UPDATE configuration SET value = json_set(value, '$.OMFMaxRetry.order', '8')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - OMFHttpTimeout
+-- OMFHttpTimeout
 --
 UPDATE configuration SET value = json_set(value, '$.OMFHttpTimeout.order', '9')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - formatInteger
+-- formatInteger
 --
 UPDATE configuration SET value = json_set(value, '$.formatInteger.order', '10')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - formatNumber
+-- formatNumber
 --
 UPDATE configuration SET value = json_set(value, '$.formatNumber.order', '11')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - compression
+-- compression
 --
 UPDATE configuration SET value = json_set(value, '$.compression.order', '12')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - DefaultAFLocation
+--  DefaultAFLocation
+-- Note: This is a new config item and its default & value extract from old AFHierarchy1Level config item
 --
+UPDATE configuration SET value = json_set(value, '$.DefaultAFLocation.description', 'Defines the hierarchies tree in Asset Framework in which the assets will be created, each level is separated by /, PI Web API only.')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.DefaultAFLocation.type', 'string')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.DefaultAFLocation.default', json_extract(value, '$.AFHierarchy1Level.default'))
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.DefaultAFLocation.value', json_extract(value, '$.AFHierarchy1Level.value'))
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
 UPDATE configuration SET value = json_set(value, '$.DefaultAFLocation.order', '13')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.DefaultAFLocation.displayName', 'Asset Framework hierarchies tree')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
 UPDATE configuration SET value = json_set(value, '$.DefaultAFLocation.validity', 'PIServerEndpoint == "PI Web API"')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - AFMap
+-- AFHierarchy1Level
+-- Note: Removed AFHierarchy1Level config item as it is replaced by new config item DefaultAFLocation
 --
+UPDATE configuration SET value = json_remove(value, '$.AFHierarchy1Level')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+-- AFMap
+-- Note: This is a new config item
+--
+UPDATE configuration SET value = json_set(value, '$.AFMap.description', 'Defines a SET of rules to address WHERE assets should be placed in the AF hierarchy.')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.AFMap.type', 'JSON')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.AFMap.default', '{}')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.AFMap.value', '{}')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
 UPDATE configuration SET value = json_set(value, '$.AFMap.order', '14')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.AFMap.displayName', 'Asset Framework hierarchies rules')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
 UPDATE configuration SET value = json_set(value, '$.AFMap.validity', 'PIServerEndpoint == "PI Web API"')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - notBlockingErrors
+-- notBlockingErrors
 --
 UPDATE configuration SET value = json_set(value, '$.notBlockingErrors.order', '15')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
@@ -186,25 +231,47 @@ WHERE json_extract(value, '$.plugin.value') = 'OMF';
 UPDATE configuration SET value = json_set(value, '$.PIWebAPIUserId.order', '18')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
+UPDATE configuration SET value = json_set(value, '$.PIWebAPIUserId.validity', 'PIServerEndpoint == "PI Web API"')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
 -- configuration - PIWebAPIPassword
 --
 UPDATE configuration SET value = json_set(value, '$.PIWebAPIPassword.order', '19')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - PIWebAPIKerberosKeytabFileName
+UPDATE configuration SET value = json_set(value, '$.PIWebAPIPassword.validity', 'PIServerEndpoint == "PI Web API"')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+-- PIWebAPIKerberosKeytabFileName
+-- Note: This is a new config item
 --
+UPDATE configuration SET value = json_set(value, '$.PIWebAPIKerberosKeytabFileName.description', 'Keytab file name used for Kerberos authentication in PI Web API.')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.PIWebAPIKerberosKeytabFileName.type', 'string')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.PIWebAPIKerberosKeytabFileName.default', 'piwebapi_kerberos_https.keytab')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.PIWebAPIKerberosKeytabFileName.value', 'piwebapi_kerberos_https.keytab')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
+UPDATE configuration SET value = json_set(value, '$.PIWebAPIKerberosKeytabFileName.displayName', 'PI Web API Kerberos keytab file')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
+
 UPDATE configuration SET value = json_set(value, '$.PIWebAPIKerberosKeytabFileName.order', '20')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
----
---- OCS configurations
----
+UPDATE configuration SET value = json_set(value, '$.PIWebAPIKerberosKeytabFileName.validity', 'PIWebAPIAuthenticationMethod == "kerberos"')
+WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
-
--- configuration - OCSNamespace
+---
+--- OCS configuration
+--- NOTE- All config items are new one's for OCS
+-- OCSNamespace
 --
-UPDATE configuration SET
-    value = json_set(value, '$.OCSNamespace.description', 'Specifies the OCS namespace where the information are stored and it is used for the interaction with the OCS API')
+UPDATE configuration SET value = json_set(value, '$.OCSNamespace.description', 'Specifies the OCS namespace WHERE the information are stored and it is used for the interaction with the OCS API')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
 UPDATE configuration SET value = json_set(value, '$.OCSNamespace.type', 'string')
@@ -216,8 +283,7 @@ WHERE json_extract(value, '$.plugin.value') = 'OMF';
 UPDATE configuration SET value = json_set(value, '$.OCSNamespace.order', '21')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
-UPDATE configuration SET
-    value = json_set(value, '$.OCSNamespace.displayName', 'OCS Namespace')
+UPDATE configuration SET value = json_set(value, '$.OCSNamespace.displayName', 'OCS Namespace')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
 UPDATE configuration SET value = json_set(value, '$.OCSNamespace.validity', 'PIServerEndpoint == "OSIsoft Cloud Services"')
@@ -226,10 +292,9 @@ WHERE json_extract(value, '$.plugin.value') = 'OMF';
 UPDATE configuration SET value = json_set(value, '$.OCSNamespace.value', 'name_space')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - OCSTenantId
+-- OCSTenantId
 --
-UPDATE configuration SET
-    value = json_set(value, '$.OCSTenantId.description', 'Tenant id associated to the specific OCS account')
+UPDATE configuration SET value = json_set(value, '$.OCSTenantId.description', 'Tenant id associated to the specific OCS account')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
 UPDATE configuration SET value = json_set(value, '$.OCSTenantId.type', 'string')
@@ -241,8 +306,7 @@ WHERE json_extract(value, '$.plugin.value') = 'OMF';
 UPDATE configuration SET value = json_set(value, '$.OCSTenantId.order', '22')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
-UPDATE configuration SET
-    value = json_set(value, '$.OCSTenantId.displayName', 'OCS Tenant ID')
+UPDATE configuration SET value = json_set(value, '$.OCSTenantId.displayName', 'OCS Tenant ID')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
 UPDATE configuration SET value = json_set(value, '$.OCSTenantId.validity', 'PIServerEndpoint == "OSIsoft Cloud Services"')
@@ -252,10 +316,9 @@ UPDATE configuration SET value = json_set(value, '$.OCSTenantId.value', 'ocs_ten
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
 
--- configuration - OCSClientId
+-- OCSClientId
 --
-UPDATE configuration SET
-    value = json_set(value, '$.OCSClientId.description', 'Client id associated to the specific OCS account, it is used to authenticate the source for using the OCS API')
+UPDATE configuration SET value = json_set(value, '$.OCSClientId.description', 'Client id associated to the specific OCS account, it is used to authenticate the source for using the OCS API')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
 UPDATE configuration SET value = json_set(value, '$.OCSClientId.type', 'string')
@@ -267,8 +330,7 @@ WHERE json_extract(value, '$.plugin.value') = 'OMF';
 UPDATE configuration SET value = json_set(value, '$.OCSClientId.order', '23')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
-UPDATE configuration SET
-    value = json_set(value, '$.OCSClientId.displayName', 'OCS Client ID')
+UPDATE configuration SET value = json_set(value, '$.OCSClientId.displayName', 'OCS Client ID')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
 UPDATE configuration SET value = json_set(value, '$.OCSClientId.validity', 'PIServerEndpoint == "OSIsoft Cloud Services"')
@@ -277,10 +339,9 @@ WHERE json_extract(value, '$.plugin.value') = 'OMF';
 UPDATE configuration SET value = json_set(value, '$.OCSClientId.value', 'ocs_client_id')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
--- configuration - OCSClientSecret
+-- OCSClientSecret
 --
-UPDATE configuration SET
-    value = json_set(value, '$.OCSClientSecret.description', 'Client secret associated to the specific OCS account, it is used to authenticate the source for using the OCS API')
+UPDATE configuration SET value = json_set(value, '$.OCSClientSecret.description', 'Client secret associated to the specific OCS account, it is used to authenticate the source for using the OCS API')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
 UPDATE configuration SET value = json_set(value, '$.OCSClientSecret.type', 'password')
@@ -292,8 +353,7 @@ WHERE json_extract(value, '$.plugin.value') = 'OMF';
 UPDATE configuration SET value = json_set(value, '$.OCSClientSecret.order', '24')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
-UPDATE configuration SET
-    value = json_set(value, '$.OCSClientSecret.displayName', 'OCS Client Secret')
+UPDATE configuration SET value = json_set(value, '$.OCSClientSecret.displayName', 'OCS Client Secret')
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
 UPDATE configuration SET value = json_set(value, '$.OCSClientSecret.validity', 'PIServerEndpoint == "OSIsoft Cloud Services"')
@@ -303,10 +363,11 @@ UPDATE configuration SET value = json_set(value, '$.OCSClientSecret.value', 'ocs
 WHERE json_extract(value, '$.plugin.value') = 'OMF';
 
 
-
 --- plugin_data -------------------------------------------------------------------------------------------------------
 -- plugin_data
 --
-UPDATE plugin_data SET key = REPLACE(key,'PI_Server_V2','OMF')
+UPDATE plugin_data SET key = replace(key,'PI_Server_V2','OMF')
 WHERE instr(key, 'PI_Server_V2') > 0;
 
+--- asset_tracker -------------------------------------------------------------------------------------------------------
+UPDATE asset_tracker SET plugin = 'OMF' WHERE plugin in ('PI_Server_V2', 'ocs_V2');


### PR DESCRIPTION
**Fixed items**
1) Sql queries and also added detailed comments for what purpose the queries meant to be
Also fixed new config items payload values
2) Asset_tracker plugin entry added
3) Package upgrade changes - Assuming that new version is **1.8** because upgrade script to be added with same name (i.e in our case 1.8sh)
   a) Removed C-source binaries from existing system (PI_SERVER_V2, ops_V2) so that plugin discovery will not show these with new upgraded version
  b) Syntactical error fixes in package_update.sh

**NOTE** - With the changes 
   a) I am able to run foglamp upgrade successfully with both installations package vs non-package installation with default endpoint settings of North task (i.e connection relay)

 b) But definitely it has some permutations & combination to test with on (discovery, connection relay, piwebapi). Assuming that OCS & EDS are the new ones so no upgrade tests for such cases

c) Also I believe downgrade is NOT possible for the case

**Pending items**
- postgres upgrade