### PR TITLE
FOGL-3914 - System tests fixes as per FOGL-3869

### DIFF
--- a/tests/system/python/api/test_plugin_discovery.py
+++ b/tests/system/python/api/test_plugin_discovery.py
@@ -67,8 +67,8 @@ class TestPluginDiscovery:
         assert 200 == r.status
         r = r.read().decode()
         jdoc = json.loads(r)
-        # Only north plugins (2 north_c and 2 north python) are expected by default
-        assert 4 == len(jdoc['plugins'])
+        # Only north plugins (1-C based and 2-Python based) are expected by default
+        assert 3 == len(jdoc['plugins'])
         for plugin in jdoc['plugins']:
             assert 'north' == plugin['type']
             assert plugin['type'] not in ['south', 'filter', 'notificationDelivery', 'notificationRule']
@@ -138,7 +138,7 @@ class TestPluginDiscovery:
         assert len(jdoc), "No data found"
         plugins = jdoc['plugins']
         plugin_names = [name['name'] for name in plugins]
-        # verify north plugins which is 4 by default and a new one (http)
+        # verify north plugins which is 3 by default and a new one (http)
         assert 4 == len(plugins)
         assert Counter(['ocs', 'http_north', 'pi_server', 'OMF']) == Counter(plugin_names)
 

--- a/tests/system/python/conftest.py
+++ b/tests/system/python/conftest.py
@@ -160,7 +160,7 @@ def start_north_pi_v2():
                 "schedule_enabled": _enabled,
                 "config": {"producerToken": {"value": pi_token},
                            "ServerHostname": {"value": pi_host},
-                           "ServerPort": {"value": pi_port}
+                           "ServerPort": {"value": str(pi_port)}
                            }
                 }
         conn.request("POST", '/fledge/scheduled/task', json.dumps(data))
@@ -193,7 +193,7 @@ def start_north_pi_v2_web_api():
                            "PIWebAPIUserId":  {"value": pi_user},
                            "PIWebAPIPassword": {"value": pi_pwd},
                            "ServerHostname": {"value": pi_host},
-                           "ServerPort": {"value": pi_port},
+                           "ServerPort": {"value": str(pi_port)},
                            "compression": {"value": "true"},
                            "DefaultAFLocation": {"value": "fledge/room1/machine1"}
                            }

--- a/tests/system/python/packages/test_available_and_install_api.py
+++ b/tests/system/python/packages/test_available_and_install_api.py
@@ -20,9 +20,9 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 available_pkg = []
-counter = 4
+counter = 3
 errors = []
-"""  By default 4 plugins are installed i.e. all north
+"""  By default 3 plugins are pre-installed i.e. all north
 """
 
 


### PR DESCRIPTION
System API tests - Default 3 North plugins
System Package tests - Default Counter value changed to 3 as now we have 3 by default plugins
System E2E tests - Fixed Service Port typecast as configuration needs every item into string

**NOTE** - I ran custom Jobs on ub1804 nightly & ub1804 Package installation custom Job and these JOBS are back to normal with the change