### PR TITLE
FOGL-3915 name info is added for C tasks in fledge status script

### DIFF
--- a/scripts/fledge
+++ b/scripts/fledge
@@ -522,7 +522,7 @@ fledge_status() {
                 ps -ef | grep -v 'cpulimit*' | grep -o 'python3 -m fledge.tasks.*' | grep -o 'fledge.tasks.*'    | grep -v 'fledge.tasks\.\*' || true
 
                 # Show Tasks in C code
-                ps -ef | grep './tasks.' | grep -v python3 | grep -v grep | grep -v awk | awk '{print substr($8, 3, length($8))" "$9" "$10 }' || true
+                ps -ef | grep './tasks.' | grep -v python3 | grep -v grep | grep -v awk | awk '{print substr($8, 3, length($8))" "$9" "$10" "$11}' || true
             fi
             ;;
         *)


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

Value is retrieved for --name arg of C Tasks in fledge status

**Output**
```
$ ./scripts/fledge status
Fledge v1.7.0 running.
Fledge Uptime:  35 seconds.
Fledge records: 4838 read, 5 sent, 0 purged.
Fledge does not require authentication.
=== Fledge services:
fledge.services.core
fledge.services.storage --address=0.0.0.0 --port=35519
fledge.services.south --port=35519 --address=127.0.0.1 --name=Sine
=== Fledge tasks:
fledge.tasks.north.sending_process --port=35519 --address=127.0.0.1 --name=HTP
tasks/sending_process --port=35519 --address=127.0.0.1 --name=HTC

```