### PR TITLE
FOGL-3956: Handle Uint as 64 bits in reading_set

### DIFF
--- a/C/common/reading_set.cpp
+++ b/C/common/reading_set.cpp
@@ -322,10 +322,10 @@ JSONReading::JSONReading(const Value& json)
 						    m.value.IsUint64()) {
 
 							DatapointValue *value;
-							if (m.value.IsInt() ||
-							    m.value.IsUint()) {
+							if (m.value.IsInt()) {
 								value = new DatapointValue((long) m.value.GetInt());
 							} else {
+								// Handle Uint as 64 bits
 								value = new DatapointValue((long) m.value.GetInt64());
 							}
 							this->addDatapoint(new Datapoint(m.name.GetString(),


### PR DESCRIPTION
Signed-off-by: Stefano <stefano@dianomic.com>

Db:
![image](https://user-images.githubusercontent.com/4919069/79479424-05e44e80-800d-11ea-8ea7-071c5cc0e7f0.png)

Fledge:
![image](https://user-images.githubusercontent.com/4919069/79479457-1268a700-800d-11ea-87b6-2759f4a348f9.png)

CR:
![image](https://user-images.githubusercontent.com/4919069/79479478-1b597880-800d-11ea-850e-e911d243a515.png)

