### PR TITLE
FOGL-3991 fledge status output fixes

### DIFF
--- a/scripts/fledge
+++ b/scripts/fledge
@@ -513,16 +513,15 @@ fledge_status() {
                 fledge_log "info" "=== Fledge services:" "outonly" "pretty"
                 fledge_log "info" "fledge.services.core" "outonly" "pretty"
                 ps -ef | grep "fledge.services.storage" | grep -v 'grep' | grep -v awk | awk '{print "fledge.services.storage " $9 " " $10}' || true
-                ps -ef | grep "fledge.services.south" |grep python3| grep -v 'grep' | awk '{print "fledge.services.south " $11 " " $12 " " $13}' || true
-                ps -ef | grep "fledge.services.south" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{print "fledge.services.south " $9 " " $10 " " $11}' || true
-                ps -ef | grep "fledge.services.notification" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{print "fledge.services.notification " $9 " " $10 " " $11}' || true
+                ps -ef | grep "fledge.services.south " |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.south "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' || true
+                ps -ef | grep "fledge.services.notification" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.notification "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' || true
 
                 # Show Tasks
                 fledge_log "info" "=== Fledge tasks:" "outonly" "pretty"
                 ps -ef | grep -v 'cpulimit*' | grep -o 'python3 -m fledge.tasks.*' | grep -o 'fledge.tasks.*'    | grep -v 'fledge.tasks\.\*' || true
 
                 # Show Tasks in C code
-                ps -ef | grep './tasks.' | grep -v python3 | grep -v grep | grep -v awk | awk '{print substr($8, 3, length($8))" "$9" "$10" "$11}' || true
+                ps -ef | grep './tasks.' | grep -v python3 | grep -v grep | grep -v awk | awk '{printf "tasks/sending_process "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' || true
             fi
             ;;
         *)


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

**O/P**
It has South services (both plugins language) | C tasks (both python & C version) | Notification service

```
$ ./scripts/fledge status
Fledge v1.7.0 running.
Fledge Uptime:  41 seconds.
Fledge records: 10060 read, 954 sent, 0 purged.
Fledge does not require authentication.
=== Fledge services:
fledge.services.core
fledge.services.storage --address=0.0.0.0 --port=41561
fledge.services.south --port=41561 --address=127.0.0.1 --name=Bench 
fledge.services.south --port=41561 --address=127.0.0.1 --name=Sine #1 
fledge.services.south --port=41561 --address=127.0.0.1 --name=S I N E 
fledge.services.south --port=41561 --address=127.0.0.1 --name=Rand C 
fledge.services.south --port=41561 --address=127.0.0.1 --name=Fledge Bench 
fledge.services.south --port=41561 --address=127.0.0.1 --name=HTTP South #1 
fledge.services.notification --port=41561 --address=127.0.0.1 --name=My Notif 
=== Fledge tasks:
fledge.tasks.north.sending_process --port=41561 --address=127.0.0.1 --name=HT
fledge.tasks.north.sending_process --port=41561 --address=127.0.0.1 --name=PI Serv Py
fledge.tasks.statistics --port=41561 --address=127.0.0.1 --name=stats collection
tasks/sending_process --port=41561 --address=127.0.0.1 --name=O M F 
```