### PR TITLE
FOGL-4000 common bash logger script used for scripts.services.storage

### DIFF
--- a/scripts/services/storage
+++ b/scripts/services/storage
@@ -1,30 +1,33 @@
-#!/bin/sh
-if [ "${FLEDGE_ROOT}" = "" ]; then
-	if [ ! -x /usr/local/fledge/services/fledge.services.storage ] && [ ! -x /usr/local/fledge/services/storage ]; then
-		logger "Unable to find Fledge storage microservice in the default location"
-		exit 1
-	else
-		if [ -x /usr/local/fledge/services/fledge.services.storage ]; then
-			export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/fledge/lib
-			/usr/local/fledge/services/fledge.services.storage "$@"
-		else
-			/usr/local/fledge/services/storage "$@"
-		fi
-		logger "Fledge storage microservice in the default location: /usr/local/fledge"
-		exit 0
-	fi
+#!/bin/bash
+# Run a Fledge Storage service written in C/C++
+if [[ "${FLEDGE_ROOT}" = "" ]]; then
+    if [[ ! -x /usr/local/fledge/services/fledge.services.storage ]] && [[ ! -x /usr/local/fledge/services/storage ]]; then
+        logger "Unable to find Fledge storage microservice in the default location"
+        exit 1
+    else
+        if [[ -x /usr/local/fledge/services/fledge.services.storage ]]; then
+            export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/fledge/lib
+            /usr/local/fledge/services/fledge.services.storage "$@"
+        else
+            /usr/local/fledge/services/storage "$@"
+        fi
+        logger "Fledge storage microservice in the default location: /usr/local/fledge"
+        exit 0
+    fi
 else
-	if [ ! -x ${FLEDGE_ROOT}/services/fledge.services.storage ] && [ ! -x ${FLEDGE_ROOT}/services/storage ]; then
-		logger "Unable to find Fledge storage microservice in ${FLEDGE_ROOT}/services/storage"
-		exit 1
-	else
-		if [ -x ${FLEDGE_ROOT}/services/fledge.services.storage ]; then
-			export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${FLEDGE_ROOT}/lib:/usr/local/fledge/lib
-			${FLEDGE_ROOT}/services/fledge.services.storage "$@"
-		else
-			${FLEDGE_ROOT}/services/storage "$@"
-		fi
-		logger "Fledge storage microservice found in FLEDGE_ROOT location: ${FLEDGE_ROOT}"
-		exit 0
-	fi
+    # Include common logger script code
+    . $FLEDGE_ROOT/scripts/common/write_log.sh
+    if [[ ! -x ${FLEDGE_ROOT}/services/fledge.services.storage ]] && [[ ! -x ${FLEDGE_ROOT}/services/storage ]]; then
+        write_log "" "scripts.services.storage" "err" "Unable to find Fledge storage microservice in ${FLEDGE_ROOT}/services/storage" "logonly" ""
+        exit 1
+    else
+        if [[ -x ${FLEDGE_ROOT}/services/fledge.services.storage ]]; then
+            export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${FLEDGE_ROOT}/lib:/usr/local/fledge/lib
+            ${FLEDGE_ROOT}/services/fledge.services.storage "$@"
+        else
+            ${FLEDGE_ROOT}/services/storage "$@"
+        fi
+        write_log "" "scripts.services.storage" "info" "Fledge storage microservice found in FLEDGE_ROOT location: ${FLEDGE_ROOT}" "logonly" ""
+        exit 0
+    fi
 fi


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

**Fixed items**
1) indentation & style fixes (square brackets [[ ]] )
2) common write_log bash logger used for logging in case of FLEDGE_ROOT is set

**O/P**
New log
```
Apr 29 17:22:35 aj Fledge [31919] INFO: scripts.services.storage: Fledge storage microservice found in FLEDGE_ROOT location: /home/Development/fledge
```

Previously it was without Fledge Prefix & PID. Below is the old log

```
Apr 28 08:18:55 aj pi: Fledge storage microservice found in FLEDGE_ROOT location: /home/pi/fledge
```