### PR TITLE
FOGL-3980 module name fixes for loading python plugin

### DIFF
--- a/python/fledge/services/core/api/plugins/common.py
+++ b/python/fledge/services/core/api/plugins/common.py
@@ -32,7 +32,7 @@ _NO_OF_FILES_TO_RETAIN = 10
 
 def load_python_plugin(plugin_module_path: str, plugin: str, _type: str) -> Dict:
     _plugin = None
-    module_name = "fledge.plugins.{}.{}.{}".format(_type, plugin, plugin)
+    module_name = "fledge.plugins.{}.{}".format(_type, plugin)
     try:
         spec = importlib.util.spec_from_file_location(module_name, "{}/{}.py".format(plugin_module_path, plugin))
         _plugin = importlib.util.module_from_spec(spec)

--- a/python/fledge/services/core/api/plugins/common.py
+++ b/python/fledge/services/core/api/plugins/common.py
@@ -32,8 +32,9 @@ _NO_OF_FILES_TO_RETAIN = 10
 
 def load_python_plugin(plugin_module_path: str, plugin: str, _type: str) -> Dict:
     _plugin = None
+    module_name = "fledge.plugins.{}.{}.{}".format(_type, plugin, plugin)
     try:
-        spec = importlib.util.spec_from_file_location("module.name", "{}/{}.py".format(plugin_module_path, plugin))
+        spec = importlib.util.spec_from_file_location(module_name, "{}/{}.py".format(plugin_module_path, plugin))
         _plugin = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(_plugin)
     except FileNotFoundError:
@@ -42,7 +43,7 @@ def load_python_plugin(plugin_module_path: str, plugin: str, _type: str) -> Dict
             for pp in plugin_paths:
                 if os.path.isdir(pp):
                     plugin_module_path = "{}/{}/{}".format(pp, _type, plugin)
-                    spec = importlib.util.spec_from_file_location("module.name", "{}/{}.py".format(
+                    spec = importlib.util.spec_from_file_location(module_name, "{}/{}.py".format(
                         plugin_module_path, plugin))
                     _plugin = importlib.util.module_from_spec(spec)
                     spec.loader.exec_module(_plugin)


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

**Logs**

```
Apr 30 11:52:26 aj Fledge S I N E[17333] INFO: sinusoid: fledge.plugins.south.sinusoid: Sinusoid plugin_init: called

Apr 30 11:54:02 aj Fledge HTTP South #1[17337] INFO: http_south: fledge.plugins.south.http_south: South HTTP plugin shut down.

Apr 30 11:55:55 aj Fledge Ht #1[18938] ERROR: http_north: fledge.plugins.north.http_north: Server error code: 500, reason: Internal Server Error

Apr 30 12:16:25 aj Fledge Env[13750] INFO: envirophat: fledge.plugins.south.envirophat: Old config for Enviro pHAT plugin {'plugin': {'description': 'Enviro pHAT Poll Plugin', 'type': 'string', 'value': 'envirophat', 'default': 'envirophat'}, 'assetNamePrefix': {'description': ........
```
