### PR TITLE
FOGL-3999 grep cmd improved as per Fledge Prefix for fetching logs in support bundle & other code refactoring

### DIFF
--- a/python/fledge/services/core/support.py
+++ b/python/fledge/services/core/support.py
@@ -81,7 +81,7 @@ class SupportBuilder:
                     north_cat = await cf_mgr.get_category_child("North")
                     north_categories = [nc["key"] for nc in north_cat]
                     for task in north_categories:
-                        if task != "OMF_TYPE":
+                        if task != "OMF_TYPES":
                             self.add_syslog_service(pyz, file_spec, task)
                 except:
                     pass
@@ -144,12 +144,14 @@ class SupportBuilder:
 
     def add_syslog_service(self, pyz, file_spec, service):
         # The fledge entries from the syslog file for a service or task
-        temp_file = self._interim_file_path + "/" + "syslog-{}-{}".format(service, file_spec)
+        # Replace space occurrences with hyphen for service or task - so that file is created
+        tmp_svc = service.replace(' ', '-')
+        temp_file = self._interim_file_path + "/" + "syslog-{}-{}".format(tmp_svc, file_spec)
         try:
-            subprocess.call("grep '{}\\[' {} > {}".format(service, _SYSLOG_FILE, temp_file), shell=True)
-        except OSError as ex:
+            subprocess.call("grep -a -E '(Fledge {})\[' {} > {}".format(service, _SYSLOG_FILE, temp_file), shell=True)
+            pyz.add(temp_file, arcname=basename(temp_file))
+        except Exception as ex:
             raise RuntimeError("Error in creating {}. Error-{}".format(temp_file, str(ex)))
-        pyz.add(temp_file, arcname=basename(temp_file))
 
     async def add_table_configuration(self, pyz, file_spec):
         # The contents of the configuration table from the storage layer


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

**Support extract file structure**
```
drwxrwxr-x  2 foglamp foglamp    4096 Apr 29 12:45 package_logs
-rw-rw-r--  1 foglamp foglamp   25649 Apr 30 15:13 syslogStorage-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp    3572 Apr 30 15:13 syslog-S-I-N-E-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp    3571 Apr 30 15:13 syslog-Sine-#1-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp    5831 Apr 30 15:13 syslog-Rand-C-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp    4884 Apr 30 15:13 syslog-PI-Serv-Py-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp    3099 Apr 30 15:13 syslog-Pi-#1-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp   20391 Apr 30 15:13 syslog-O-M-F-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp   18029 Apr 30 15:13 syslog-HTTP-South-#1-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp   23086 Apr 30 15:13 syslog-Ht-#1-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp    6467 Apr 30 15:13 syslog-Fledge-Bench-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp  599989 Apr 30 15:13 syslog-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp   74700 Apr 30 15:13 configuration-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp  198528 Apr 30 15:13 statistics-history-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp    2457 Apr 30 15:13 service_registry-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp    6611 Apr 30 15:13 schedules-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp    1301 Apr 30 15:13 scheduled_processes-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp    1401 Apr 30 15:13 psinfo-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp     235 Apr 30 15:13 machine-200430-15-13-48
-rw-rw-r--  1 foglamp foglamp  453796 Apr 30 15:13 audit-200430-15-13-48
```
**File O/p content**
```
syslog-O-M-F-200430-15-13-48

Apr 30 11:47:40 aj Fledge O M F[8073]: ERROR: Sending JSON dataType message 'Type' - generic error: |Failed to send data: Connection refused| - HostPort |localhost:5460| - path |/ingress/messages| - OMF message |[{ "type": "object", "properties": { "Location": {"type": "string"},"Company": {"type": "string"},"Name": { "type": "string", "isindex": true } }, "classification": "static", "id": "1_Random1_typename_sensor" }, { "type": "object", "properties": {"random": {"type": "number", "format": "float64"}, "Time": {"type": "string", "isindex": true, "format": "date-time"}}, "classification": "dynamic", "id": "1_Random1_typename_measurement" }]|

syslog-HTTP-South-#1-200430-15-13-48

Apr 30 11:49:05 aj Fledge HTTP South #1[6734] INFO: http_south: fledge.plugins.south.http_south.http_south: Old config for HTTP south plugin {'assetNamePrefix': {'description': 'Asset name prefix', 'displayName': 'Asset Name Prefix', 'type': 'string', 'value': 'http-', 'default': 'http-'}, 'server': <Server sockets=[<socket.socket fd=29, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('0.0.0.0', 6683)>]>, 'port': {'description': 'Port to listen on', 'displayName': 'Port', 'type': 'integer', 'value': '6683', 'default': '6683'}, 'uri': {'description': 'URI to accept data on', 'displayName': 'URI', 'type': 'string', 'value': 'sensor-reading', 'default': 'sensor-reading'}, 'host': {'description': 'Address to accept data on', 'displayName': 'Host', 'type': 'string', 'value': '0.0.0.0', 'default': '0.0.0.0'}, 'handler': <aiohttp.web_server.Server object at 0x7fa48522f5c0>, 'httpsPort': {'description': 'Port to accept HTTPS connections on', 'displayName': 'HTTPS Port', 'type': 'integer', 'value': '6684', 'default': '6684'}, 'enableHttp': {'description': 'Enable HTTP (Set false to use HTTPS)', 'displayName': 'Enable HTTP', 'type': 'boolean', 'value': 'true', 'default': 'true'}, 'plugin': {'description': 'HTTP Listener South Plugin', 'type': 'string', 'value': 'http_south', 'default': 'http_south'}, 'certificateName': {'description': 'Certificate file name', 'displayName': 'Certificate Name', 'type': 'string', 'value': 'fledge', 'default': 'fledge'}, 'app': <Application 0x7fa47fb58d68>} #012 new config {'assetNamePrefix': {'type': 'string', 'value': 'http-d', 'displayName': 'Asset Name Prefix', 'order': '4', 'description': 'Asset name prefix', 'default': 'http-'}, 'uri': {'type': 'string', 'value': 'sensor-reading', 'displayName': 'URI', 'order': '3', 'description': 'URI to accept data on', 'default': 'sensor-reading'}, 'port': {'type': 'integer', 'value': '6683', 'displayName': 'Port', 'order': '2', 'description': 'Port to listen on', 'default': '6683'}, 'httpsPort': {'type': 'integer', 'value': '6684', 'displayName': 'HTTPS Port', 'order': '6', 'description': 'Port to accept HTTPS connections on', 'default': '6684'}, 'host': {'type': 'string', 'value': '0.0.0.0', 'displayName': 'Host', 'order': '1', 'description': 'Address to accept data on', 'default': '0.0.0.0'}, 'plugin': {'description': 'HTTP Listener South Plugin', 'type': 'string', 'value': 'http_south', 'default': 'http_south', 'readonly': 'true'}, 'enableHttp': {'type': 'boolean', 'value': 'true', 'displayName': 'Enable HTTP', 'order': '5', 'description': 'Enable HTTP (Set false to use HTTPS)', 'default': 'true'}, 'certificateName': {'type': 'string', 'value': 'fledge', 'displayName': 'Certificate Name', 'order': '7', 'description': 'Certificate file name', 'default': 'fledge'}}
Apr 30 11:49:05 aj Fledge HTTP South #1[6734] INFO: http_south: fledge.plugins.south.http_south.http_south: South HTTP plugin shut down.
Apr 30 11:49:05 aj Fledge HTTP South #1[6734] INFO: http_south: fledge.plugins.south.http_south.http_south: plugin_start called

syslog-S-I-N-E-200430-15-13-48

Apr 30 11:47:12  aj Fledge S I N E[6730] INFO: sinusoid: fledge.plugins.south.sinusoid.sinusoid: Sinusoid plugin_init: called

syslog-Fledge-Bench-200430-15-13-48

Apr 30 11:47:12 aj Fledge Fledge Bench[6742]: INFO: Ingest::loadFilters(): categoryName=Fledge Bench
Apr 30 11:47:12 aj Fledge Fledge Bench[6742]: INFO: loadFilters: no filters configured for 'Fledge Bench'
Apr 30 11:47:12 aj Fledge Fledge Bench[6742]: INFO: pollInterfaceV2=false

syslog-Ht-#1-200430-15-13-48

Apr 30 11:55:54 aj Fledge Ht #1[18938] INFO: sending_process: sending_process_Ht #1: Started
Apr 30 11:55:55 aj Fledge Ht #1[18938] ERROR: http_north: fledge.plugins.north.http_north.http_north: Server error code: 500, reason: Internal Server Error
Apr 30 12:30:15 aj Fledge Ht #1[20679] INFO: sending_process: sending_process_Ht #1: Started
Apr 30 12:31:19 aj Fledge Ht #1[20679] INFO: sending_process: sending_process_Ht #1: Stopped

```

**Note** - Also I do not see any individual log file for Notification service as we have missed earlier. Do we need to add on the same PR or another JIRA?