### PR TITLE
FOGL-4068 API to retrieve statistics rates

### DIFF
--- a/python/fledge/services/core/api/statistics.py
+++ b/python/fledge/services/core/api/statistics.py
@@ -3,7 +3,6 @@
 # FLEDGE_BEGIN
 # See: http://fledge.readthedocs.io/
 # FLEDGE_END
-import time
 import datetime
 from aiohttp import web
 
@@ -199,31 +198,29 @@ async def get_statistics_rate(request: web.Request) -> web.Response:
     if len(result['rows']) > 0:
         scheduler = Scheduler()
         interval_days, interval_dt = scheduler.extract_day_time_from_interval(result['rows'][0]['schedule_interval'])
-        interval = datetime.timedelta(days=interval_days, hours=interval_dt.hour, minutes=interval_dt.minute,
-                                      seconds=interval_dt.second)
-        interval_in_secs = interval.total_seconds()
+        interval_in_secs = datetime.timedelta(days=interval_days, hours=interval_dt.hour, minutes=interval_dt.minute,
+                                              seconds=interval_dt.second).total_seconds()
     else:
         raise web.HTTPNotFound(reason="No stats collector schedule found")
     ts = datetime.datetime.now().timestamp()
     resp = []
     for x, y in [(x, y) for x in period_split_list for y in stat_split_list]:
         time_diff = ts - int(x)
-        dt = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(time_diff))
-        # FIXME:
+        # TODO: FOGL-4102
         # For example:
         # time_diff = 1590066814.037321
         # ERROR: PostgreSQL storage plugin raising error: ERROR:  invalid input syntax for type timestamp with time zone: "1590066814.037321"
         # "where": {"column": "history_ts", "condition": ">=", "value": "1590066814.037321"} - Payload works with sqlite engine BUT not with postgres
         # To overcome above problem on postgres - I have used "dt = 2020-05-21 13:13:34" - but I see some deviations in results for both engines when we use datetime format
         _payload = PayloadBuilder().SELECT("key").AGGREGATE(["sum", "value"]).AGGREGATE(["count", "value"]).WHERE(
-            ['history_ts', '>=', str(dt)]).AND_WHERE(['key', '=', y]).chain_payload()
+            ['history_ts', '>=', str(time_diff)]).AND_WHERE(['key', '=', y]).chain_payload()
         stats_rate_payload = PayloadBuilder(_payload).GROUP_BY("key").payload()
         result = await storage_client.query_tbl_with_payload("statistics_history", stats_rate_payload)
+        temp_dict = {y: {x: 0}}
         if result['rows']:
-            formula_str = (int(result['rows'][0]['sum_value']) / int(result['rows'][0]['count_value'])) * (60 / int(interval_in_secs))
-            temp_dict = {y: {x: formula_str}}
-        else:
-            temp_dict = {y: {x: 0}}
+            calculated_formula_str = (int(result['rows'][0]['sum_value']) / int(result['rows'][0]['count_value'])
+                                      ) * (60 / int(interval_in_secs))
+            temp_dict = {y: {x: calculated_formula_str}}
         resp.append(temp_dict)
     rate_dict = {}
     for d in resp:

--- a/python/fledge/services/core/api/statistics.py
+++ b/python/fledge/services/core/api/statistics.py
@@ -215,4 +215,4 @@ async def get_statistics_rate(request: web.Request) -> web.Response:
     for d in resp:
         for k, v in d.items():
             rate_dict[k] = {**rate_dict[k], **v} if k in rate_dict else v
-    return web.json_response({"rates": rate_dict})
+    return web.json_response({"rates": [rate_dict]})

--- a/python/fledge/services/core/routes.py
+++ b/python/fledge/services/core/routes.py
@@ -130,6 +130,7 @@ def setup(app):
     # Statistics - As per doc
     app.router.add_route('GET', '/fledge/statistics', api_statistics.get_statistics)
     app.router.add_route('GET', '/fledge/statistics/history', api_statistics.get_statistics_history)
+    app.router.add_route('GET', '/fledge/statistics/rate', api_statistics.get_statistics_rate)
 
     # Audit trail - As per doc
     app.router.add_route('POST', '/fledge/audit', api_audit.create_audit_entry)

--- a/tests/unit/python/fledge/services/core/api/test_statistics_api.py
+++ b/tests/unit/python/fledge/services/core/api/test_statistics_api.py
@@ -477,11 +477,12 @@ class TestStatistics:
         assert msg == resp.reason
 
     async def test_get_statistics_rate(self, client, params='?periods=1,5&statistics=readings'):
-        output = {'rates': {'READINGS': {'1': 240, '5': 240}}}
+        output = {'rates': {'READINGS': {'1': 120.52585669781932, '5': 120.52585669781932}}}
         p1 = {'where': {'value': 'stats collector', 'condition': '=', 'column': 'process_name'},
               'return': ['schedule_interval']}
-        p2 = {"return": ["key", {"column": "(sum(value) / count(value)) * 60 / 15", "alias": "readings"}],
-              "where": {"column": "history_ts", "condition": ">=", "value": "1589956964.663594",
+        p2 = {"return": ["key"], "aggregate": [{"operation": "sum", "column": "value"},
+                                               {"operation": "count", "column": "value"}],
+              "where": {"column": "history_ts", "condition": ">=", "value": "2020-05-21 13:03:03",
                         "and": {"column": "key", "condition": "=", "value": "READINGS"}}, "group": "key"}
 
         @asyncio.coroutine
@@ -496,7 +497,7 @@ class TestStatistics:
             if table == 'statistics_history':
                 # TODO: datetime patch required which is a bit tricky
                 # assert p2 == json.loads(payload)
-                return {"rows": [{"readings": 240, "key": "READINGS"}], "count": 1}
+                return {"rows": [{'sum_value': 96722, 'count_value': 3210, "key": "READINGS"}], "count": 1}
 
         mock_async_storage_client = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=mock_async_storage_client):

--- a/tests/unit/python/fledge/services/core/api/test_statistics_api.py
+++ b/tests/unit/python/fledge/services/core/api/test_statistics_api.py
@@ -482,7 +482,11 @@ class TestStatistics:
               'return': ['schedule_interval']}
         p2 = {"return": ["key"], "aggregate": [{"operation": "sum", "column": "value"},
                                                {"operation": "count", "column": "value"}],
-              "where": {"column": "history_ts", "condition": ">=", "value": "2020-05-21 13:03:03",
+              "where": {"column": "history_ts", "condition": ">=", "value": "1590126369.123255",
+                        "and": {"column": "key", "condition": "=", "value": "READINGS"}}, "group": "key"}
+        p3 = {"return": ["key"], "aggregate": [{"operation": "sum", "column": "value"},
+                                               {"operation": "count", "column": "value"}],
+              "where": {"column": "history_ts", "condition": ">=", "value": "1590126369.123255",
                         "and": {"column": "key", "condition": "=", "value": "READINGS"}}, "group": "key"}
 
         @asyncio.coroutine


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

- [ ] Postgres query (known issues - FOGL-4102 created)

**DB results**
```
$ sqlite3 data/fledge.db 
SQLite version 3.11.0 2016-02-15 17:29:24
Enter ".help" for usage hints.
sqlite> .headers on
sqlite> select key, 4 * (sum(value) / count(value)) from statistics_history where history_ts >= datetime('now', '-5 Minute') and key in ("RANDOM1", "FASTSINUSOID", "READINGS", "SINUSOID" ) group by key;
key|4 * (sum(value) / count(value))
FASTSINUSOID|120
RANDOM1|60
READINGS|240
SINUSOID|60
sqlite> 
sqlite> select key, 4 * (sum(value) / count(value)) from statistics_history where history_ts >= datetime('now', '-15 Minute') and key in ("RANDOM1", "FASTSINUSOID", "READINGS", "SINUSOID" ) group by key;
key|4 * (sum(value) / count(value))
FASTSINUSOID|120
RANDOM1|60
READINGS|240
SINUSOID|60

```

**curl output**
```
 $ curl -sX GET 'http://localhost:8081/fledge/statistics/rate?periods=5,15&statistics=sinusoid,fastsinusoid,readings,random1' | jq
{
  "rates": 
    {
      "RANDOM1": {
        "5": 60,
        "15": 60
      },
      "SINUSOID": {
        "5": 60,
        "15": 60
      },
      "READINGS": {
        "5": 240,
        "15": 240
      },
      "FASTSINUSOID": {
        "5": 120,
        "15": 120
      }
    }
}

```