### PR TITLE
FOGL-4122 Update zeroconf library and allow south services on remote machines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to Fledge
+
+The project welcomes contributions of all types; documentation, code
+changes, new plugins, scripts, just simply reports of the way you use Fledge
+or suggestions of features you would like to see within Fledge.
+
+The following is a set of guidelines for contributing to Fledge IoT
+project and its plugins, which are hosted in
+the [fledge-iot Organization](https://github.com/fledge-iot) on GitHub.
+
+To give us feedback or make suggestions use the [Fledge Slack Channel](https://slack/lfedge.org/).
+
+## Pull requests
+
+**Please ask first** before embarking on any significant work (e.g. implementing new features,
+refactoring code etc.), otherwise you risk spending a lot of time working on something that might
+already be underway or is unlikely to be merged into the project.
+
+Join the Fledge slack channel on [LFEdge](https://slack.lfedge.org/). This
+will allow you to talk to the wider fledge community and discuss your
+proposed changes and get help from the maintainers when needed.
+
+Please adhere to the coding conventions used throughout the project and
+limit your changes to functional rather than aesthetic changes to make
+it as easy as possible to review your changes. We also encourage you to
+comment your code changes for the same reason and for the benefit of those
+that come after you.
+
+Adhering to the following process is the best way to get your work included in the project:
+
+1. [Fork](https://help.github.com/articles/fork-a-repo/) the project, clone your fork, and configure
+   the remotes:
+
+   ```bash
+   # Clone your fork of the repo into the current directory
+   git clone https://github.com/<your-username>/fledge-iot.git
+
+   # Navigate to the newly cloned directory
+   cd fledge-iot
+
+   # Assign the original repo to a remote called "upstream"
+   git remote add upstream https://github.com/fledge-iot/fledge.git
+   ```
+
+2. If you cloned a while ago, get the latest changes from upstream:
+
+   ```bash
+   git checkout master
+   git pull --rebase upstream master
+   ```
+
+3. Create a new topic branch from `develop`, if you are working a particular issue from the Project Jira then the convention for branch names is to use the Jira name, otherwise choose a descriptive branch name that contains your GitHub username in order to help us track the changes.
+
+   ```bash
+   git checkout -b [branch-name]
+   ```
+
+4. Commit your changes in logical chunks. When you are ready to commit, make sure to write a Good
+   Commit Message™.  Use [interactive rebase](https://help.github.com/articles/about-git-rebase)
+   to group your commits into logical units of working before making them public.
+
+   Note that every commit you make must be signed. By signing off your work you indicate that you
+   are accepting the [Developer Certificate of Origin](https://developercertificate.org/).
+
+   Use your real name (sorry, no pseudonyms or anonymous contributions). If you set your `user.name`
+   and `user.email` git configs, you can sign your commit automatically with `git commit -s`.
+
+5. Locally merge (or rebase) the upstream development branch into your topic branch:
+
+   ```bash
+   git pull --rebase upstream master
+   ```
+
+6. Push your topic branch up to your fork:
+
+   ```bash
+   git push origin [branch-name]
+   ```
+
+7. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/) with a clear title
+   and detailed description.
+
+### Plugins
+
+The above addresses the main Fledge repository, however plugins each have
+a repository of their own which contains the code for the plugin and the
+documentation for the plugin. If you wish to work on an existing plugin
+then the process is similar to that above, just replace the fledge.git
+repository with the <plugin>.git repository, for example
+
+   ```bash
+   # Clone your fork of the repo into the current directory
+   git clone https://github.com/<your-username>/fledge-south-sinusoid.git
+
+   # Navigate to the newly cloned directory
+   cd fledge-south-sinusoid
+
+   # Assign the original repo to a remote called "upstream"
+   git remote add upstream https://github.com/fledge-iot/fledge-south-sinusoid.git
+   ```
+
+If you wish to create a new plugin then contact the maintainers and we
+will create a blank base repository for you to add your code into.

--- a/python/fledge/services/core/api/south.py
+++ b/python/fledge/services/core/api/south.py
@@ -62,6 +62,12 @@ async def _services_with_assets(storage_client, south_services):
                     plugin_version = p["version"]
                     break
 
+            # Service running on another machine have no scheduler entry
+            sched_enable = 'unknown'
+            try:
+                sched_enable = await _get_schedule_status(storage_client, s_record._name)
+            except:
+                pass
             sr_list.append(
                 {
                     'name': s_record._name,
@@ -72,7 +78,7 @@ async def _services_with_assets(storage_client, south_services):
                     'status': ServiceRecord.Status(int(s_record._status)).name.lower(),
                     'assets': assets,
                     'plugin': {'name': plugin, 'version': plugin_version},
-                    'schedule_enabled': await _get_schedule_status(storage_client, s_record._name)
+                    'schedule_enabled': sched_enable
                 })
         for s_name in south_services:
             south_svc = is_svc_in_service_registry(s_name)


### PR DESCRIPTION
The version of zeroconf used previously stops currently announcing services after a short period. This prevents services running outside the machine, e.g. ESP8266 service, to find services other than during a short window after fledge is start.

Also the fledge/south API gives an internal error if a service outside of the machine is registered with the core.