### PR TITLE
FOGL-4057 test on RPi with postgres and sqlite-in-memory

### DIFF
--- a/tests/system/lab/reset
+++ b/tests/system/lab/reset
@@ -1,5 +1,34 @@
 #!/usr/bin/env bash
 
+_postgres() {
+    sudo apt install -y postgresql
+    sudo -u postgres createuser -d "$(whoami)"
+    sudo sed -i 's/"plugin":{"value":"sqlite"/"plugin":{"value":"postgres"/g' /usr/local/fledge/data/etc/storage.json
+    sudo sed -i 's/"readingPlugin":{"value":"sqlitememory"/"readingPlugin":{"value":""/g' /usr/local/fledge/data/etc/storage.json
+}
+_sqliteinmemory () {
+    sudo sed -i 's/"plugin":{"value":"postgres"/"plugin":{"value":"sqlite"/g' /usr/local/fledge/data/etc/storage.json
+    sudo sed -i 's/"readingPlugin":{"value":""/"readingPlugin":{"value":"sqlitememory"/g' /usr/local/fledge/data/etc/storage.json
+}
+
+_sqlite () {
+    sudo sed -i 's/"plugin":{"value":"postgres"/"plugin":{"value":"sqlite"/g' /usr/local/fledge/data/etc/storage.json
+    sudo sed -i 's/"readingPlugin":{"value":"sqlitememory"/"readingPlugin":{"value":""/g' /usr/local/fledge/data/etc/storage.json
+}
+
+# check for storage plugin
+. ./test.config
+
+if [[  ${STORAGE} == "postgres" ]]
+then
+   _postgres
+elif [[  ${STORAGE} == "sqlite-in-memory" ]]
+then
+  _sqliteinmemory
+else
+  _sqlite
+fi
+
 echo "Stopping Fledge using systemctl ..."
 sudo systemctl stop fledge
 echo "YES" | /usr/local/fledge/bin/fledge reset || exit 1

--- a/tests/system/lab/reset
+++ b/tests/system/lab/reset
@@ -4,8 +4,6 @@ echo "Stopping Fledge using systemctl ..."
 sudo systemctl stop fledge
 echo "YES" | /usr/local/fledge/bin/fledge reset || exit 1
 echo
-# TODO: FOGL-2349
-rm -rf /usr/local/fledge/data/scripts/* || exit 1
 echo "Starting Fledge using systemctl ..."
 sudo systemctl start fledge
 echo "Fledge Status"

--- a/tests/system/lab/run
+++ b/tests/system/lab/run
@@ -11,5 +11,5 @@ fi
 
 ./remove
 ./install ${VERSION}
-#./reset
+./reset
 ./test

--- a/tests/system/lab/test
+++ b/tests/system/lab/test
@@ -10,7 +10,7 @@ CRESET="${CPFX}0m"
 
 # Read config file
 . ./test.config
-if [[  ${STORAGE} == "postgres" ]] then
+if [[  ${STORAGE} == "postgres" ]]; then
    sudo apt install -y postgresql
    sudo -u postgres createuser -d "$(whoami)"
    sudo cp /usr/local/fledge/data/etc/storage.json /usr/local/fledge/data/etc/storage.json.bak

--- a/tests/system/lab/test
+++ b/tests/system/lab/test
@@ -8,8 +8,16 @@ CINFO="${CPFX}1;32m"
 CERR="${CPFX}1;31m"
 CRESET="${CPFX}0m"
 
-# Read config file for FLEDGE IP, PI host and token etc.
+# Read config file
 . ./test.config
+if [[  ${STORAGE} == "postgres" ]] then
+   sudo apt install -y postgresql
+   sudo -u postgres createuser -d "$(whoami)"
+   sudo cp /usr/local/fledge/data/etc/storage.json /usr/local/fledge/data/etc/storage.json.bak
+   sudo sed -i 's/sqlite/postgres/g' /usr/local/fledge/data/etc/storage.json
+   ./reset
+fi
+
 
 rm -f err.txt
 touch err.txt

--- a/tests/system/lab/test
+++ b/tests/system/lab/test
@@ -10,14 +10,6 @@ CRESET="${CPFX}0m"
 
 # Read config file
 . ./test.config
-if [[  ${STORAGE} == "postgres" ]]; then
-   sudo apt install -y postgresql
-   sudo -u postgres createuser -d "$(whoami)"
-   sudo cp /usr/local/fledge/data/etc/storage.json /usr/local/fledge/data/etc/storage.json.bak
-   sudo sed -i 's/sqlite/postgres/g' /usr/local/fledge/data/etc/storage.json
-   ./reset
-fi
-
 
 rm -f err.txt
 touch err.txt

--- a/tests/system/lab/test.config
+++ b/tests/system/lab/test.config
@@ -5,4 +5,4 @@ MAX_RETRIES=100
 SLEEP_FIX=10 # Time to sleep to fix bugs. This should be zero.
 EXIT_EARLY=0
 VERIFY_EGRESS_TO_PI=1
-STORAGE=postgres # sqlite, sqlite-in-memory
+STORAGE=sqlite # postgres, sqlite-in-memory

--- a/tests/system/lab/test.config
+++ b/tests/system/lab/test.config
@@ -5,3 +5,4 @@ MAX_RETRIES=100
 SLEEP_FIX=10 # Time to sleep to fix bugs. This should be zero.
 EXIT_EARLY=0
 VERIFY_EGRESS_TO_PI=1
+STORAGE=postgres # sqlite, sqlite-in-memory


### PR DESCRIPTION
7. RPi -  postgres
8. RPi -  sqlitememory

note- Raspberry Pi with sqlite was already covered. 

We already allow storage engine in conftest for system test using pytest, so we can setup CI jobs with that param to run for postgres (across the platforms).

For sqlite in memeory we need to modify conftest. I will raise a JIRA for that; Also we will start to run test for CSV playback (vibration demo) using  sqlite in memeory.




