### PR TITLE
FOGL-4134 Failed external services can not register when they restart

### DIFF
--- a/python/fledge/services/core/service_registry/service_registry.py
+++ b/python/fledge/services/core/service_registry/service_registry.py
@@ -162,7 +162,7 @@ class ServiceRegistry:
     def check_address_and_port(cls, address, port):
         # AND based check
         # ugly hack! <Make filter to support AND | OR>
-        services = [s for s in cls._registry if getattr(s, "_address") == address and getattr(s, "_port") == port]
+        services = [s for s in cls._registry if getattr(s, "_address") == address and getattr(s, "_port") == port and getattr(s, "_status") != ServiceRecord.Status.Failed]
         if len(services) == 0:
             return False
         return True
@@ -172,7 +172,7 @@ class ServiceRegistry:
         # AND based check
         # ugly hack! <Make filter to support AND | OR>
         services = [s for s in cls._registry if getattr(s, "_address") == address
-                    and getattr(s, "_management_port") == m_port]
+                    and getattr(s, "_management_port") == m_port and getattr(s, "_status") != ServiceRecord.Status.Failed]
         if len(services) == 0:
             return False
         return True


### PR DESCRIPTION
due to too strict checks in the service registry

Signed-off-by: Mark Riddoch <mark@dianomic.com>