### PR TITLE
FOGL-4076-fix When Fledge is started with a blank database there is a

### DIFF
--- a/C/services/storage/storage.cpp
+++ b/C/services/storage/storage.cpp
@@ -257,7 +257,10 @@ void StorageService::start(string& coreAddress, unsigned short corePort)
 		}
 		vector<string> children1;
 		children1.push_back(STORAGE_CATEGORY);
-		client->addChildCategories(ADVANCED, children1);
+		try {
+			client->addChildCategories(ADVANCED, children1);
+		} catch (...) {
+		}
 
 		// Regsiter for configuration chanegs to our category
 		ConfigHandler *configHandler = ConfigHandler::getInstance(client);


### PR DESCRIPTION
failure as the Advanced configuration category does not exist

Signed-off-by: Mark Riddoch <mark@dianomic.com>