### PR TITLE
FOGL-4133 POST repository API endpoint added for debian systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ data/scripts
 data/plugins
 data/snapshots
 data/logs
+data/configure_repo_output.txt
 
 # SQLite3 default db location and after migration
 data/*.db

--- a/python/fledge/services/core/api/repos/configure.py
+++ b/python/fledge/services/core/api/repos/configure.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+# FLEDGE_BEGIN
+# See: http://fledge.readthedocs.io/
+# FLEDGE_END
+
+import os
+import platform
+import logging
+import json
+
+from aiohttp import web
+
+from fledge.common.common import _FLEDGE_ROOT
+from fledge.common import logger
+
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2020 Dianomic Systems Inc."
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+_help = """
+    -------------------------------------------------------------------------------
+    | POST             | /fledge/repository                                       |
+    -------------------------------------------------------------------------------
+"""
+_LOGGER = logger.setup(__name__, level=logging.INFO)
+
+
+async def add_package_repo(request: web.Request) -> web.Response:
+    """ configure package repo
+
+    :Example:
+        curl -X POST http://localhost:8081/fledge/repository
+        data:
+            url - Set a repository URL that used for installing packages via apt or yum
+            version - Points to the package release version or any custom branch fixes
+
+        curl -sX POST http://localhost:8081/fledge/repository -d '{"url":"http://archives.fledge-iot.org"'
+        curl -sX POST http://localhost:8081/fledge/repository -d '{"url":"http://archives.fledge-iot.org", "version":"latest"}'
+    """
+    try:
+        data = await request.json()
+        url = data.get('url', None)
+        # By default version is latest
+        version = data.get('version', 'latest')
+        if not url:
+            raise ValueError('url param is required')
+
+        _platform = platform.platform()
+        pkg_mgt = 'yum' if 'centos' in _platform or 'redhat' in _platform else 'apt'
+        my_list = ['nightly', 'latest', 'fixes/']
+        if not any(x in version for x in my_list):
+            delimiter = '.'
+            if str(version).count(delimiter) != 2:
+                raise ValueError('Semantic version is incorrect; it should be like X.Y.Z')
+
+        if 'x86_64-with-Ubuntu-18.04' in _platform:
+            os_name = "ubuntu1804"
+            architecture = "x86_64"
+        elif 'armv7l-with-debian' in _platform:
+            os_name = "buster"
+            architecture = "armv7l"
+        elif 'aarch64-with-Ubuntu-18.04' in _platform:
+            os_name = "ubuntu1804"
+            architecture = "aarch64"
+        elif 'x86_64-with-redhat' in _platform:
+            os_name = "rhel76"
+            architecture = "x86_64"
+        elif 'aarch64-with-Mendel' in _platform:
+            os_name = "mendel"
+            architecture = "aarch64"
+        elif 'x86_64-with-centos' in _platform:
+            os_name = "centos76"
+            architecture = "x86_64"
+        else:
+            raise ValueError("{} is not supported".format(_platform))
+
+        stdout_file_path = _FLEDGE_ROOT + "/data/configure_repo_output.txt"
+        cmd = "wget -q -O - {}/KEY.gpg | sudo apt-key add - > {} 2>&1".format(url, stdout_file_path)
+        _LOGGER.debug("CMD....{}".format(cmd))
+        ret_code = os.system(cmd)
+        if ret_code != 0:
+            raise RuntimeError("See logs in {}".format(stdout_file_path))
+        full_url = "{}/{}/{}/{}".format(url, version, os_name, architecture)
+        cmd = "echo \"deb {}/ /\" | sudo tee /etc/apt/sources.list.d/fledge.list >> {} 2>&1".format(full_url,
+                                                                                                    stdout_file_path)
+        _LOGGER.debug("CMD....{}".format(cmd))
+        ret_code = os.system(cmd)
+        if ret_code != 0:
+            raise RuntimeError("See logs in {}".format(stdout_file_path))
+        cmd = "sudo {} -y update >> {} 2>&1".format(pkg_mgt, stdout_file_path)
+        _LOGGER.debug("CMD....{}".format(cmd))
+        ret_code = os.system(cmd)
+        if ret_code != 0:
+            raise RuntimeError("See logs in {}".format(stdout_file_path))
+        # TODO: audit log entry?
+    except ValueError as ex:
+        raise web.HTTPBadRequest(body=json.dumps({"message": str(ex)}), reason=str(ex))
+    except RuntimeError as ex:
+        raise web.HTTPBadRequest(body=json.dumps({"message": "Package repository is failed", "output_log": str(ex)}),
+                                 reason=str(ex))
+    except Exception as ex:
+        raise web.HTTPInternalServerError(reason=str(ex))
+    else:
+        return web.json_response({"message": "Package repository is configured successfully.",
+                                  "output_log": stdout_file_path})
+

--- a/python/fledge/services/core/routes.py
+++ b/python/fledge/services/core/routes.py
@@ -28,6 +28,7 @@ from fledge.services.core.api.plugins import remove as plugins_remove
 from fledge.services.core.api.snapshot import plugins as snapshot_plugins
 from fledge.services.core.api.snapshot import table as snapshot_table
 from fledge.services.core.api import package_log
+from fledge.services.core.api.repos import configure as configure_repo
 
 
 __author__ = "Ashish Jabble, Praveen Garg, Massimiliano Pinto, Amarendra K Sinha"
@@ -207,6 +208,9 @@ def setup(app):
     app.router.add_route('POST', '/fledge/snapshot/schedule', snapshot_table.post_snapshot)
     app.router.add_route('PUT', '/fledge/snapshot/schedule/{id}', snapshot_table.put_snapshot)
     app.router.add_route('DELETE', '/fledge/snapshot/schedule/{id}', snapshot_table.delete_snapshot)
+
+    # Repo configure
+    app.router.add_route('POST', '/fledge/repository', configure_repo.add_package_repo)
 
     # enable cors support
     enable_cors(app)


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

**Assumption**
1)There is no existing setup for currently.
2) Non Package installation (i.e sudo make install) - manual install of FL via sudo will work
3) WL code available [here](http://archives.dianomic.com/foglamp/fixes/FOGL-4133/ubuntu1804/x86_64/sources.tar.gz)

**How to test?**
```
$ curl -sX POST localhost:8081/foglamp/repository -d '{"url": "http://archives.fledge-iot.org", "version": "nightly"}'

$ curl -sX POST localhost:8081/foglamp/repository -d '{"url": "http://archives.dianomic.com/foglamp", "version": "fixes/FOGL-4133"}'
```

**Pending**
1) RPM Platform - Raise JIRA FOGL-4176