### PR TITLE
FOGL-4185 ca-certificates dep is needed in case its not installed on specific d…

### DIFF
--- a/docs/building_fledge/building_fledge.rst
+++ b/docs/building_fledge/building_fledge.rst
@@ -73,6 +73,7 @@ Fledge is currently based on C/C++ and Python code. The packages needed to build
 - automake
 - avahi-daemon
 - build-essential
+- ca-certificates
 - cmake
 - cpulimit
 - curl

--- a/docs/building_fledge/building_fledge.rst
+++ b/docs/building_fledge/building_fledge.rst
@@ -105,7 +105,7 @@ Fledge is currently based on C/C++ and Python code. The packages needed to build
   ...
   All packages are up-to-date.
   $
-  $ sudo apt-get install avahi-daemon curl git cmake g++ make build-essential autoconf automake
+  $ sudo apt-get install avahi-daemon ca-certificates curl git cmake g++ make build-essential autoconf automake
   Reading package lists... Done
   Building dependency tree
   ...

--- a/requirements.sh
+++ b/requirements.sh
@@ -191,7 +191,7 @@ elif apt --version 2>/dev/null; then
 	# avoid interactive questions
 	DEBIAN_FRONTEND=noninteractive apt install -yq libssl-dev
 
-	apt install -y avahi-daemon curl
+	apt install -y avahi-daemon ca-certificates curl
 	apt install -y cmake g++ make build-essential autoconf automake uuid-dev
 	apt install -y libtool libboost-dev libboost-system-dev libboost-thread-dev libpq-dev libz-dev
 	apt install -y python-dev python3-dev python3-pip


### PR DESCRIPTION
…ebian based os e.g. moxa using strech / armhf based custom image