### PR TITLE
FOGL-4264 - extend service API for management type

### DIFF
--- a/python/fledge/services/core/api/scheduler.py
+++ b/python/fledge/services/core/api/scheduler.py
@@ -134,7 +134,7 @@ async def post_scheduled_process(request: web.Request) -> web.Response:
             msg = str(ex)
             raise web.HTTPInternalServerError(body=json.dumps(
                 {"message": "Failed to create scheduled process. {}".format(msg)}), reason=msg)
-        finally:
+        else:
             return web.json_response({"message": "{} process name created successfully.".format(process_name)})
     else:
         msg = '{} process name already exists.'.format(process_name)

--- a/python/fledge/services/core/api/service.py
+++ b/python/fledge/services/core/api/service.py
@@ -214,7 +214,7 @@ async def add_service(request):
         if service_type == 'north':
             raise web.HTTPNotAcceptable(reason='north type is not supported for the time being.')
         if service_type not in ['south', 'notification', 'management']:
-            raise web.HTTPBadRequest(reason='Only south, notification, management types are supported.')
+            raise web.HTTPBadRequest(reason='Only south, notification and management types are supported.')
         if plugin is None and service_type == 'south':
             raise web.HTTPBadRequest(reason='Missing plugin property for type south in payload.')
         if plugin and utils.check_reserved(plugin) is False:
@@ -293,14 +293,13 @@ async def add_service(request):
 
         # check that notification service is not already registered, right now notification service LIMIT to 1
         if service_type == 'notification':
-            res = await check_notification_schedule(storage)
+            res = await check_schedule_entry(storage)
             for ps in res['rows']:
                 if 'notification_c' in ps['process_name']:
                     raise web.HTTPBadRequest(reason='A Notification service schedule already exists.')
         # check that management service is not already registered, right now management service LIMIT to 1
         elif service_type == 'management':
-            # TODO: we may rename check_notification_schedule def to check_schedule_entry
-            res = await check_notification_schedule(storage)
+            res = await check_schedule_entry(storage)
             for ps in res['rows']:
                 if 'management' in ps['process_name']:
                     raise web.HTTPBadRequest(reason='A Management service schedule already exists.')
@@ -394,7 +393,7 @@ async def get_schedule(storage, schedule_name):
     return result
 
 
-async def check_notification_schedule(storage):
+async def check_schedule_entry(storage):
     payload = PayloadBuilder().SELECT("process_name").payload()
     result = await storage.query_tbl_with_payload('schedules', payload)
     return result

--- a/python/fledge/services/core/api/service.py
+++ b/python/fledge/services/core/api/service.py
@@ -71,12 +71,16 @@ def get_service_records():
 
 
 def get_service_installed() -> List:
+    paths = [_FLEDGE_ROOT + "/services", _FLEDGE_ROOT + "/python/fledge/services/management"]
     services = []
     svc_prefix = 'fledge.services.'
-    for root, dirs, files in os.walk(_FLEDGE_ROOT + "/" + "services"):
-        for f in files:
-            if f.startswith(svc_prefix):
-                services.append(f.split(svc_prefix)[-1])
+    for _path in paths:
+        for root, dirs, files in os.walk(_path):
+            for _file in files:
+                if _file.startswith(svc_prefix):
+                    services.append(_file.split(svc_prefix)[-1])
+                elif _file == '__main__.py':
+                    services.append('management')
     return services
 
 

--- a/python/fledge/services/core/api/service.py
+++ b/python/fledge/services/core/api/service.py
@@ -42,7 +42,8 @@ _help = """
     | GET POST            | /fledge/service                                      |
     | GET                 | /fledge/service/available                            |
     | GET                 | /fledge/service/installed                            |
-    | PUT                 | /fledge/service/{type}/{name}/update                |
+    | PUT                 | /fledge/service/{type}/{name}/update                 |
+    | DELETE              | /fledge/service/{service_name}                       |
     ------------------------------------------------------------------------------
 """
 

--- a/python/fledge/services/core/routes.py
+++ b/python/fledge/services/core/routes.py
@@ -80,6 +80,7 @@ def setup(app):
     # Scheduler
     # Scheduled_processes - As per doc
     app.router.add_route('GET', '/fledge/schedule/process', api_scheduler.get_scheduled_processes)
+    app.router.add_route('POST', '/fledge/schedule/process', api_scheduler.post_scheduled_process)
     app.router.add_route('GET', '/fledge/schedule/process/{scheduled_process_name}', api_scheduler.get_scheduled_process)
 
     # Schedules - As per doc

--- a/tests/unit/python/fledge/services/core/api/test_service.py
+++ b/tests/unit/python/fledge/services/core/api/test_service.py
@@ -146,7 +146,7 @@ class TestService:
         ('{"name": "test", "plugin": "dht11", "type": "south", "enabled": "0"}', 400,
          'Only "true", "false", true, false are allowed for value of enabled.'),
         ('{"name": "test", "plugin": "dht11"}', 400, "Missing type property in payload."),
-        ('{"name": "test", "plugin": "dht11", "type": "blah"}', 400, "Only south and notification type are supported."),
+        ('{"name": "test", "plugin": "dht11", "type": "blah"}', 400, "Only south, notification, management types are supported."),
         ('{"name": "test", "plugin": "dht11", "type": "North"}', 406, "north type is not supported for the time being."),
         ('{"name": "test", "type": "south"}', 400, "Missing plugin property for type south in payload.")
     ])

--- a/tests/unit/python/fledge/services/core/api/test_service.py
+++ b/tests/unit/python/fledge/services/core/api/test_service.py
@@ -146,7 +146,7 @@ class TestService:
         ('{"name": "test", "plugin": "dht11", "type": "south", "enabled": "0"}', 400,
          'Only "true", "false", true, false are allowed for value of enabled.'),
         ('{"name": "test", "plugin": "dht11"}', 400, "Missing type property in payload."),
-        ('{"name": "test", "plugin": "dht11", "type": "blah"}', 400, "Only south, notification, management types are supported."),
+        ('{"name": "test", "plugin": "dht11", "type": "blah"}', 400, "Only south, notification and management types are supported."),
         ('{"name": "test", "plugin": "dht11", "type": "North"}', 406, "north type is not supported for the time being."),
         ('{"name": "test", "type": "south"}', 400, "Missing plugin property for type south in payload.")
     ])
@@ -712,5 +712,106 @@ class TestService:
             result = await resp.text()
             json_response = json.loads(result)
             assert {'services': ['south', 'storage']} == json_response
+
+    p1 = '{"name": "FL Agent", "type": "management"}'
+    p2 = '{"name": "FL #1", "type": "management", "enabled": false}'
+    p3 = '{"name": "FL_MGT", "type": "management", "enabled": true}'
+    @pytest.mark.parametrize("payload", [p1, p2, p3])
+    async def test_add_management_service(self, client, payload):
+        data = json.loads(payload)
+        sch_id = '4624d3e4-c295-4bfd-848b-8a843cc90c3f'
+
+        async def async_mock_get_schedule():
+            schedule = StartUpSchedule()
+            schedule.schedule_id = sch_id
+            return schedule
+
+        @asyncio.coroutine
+        def q_result(*arg):
+            table = arg[0]
+            _payload = json.loads(arg[1])
+            if table == 'schedules':
+                if _payload['return'][0] == 'process_name':
+                    assert {"return": ["process_name"]} == _payload
+                    return {'rows': [{'process_name': 'purge'}, {'process_name': 'stats collector'}], 'count': 2}
+                else:
+                    assert {"return": ["schedule_name"], "where": {"column": "schedule_name", "condition": "=",
+                                                                   "value": data['name']}} == _payload
+
+                    return {'count': 0, 'rows': []}
+            if table == 'scheduled_processes':
+                assert {"return": ["name"], "where": {"column": "name", "condition": "=",
+                                                      "value": "management"}} == _payload
+                return {'count': 0, 'rows': []}
+
+        expected_insert_resp = {'rows_affected': 1, "response": "inserted"}
+
+        server.Server.scheduler = Scheduler(None, None)
+        storage_client_mock = MagicMock(StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
+            with patch.object(c_mgr, 'get_category_all_items', return_value=self.async_mock(None)) as patch_get_cat_info:
+                with patch.object(storage_client_mock, 'query_tbl_with_payload', side_effect=q_result):
+                    with patch.object(storage_client_mock, 'insert_into_tbl', return_value=self.async_mock(expected_insert_resp)) as insert_table_patch:
+                        with patch.object(server.Server.scheduler, 'save_schedule', return_value=self.async_mock("")) as patch_save_schedule:
+                            with patch.object(server.Server.scheduler, 'get_schedule_by_name', return_value=async_mock_get_schedule()) as patch_get_schedule:
+                                resp = await client.post('/fledge/service', data=payload)
+                                server.Server.scheduler = None
+                                assert 200 == resp.status
+                                result = await resp.text()
+                                json_response = json.loads(result)
+                                assert {'id': sch_id, 'name': data['name']} == json_response
+                            patch_get_schedule.assert_called_once_with(data['name'])
+                        patch_save_schedule.called_once_with()
+                    args, kwargs = insert_table_patch.call_args
+                    assert 'scheduled_processes' == args[0]
+                    p = json.loads(args[1])
+                    assert {'name': 'management', 'script': '["services/management"]'} == p
+            patch_get_cat_info.assert_called_once_with(category_name=data['name'])
+
+    async def test_dupe_management_service_schedule(self, client):
+        payload = '{"name": "FL Agent", "type": "management"}'
+        data = json.loads(payload)
+
+        @asyncio.coroutine
+        def q_result(*arg):
+            table = arg[0]
+            _payload = json.loads(arg[1])
+            if table == 'schedules':
+                if _payload['return'][0] == 'process_name':
+                    assert {"return": ["process_name"]} == _payload
+                    return {'rows': [{'process_name': 'stats collector'}, {'process_name': 'management'}],
+                            'count': 2}
+
+                else:
+                    assert {"return": ["schedule_name"], "where": {"column": "schedule_name", "condition": "=",
+                                                                   "value": data['name']}} == _payload
+
+                    return {'count': 0, 'rows': []}
+            if table == 'scheduled_processes':
+                assert {"return": ["name"], "where": {"column": "name", "condition": "=",
+                                                      "value": "management"}} == _payload
+                return {'count': 0, 'rows': []}
+
+        expected_insert_resp = {'rows_affected': 1, "response": "inserted"}
+
+        server.Server.scheduler = Scheduler(None, None)
+        storage_client_mock = MagicMock(StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
+            with patch.object(c_mgr, 'get_category_all_items',
+                              return_value=self.async_mock(None)) as patch_get_cat_info:
+                with patch.object(storage_client_mock, 'query_tbl_with_payload', side_effect=q_result):
+                    with patch.object(storage_client_mock, 'insert_into_tbl',
+                                      return_value=self.async_mock(expected_insert_resp)) as insert_table_patch:
+                        resp = await client.post('/fledge/service', data=payload)
+                        server.Server.scheduler = None
+                        assert 400 == resp.status
+                        assert 'A Management service schedule already exists.' == resp.reason
+                    args, kwargs = insert_table_patch.call_args
+                    assert 'scheduled_processes' == args[0]
+                    p = json.loads(args[1])
+                    assert {'name': 'management', 'script': '["services/management"]'} == p
+            patch_get_cat_info.assert_called_once_with(category_name=data['name'])
 
 # TODO:  add negative tests and C type plugin add service tests


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

- [x] POST - /fledge/service
- [x] GET -  /fledge/service/installed
- [x] POST - /fledge/schedule/process - `We can avoid that work to insert direct entry in init.sql along with upgrade/downgrade scripts`