### PR TITLE
FOGL-4233 plugin available packages with 'north', 'south', 'filter', 'notify', 'rule' types only

### DIFF
--- a/python/fledge/services/core/api/plugins/discovery.py
+++ b/python/fledge/services/core/api/plugins/discovery.py
@@ -74,9 +74,9 @@ async def get_plugins_available(request: web.Request) -> web.Response:
         if package_type and package_type not in ['north', 'south', 'filter', 'notify', 'rule']:
             raise ValueError("Invalid package type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule'.")
         plugins, log_path = await common.fetch_available_packages(package_type)
-        # fledge-gui, fledge-quickstart and fledge-service-* packages are excluded when no type is given
         if not package_type:
-            plugins = [p for p in plugins if not str(p).startswith('fledge-service-') and p not in ('fledge-quickstart', 'fledge-gui')]
+            prefix_list = ['fledge-filter-', 'fledge-north-', 'fledge-notify-', 'fledge-rule-', 'fledge-south-']
+            plugins = [p for p in plugins if str(p).startswith(tuple(prefix_list))]
     except ValueError as e:
         raise web.HTTPBadRequest(reason=e)
     except PackageError as e:

--- a/tests/unit/python/fledge/services/core/api/plugins/test_discovery.py
+++ b/tests/unit/python/fledge/services/core/api/plugins/test_discovery.py
@@ -117,12 +117,16 @@ class TestPluginDiscoveryApi:
         assert message == resp.reason
 
     @pytest.mark.parametrize("param, output, result", [
-        ("", ['fledge-south-sinusoid', 'fledge-service-notification', 'fledge-gui', 'fledge-service-new',
-              'fledge-quickstart'], ['fledge-south-sinusoid']),
+        ("", ['fledge-dev', 'fledge-south-sinusoid', 'fledge-service-notification', 'fledge-gui',
+              'fledge-service-new', 'fledge-quickstart', 'fledge-north-http', 'fledge-filter-asset',
+              'fledge-notify-slack', 'fledge-rule-average'], ['fledge-south-sinusoid', 'fledge-north-http',
+                                                                'fledge-filter-asset', 'fledge-notify-slack',
+                                                                'fledge-rule-average']),
         ("?type=south", ['fledge-south-random'], ['fledge-south-random']),
         ("?type=north", ['fledge-north-http'], ['fledge-north-http']),
         ("?type=filter", ['fledge-filter-asset'], ['fledge-filter-asset']),
-        ("?type=notify", ['fledge-notify-slack'], ['fledge-notify-slack'])
+        ("?type=notify", ['fledge-notify-slack'], ['fledge-notify-slack']),
+        ("?type=rule", ['fledge-rule-average'], ['fledge-rule-average'])
     ])
     async def test_get_plugins_available(self, client, param, output, result):
         async def async_mock(return_value):


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

@MarkRiddoch fyi, We would also want to see all available packages. 
At the moment we have restricted with supported types
a) For plugins: `http://localhost:8081/fledge/plugins/available?type=` | `'north', 'south', 'filter', 'notify', 'rule'` 
b) For service package we have separate endpoint `http://localhost:8081/fledge/service/available`

We may add new endpoint and get it via `curl -sX GET http://localhost:8081/fledge/packages/available`