### PR TITLE
FOGL-4419 - API enhancements for notification plugin type info & installed directory, package info KV pair added to installed plugins

### DIFF
--- a/python/fledge/common/plugin_discovery.py
+++ b/python/fledge/common/plugin_discovery.py
@@ -30,16 +30,12 @@ class PluginDiscovery(object):
     def get_plugins_installed(cls, plugin_type=None, is_config=False):
         if plugin_type is None:
             plugins_list = []
-            plugins_list_north = cls.fetch_plugins_installed(plugin_type="north", is_config=is_config,
-                                                             installed_dir_name="north")
-            plugins_list_south = cls.fetch_plugins_installed(plugin_type="south", is_config=is_config,
-                                                             installed_dir_name="south")
-            plugins_list_filter = cls.fetch_plugins_installed(plugin_type="filter", is_config=is_config,
-                                                              installed_dir_name="filter")
-            plugins_list_notify = cls.fetch_plugins_installed(plugin_type="notify", is_config=is_config,
-                                                              installed_dir_name="notificationDelivery")
-            plugins_list_rule = cls.fetch_plugins_installed(plugin_type="rule", is_config=is_config,
-                                                            installed_dir_name="notificationRule")
+            plugins_list_north = cls.fetch_plugins_installed(installed_dir_name="north", is_config=is_config)
+            plugins_list_south = cls.fetch_plugins_installed(installed_dir_name="south", is_config=is_config)
+            plugins_list_filter = cls.fetch_plugins_installed(installed_dir_name="filter", is_config=is_config)
+            plugins_list_notify = cls.fetch_plugins_installed(installed_dir_name="notificationDelivery",
+                                                              is_config=is_config)
+            plugins_list_rule = cls.fetch_plugins_installed(installed_dir_name="notificationRule", is_config=is_config)
             plugins_list_c_north = cls.fetch_c_plugins_installed(plugin_type="north", is_config=is_config,
                                                                  installed_dir_name="north")
             plugins_list_c_south = cls.fetch_c_plugins_installed(plugin_type="south", is_config=is_config,
@@ -67,13 +63,13 @@ class PluginDiscovery(object):
                 installed_dir_name = 'notificationRule'
             else:
                 installed_dir_name = plugin_type
-            plugins_list = cls.fetch_plugins_installed(plugin_type, is_config, installed_dir_name=installed_dir_name)
-            plugins_list.extend(cls.fetch_c_plugins_installed(plugin_type, is_config,
+            plugins_list = cls.fetch_plugins_installed(installed_dir_name=installed_dir_name, is_config=is_config)
+            plugins_list.extend(cls.fetch_c_plugins_installed(plugin_type = plugin_type, is_config=is_config,
                                                               installed_dir_name=installed_dir_name))
         return plugins_list
 
     @classmethod
-    def fetch_plugins_installed(cls, plugin_type, is_config, installed_dir_name):
+    def fetch_plugins_installed(cls, installed_dir_name, is_config):
         directories = cls.get_plugin_folders(installed_dir_name)
         # Check is required only for notificationDelivery & notificationRule python plugins as NS is an external service
         # Hence we are not creating empty directories, as we had for south & filters
@@ -81,7 +77,7 @@ class PluginDiscovery(object):
             directories = []
         configs = []
         for d in directories:
-            plugin_config = cls.get_plugin_config(d, is_config, installed_dir_name)
+            plugin_config = cls.get_plugin_config(d, installed_dir_name, is_config)
             if plugin_config is not None:
                 configs.append(plugin_config)
         return configs
@@ -159,7 +155,7 @@ class PluginDiscovery(object):
         return configs
 
     @classmethod
-    def get_plugin_config(cls, plugin_dir, is_config, installed_dir_name):
+    def get_plugin_config(cls, plugin_dir, installed_dir_name, is_config):
         plugin_module_path = plugin_dir
         plugin_config = None
         # Now load the plugin to fetch its configuration

--- a/python/fledge/services/core/api/plugins/common.py
+++ b/python/fledge/services/core/api/plugins/common.py
@@ -94,7 +94,9 @@ def load_and_fetch_c_hybrid_plugin_info(plugin_name: str, is_config: bool, plugi
                                        'type': plugin_type,
                                        'description': data['description'],
                                        'version': jdoc['version'],
-                                       'installedDirectory': plugin_type
+                                       'installedDirectory': '{}/{}'.format(plugin_type, plugin_name),
+                                       'packageName': 'fledge-{}-{}'.format(plugin_type,
+                                                                            plugin_name.lower().replace("_", "-"))
                                        }
                         keys_a = set(jdoc['config'].keys())
                         keys_b = set(data['defaults'].keys())

--- a/python/fledge/services/core/api/plugins/common.py
+++ b/python/fledge/services/core/api/plugins/common.py
@@ -69,7 +69,8 @@ def load_and_fetch_c_hybrid_plugin_info(plugin_name: str, is_config: bool, plugi
     plugin_info = None
     if plugin_type == 'south':
         config_items = ['default', 'type', 'description']
-        optional_items = ['readonly', 'order', 'length', 'maximum', 'minimum', 'rule', 'deprecated', 'displayName', 'options']
+        optional_items = ['readonly', 'order', 'length', 'maximum', 'minimum', 'rule', 'deprecated', 'displayName',
+                          'options']
         config_items.extend(optional_items)
         plugin_dir = _FLEDGE_ROOT + '/' + 'plugins' + '/' + plugin_type
         if _FLEDGE_PLUGIN_PATH:
@@ -89,13 +90,17 @@ def load_and_fetch_c_hybrid_plugin_info(plugin_name: str, is_config: bool, plugi
                 if _FLEDGE_ROOT + '/' + 'plugins' + '/' + plugin_type or os.path.isdir(plugin_dir + '/' + connection_name):
                     jdoc = utils.get_plugin_info(connection_name, dir=plugin_type)
                     if jdoc:
-                        plugin_info = {'name': plugin_name, 'type': plugin_type,
+                        plugin_info = {'name': plugin_name,
+                                       'type': plugin_type,
                                        'description': data['description'],
-                                       'version': jdoc['version']}
+                                       'version': jdoc['version'],
+                                       'installedDirectory': plugin_type
+                                       }
                         keys_a = set(jdoc['config'].keys())
                         keys_b = set(data['defaults'].keys())
                         intersection = keys_a & keys_b
-                        # Merge default and other configuration fields of both connection plugin and hybrid plugin with intersection of 'config' keys
+                        # Merge default and other configuration fields of both connection plugin
+                        # and hybrid plugin with intersection of 'config' keys
                         # Use Hybrid Plugin name and description defined in json file
                         temp = jdoc['config']
                         temp['plugin']['default'] = plugin_name

--- a/python/fledge/services/core/api/plugins/discovery.py
+++ b/python/fledge/services/core/api/plugins/discovery.py
@@ -34,23 +34,23 @@ async def get_plugins_installed(request):
     :Example:
         curl -X GET http://localhost:8081/fledge/plugins/installed
         curl -X GET http://localhost:8081/fledge/plugins/installed?config=true
-        curl -X GET http://localhost:8081/fledge/plugins/installed?type=north|south|filter|notificationDelivery|notificationRule
+        curl -X GET http://localhost:8081/fledge/plugins/installed?type=north|south|filter|notify|rule
         curl -X 'GET http://localhost:8081/fledge/plugins/installed?type=north&config=true'
     """
 
     plugin_type = None
     is_config = False
     if 'type' in request.query and request.query['type'] != '':
-        plugin_type = request.query['type'].lower() if request.query['type'] not in ['notificationDelivery', 'notificationRule'] else request.query['type']
+        plugin_type = request.query['type'].lower()
 
-    if plugin_type is not None and plugin_type not in ['north', 'south', 'filter', 'notificationDelivery', 'notificationRule']:
-        raise web.HTTPBadRequest(reason="Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notificationDelivery' or 'notificationRule'.")
+    if plugin_type is not None and plugin_type not in ['north', 'south', 'filter', 'notify', 'rule']:
+        raise web.HTTPBadRequest(reason="Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify' "
+                                        "or 'rule'.")
 
     if 'config' in request.query:
         config = request.query['config']
         if config not in ['true', 'false', True, False]:
-            raise web.HTTPBadRequest(reason='Only "true", "false", true, false'
-                                                ' are allowed for value of config.')
+            raise web.HTTPBadRequest(reason='Only "true", "false", true, false are allowed for value of config.')
         is_config = True if ((type(config) is str and config.lower() in ['true']) or (
             (type(config) is bool and config is True))) else False
 

--- a/python/fledge/services/core/api/plugins/install.py
+++ b/python/fledge/services/core/api/plugins/install.py
@@ -100,10 +100,8 @@ async def add_plugin(request: web.Request) -> web.Response:
                 raise TypeError('URL, checksum params are required')
             if file_format == "tar" and not plugin_type:
                 raise ValueError("Plugin type param is required")
-            if file_format == "tar" and plugin_type not in ['south', 'north', 'filter', 'notificationDelivery',
-                                                            'notificationRule']:
-                raise ValueError("Invalid plugin type. Must be 'north' or 'south' or 'filter' "
-                                 "or 'notificationDelivery' or 'notificationRule'")
+            if file_format == "tar" and plugin_type not in ['south', 'north', 'filter', 'notify', 'rule']:
+                raise ValueError("Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule'")
             if compressed:
                 if compressed not in ['true', 'false', True, False]:
                     raise ValueError('Only "true", "false", true, false are allowed for value of compressed.')

--- a/python/fledge/services/core/api/plugins/remove.py
+++ b/python/fledge/services/core/api/plugins/remove.py
@@ -33,7 +33,7 @@ _help = """
 
 _logger = logger.setup(__name__, level=logging.INFO)
 
-valid_plugin_types = ['north', 'south', 'filter', 'notificationDelivery', 'notificationRule']
+valid_plugin_types = ['north', 'south', 'filter', 'notify', 'rule']
 PYTHON_PLUGIN_PATH = _FLEDGE_ROOT+'/python/fledge/plugins/'
 C_PLUGINS_PATH = _FLEDGE_ROOT+'/plugins/'
 
@@ -48,24 +48,29 @@ async def remove_plugin(request):
         curl -X DELETE http://localhost:8081/fledge/plugins/south/sinusoid
         curl -X DELETE http://localhost:8081/fledge/plugins/north/http_north
         curl -X DELETE http://localhost:8081/fledge/plugins/filter/expression
-        curl -X DELETE http://localhost:8081/fledge/plugins/notificationDelivery/alexa
-        curl -X DELETE http://localhost:8081/fledge/plugins/notificationRule/Average
+        curl -X DELETE http://localhost:8081/fledge/plugins/notify/alexa
+        curl -X DELETE http://localhost:8081/fledge/plugins/rule/Average
     """
     plugin_type = request.match_info.get('type', None)
     name = request.match_info.get('name', None)
     try:
-        plugin_type = str(plugin_type).lower() if not str(plugin_type).startswith('notification') else plugin_type
+        plugin_type = str(plugin_type).lower()
         if plugin_type not in valid_plugin_types:
             raise ValueError("Invalid plugin type. Please provide valid type: {}".format(valid_plugin_types))
-        installed_plugin = PluginDiscovery.get_plugins_installed(plugin_type, False)
+        if plugin_type == 'notify':
+            installed_dir_name = 'notificationDelivery'
+        elif plugin_type == 'rule':
+            installed_dir_name = 'notificationRule'
+        else:
+            installed_dir_name = plugin_type
+        installed_plugin = PluginDiscovery.get_plugins_installed(installed_dir_name, False)
         if name not in [plugin['name'] for plugin in installed_plugin]:
             raise KeyError("Invalid plugin name {} or plugin is not installed".format(name))
-        if plugin_type in ['notificationDelivery', 'notificationRule']:
+        if plugin_type in ['notify', 'rule']:
             notification_instances_plugin_used_in = await check_plugin_usage_in_notification_instances(name)
             if notification_instances_plugin_used_in:
                 raise RuntimeError("{} cannot be removed. This is being used by {} instances".
                                    format(name, notification_instances_plugin_used_in))
-            plugin_type = 'notify' if plugin_type == 'notificationDelivery' else 'rule'
         else:
             get_tracked_plugins = await check_plugin_usage(plugin_type, name)
             if get_tracked_plugins:

--- a/tests/system/python/api/test_plugin_discovery.py
+++ b/tests/system/python/api/test_plugin_discovery.py
@@ -4,7 +4,7 @@
 # See: http://fledge.readthedocs.io/
 # FLEDGE_END
 
-""" Test plugin discovery (north, south, filter, notificationDelivery, notificationRule) REST API """
+""" Test plugin discovery (north, south, filter, notify, rule) REST API """
 
 import subprocess
 import http.client
@@ -32,10 +32,7 @@ def install_plugin(_type, plugin, branch="develop", plugin_lang="python", use_pi
         assert False, "{} plugin installation failed".format(plugin)
 
     # Cleanup /tmp repos
-    if _type == "notificationDelivery":
-        _type = "notify"
-    if _type == "notificationRule":
-        _type = "rule"
+    if _type == "rule":
         subprocess.run(["rm -rf /tmp/fledge-service-notification"], shell=True, check=True)
     subprocess.run(["rm -rf /tmp/fledge-{}-{}".format(_type, plugin)], shell=True, check=True)
 
@@ -71,7 +68,7 @@ class TestPluginDiscovery:
         assert 3 == len(jdoc['plugins'])
         for plugin in jdoc['plugins']:
             assert 'north' == plugin['type']
-            assert plugin['type'] not in ['south', 'filter', 'notificationDelivery', 'notificationRule']
+            assert plugin['type'] not in ['south', 'filter', 'notify', 'rule']
             # config is not expected by default
             assert 'config' in plugin if config else 'config' not in plugin
 

--- a/tests/system/python/api/test_plugin_discovery.py
+++ b/tests/system/python/api/test_plugin_discovery.py
@@ -78,8 +78,8 @@ class TestPluginDiscovery:
     @pytest.mark.parametrize("method, count, config", [
         ("/fledge/plugins/installed?type=south", 0, None),
         ("/fledge/plugins/installed?type=filter", 0, None),
-        ("/fledge/plugins/installed?type=notificationDelivery", 0, None),
-        ("/fledge/plugins/installed?type=notificationRule", 0, None),
+        ("/fledge/plugins/installed?type=notify", 0, None),
+        ("/fledge/plugins/installed?type=rule", 0, None),
         ("/fledge/plugins/installed?type=north&config=false", 3, False),
         ("/fledge/plugins/installed?type=north&config=true", 3, True)
     ])
@@ -170,7 +170,7 @@ class TestPluginDiscovery:
         assert 1 == len(plugins)
         assert 'rms' == plugins[0]['name']
 
-    def test_delivery_plugins_installed(self, fledge_url, _type='notificationDelivery'):
+    def test_delivery_plugins_installed(self, fledge_url, _type='notify'):
         # install slack delivery plugin
         install_plugin(_type, plugin='slack', plugin_lang='C')
         conn = http.client.HTTPConnection(fledge_url)
@@ -184,7 +184,7 @@ class TestPluginDiscovery:
         assert 1 == len(plugins)
         assert 'slack' == plugins[0]['name']
 
-    def test_rule_plugins_installed(self, fledge_url, _type='notificationRule'):
+    def test_rule_plugins_installed(self, fledge_url, _type='rule'):
         # install OutOfBound rule plugin
         install_plugin(_type, plugin='outofbound', plugin_lang='C')
         conn = http.client.HTTPConnection(fledge_url)

--- a/tests/system/python/api/test_plugin_discovery.py
+++ b/tests/system/python/api/test_plugin_discovery.py
@@ -109,6 +109,9 @@ class TestPluginDiscovery:
         plugins = jdoc['plugins']
         assert 1 == len(plugins)
         assert 'sinusoid' == plugins[0]['name']
+        assert 'south' == plugins[0]['type']
+        assert 'south/sinusoid' == plugins[0]['installedDirectory']
+        assert 'fledge-south-sinusoid' == plugins[0]['packageName']
 
         # install one more south plugin (C version)
         install_plugin(_type, plugin='random', plugin_lang='C')
@@ -121,7 +124,13 @@ class TestPluginDiscovery:
         plugins = jdoc['plugins']
         assert 2 == len(plugins)
         assert 'sinusoid' == plugins[0]['name']
+        assert 'south' == plugins[0]['type']
+        assert 'south/sinusoid' == plugins[0]['installedDirectory']
+        assert 'fledge-south-sinusoid' == plugins[0]['packageName']
         assert 'Random' == plugins[1]['name']
+        assert 'south' == plugins[1]['type']
+        assert 'south/Random' == plugins[1]['installedDirectory']
+        assert 'fledge-south-random' == plugins[1]['packageName']
 
     def test_north_plugins_installed(self, fledge_url, _type='north'):
         # install north plugin (Python version)
@@ -180,6 +189,9 @@ class TestPluginDiscovery:
         plugins = jdoc['plugins']
         assert 1 == len(plugins)
         assert 'slack' == plugins[0]['name']
+        assert 'notify' == plugins[0]['type']
+        assert 'notificationDelivery/slack' == plugins[0]['installedDirectory']
+        assert 'fledge-notify-slack' == plugins[0]['packageName']
 
     def test_rule_plugins_installed(self, fledge_url, _type='rule'):
         # install OutOfBound rule plugin
@@ -194,3 +206,6 @@ class TestPluginDiscovery:
         plugins = jdoc['plugins']
         assert 1 == len(plugins)
         assert 'OutOfBound' == plugins[0]['name']
+        assert 'rule' == plugins[0]['type']
+        assert 'notificationRule/OutOfBound' == plugins[0]['installedDirectory']
+        assert 'fledge-rule-outofbound' == plugins[0]['packageName']

--- a/tests/system/python/plugin_and_service.py
+++ b/tests/system/python/plugin_and_service.py
@@ -24,10 +24,7 @@ def install(_type, plugin, branch="develop", plugin_lang="python", use_pip_cache
         assert False, "{} plugin installation failed".format(plugin)
 
     # Cleanup /tmp repos
-    if _type == "notificationDelivery":
-        _type = "notify"
-    if _type == "notificationRule":
-        _type = "rule"
+    if _type == "rule":
         subprocess.run(["rm -rf /tmp/fledge-service-notification"], shell=True, check=True)
     subprocess.run(["rm -rf /tmp/fledge-{}-{}".format(_type, plugin)], shell=True, check=True)
 

--- a/tests/system/python/scripts/install_c_plugin
+++ b/tests/system/python/scripts/install_c_plugin
@@ -19,17 +19,8 @@ PLUGIN_NAME=$3
 [[ -z "${PLUGIN_TYPE}" ]] && echo "Plugin type not found." && exit 1
 [[ -z "${PLUGIN_NAME}" ]] && echo "Plugin name not found." && exit 1
 
-###############################################################################################################
-# FIXME: As some of the C-plugins are having different project name & repo name convention
-# So when we are using this script we need to check carefully about the convention
-# Plugin name converted to lowercase for repo name
-# For PLUGIN_TYPE 'notificationDelivery' & 'notificationRule', In REPO_NAME type converted to 'notify' & 'rule'
-###############################################################################################################
-
 REPO_NAME=fledge-${PLUGIN_TYPE}-${PLUGIN_NAME,,}
-
-if [[ "${PLUGIN_TYPE}" = "notificationDelivery" ]]; then REPO_NAME=fledge-notify-${PLUGIN_NAME,,}; fi
-if [[ "${PLUGIN_TYPE}" = "notificationRule" ]]; then rm -rf /tmp/fledge-service-notification; REPO_NAME=fledge-rule-${PLUGIN_NAME,,}; fi
+if [[ "${PLUGIN_TYPE}" = "rule" ]]; then rm -rf /tmp/fledge-service-notification; fi
 
 
 clean () {
@@ -47,7 +38,7 @@ install_requirement (){
 }
 
 install_binary_file () {
-   if [[ "${PLUGIN_TYPE}" = "notificationRule" ]]
+   if [[ "${PLUGIN_TYPE}" = "rule" ]]
    then
         # fledge-service-notification repo is required to build notificationRule Plugins
         service_repo_name='fledge-service-notification'

--- a/tests/system/python/scripts/reset_plugins
+++ b/tests/system/python/scripts/reset_plugins
@@ -37,10 +37,12 @@ remove_filter () {
 
 remove_notification_delivery () {
     rm -rf $FLEDGE_ROOT/plugins/notificationDelivery
+    rm -rf $FLEDGE_ROOT/python/fledge/plugins/notificationDelivery
 }
 
 remove_notification_rule () {
     rm -rf $FLEDGE_ROOT/plugins/notificationRule
+    rm -rf $FLEDGE_ROOT/python/fledge/plugins/notificationRule
 }
 
 remove_all () {

--- a/tests/unit/python/fledge/common/test_plugin_discovery.py
+++ b/tests/unit/python/fledge/common/test_plugin_discovery.py
@@ -345,7 +345,7 @@ class TestPluginDiscovery:
                                                         return_value=next(mock_c_folders()))
         mock_get_c_plugin_config = mocker.patch.object(utils, "get_plugin_info",
                                                               side_effect=TestPluginDiscovery.mock_c_notify_config)
-        plugins = PluginDiscovery.get_plugins_installed("notificationDelivery")
+        plugins = PluginDiscovery.get_plugins_installed("notify")
         # expected_plugin = TestPluginDiscovery.mock_c_plugins_config[3]
         # FIXME: ordering issue
         # assert expected_plugin == plugins
@@ -371,7 +371,7 @@ class TestPluginDiscovery:
         mock_get_c_plugin_config = mocker.patch.object(utils, "get_plugin_info",
                                                             side_effect=TestPluginDiscovery.mock_c_rule_config)
 
-        plugins = PluginDiscovery.get_plugins_installed("notificationRule")
+        plugins = PluginDiscovery.get_plugins_installed("rule")
         # expected_plugin = TestPluginDiscovery.mock_c_plugins_config[4]
         # FIXME: ordering issue
         # assert expected_plugin == plugins
@@ -467,8 +467,8 @@ class TestPluginDiscovery:
         (mock_c_plugins_config[0], "south"),
         (mock_c_plugins_config[1], "north"),
         (mock_c_plugins_config[2], "filter"),
-        (mock_c_plugins_config[3], "notificationDelivery"),
-        (mock_c_plugins_config[4], "notificationRule")
+        (mock_c_plugins_config[3], "notify"),
+        (mock_c_plugins_config[4], "rule")
     ])
     def test_fetch_c_plugins_installed(self, info, dir_name):
         with patch.object(utils, "find_c_plugin_libs", return_value=[(info['name'], "binary")]) as patch_plugin_lib:
@@ -481,8 +481,8 @@ class TestPluginDiscovery:
         (mock_c_plugins_config[0], "south"),
         (mock_c_plugins_config[1], "north"),
         (mock_c_plugins_config[2], "filter"),
-        (mock_c_plugins_config[3], "notificationDelivery"),
-        (mock_c_plugins_config[4], "notificationRule")
+        (mock_c_plugins_config[3], "notify"),
+        (mock_c_plugins_config[4], "rule")
     ])
     def test_deprecated_c_plugins_installed(self, info, dir_name):
         info['flag'] = api_utils.DEPRECATED_BIT_MASK_VALUE

--- a/tests/unit/python/fledge/common/test_plugin_discovery.py
+++ b/tests/unit/python/fledge/common/test_plugin_discovery.py
@@ -389,7 +389,7 @@ class TestPluginDiscovery:
         mock_get_plugin_config = mocker.patch.object(PluginDiscovery, "get_plugin_config",
                                                      side_effect=TestPluginDiscovery.mock_plugins_north_config)
 
-        plugins = PluginDiscovery.fetch_plugins_installed("north", False)
+        plugins = PluginDiscovery.fetch_plugins_installed("north", "north", False)
         # FIXME: below line is failing when in suite
         # assert TestPluginDiscovery.mock_plugins_north_config == plugins
         assert 1 == mock_get_folders.call_count
@@ -410,20 +410,42 @@ class TestPluginDiscovery:
             actual_plugin_folders.append(dir_name.split('/')[-1])
         assert TestPluginDiscovery.mock_north_folders == actual_plugin_folders
 
-    @pytest.mark.parametrize("info, expected, is_config", [
+    @pytest.mark.parametrize("info, expected, is_config, installed_dir_name", [
         ({'name': "furnace4", 'version': "1.1", 'type': "south", 'interface': "1.0",
           'config': {'plugin': {'description': "Modbus RTU plugin", 'type': 'string', 'default': 'modbus'}}},
          {'name': 'modbus', 'type': 'south', 'description': 'Modbus RTU plugin', 'version': '1.1',
-          'installedDirectory': 'south'}, False),
+          'installedDirectory': 'south/modbus', 'packageName': 'fledge-south-modbus'}, False, 'south'),
         ({'name': "furnace4", 'version': "1.1", 'type': "south", 'interface': "1.0",
           'config': {'plugin': {'description': "Modbus RTU plugin", 'type': 'string', 'default': 'modbus'}}},
          {'name': 'modbus', 'type': 'south', 'description': 'Modbus RTU plugin', 'version': '1.1',
-          'installedDirectory': 'south',
-          'config': {'plugin': {'description': 'Modbus RTU plugin', 'type': 'string', 'default': 'modbus'}}}, True)
+          'installedDirectory': 'south/modbus', 'packageName': 'fledge-south-modbus',
+          'config': {'plugin': {'description': 'Modbus RTU plugin', 'type': 'string', 'default': 'modbus'}}},
+         True, 'south'),
+        ({'name': "http_north", 'version': "1.1", 'type': "north", 'interface': "1.0",
+          'config': {'plugin': {'description': "HTTP north plugin", 'type': 'string', 'default': 'http_north'}}},
+         {'name': 'http_north', 'type': 'north', 'description': 'HTTP north plugin', 'version': '1.1',
+          'installedDirectory': 'north/http_north', 'packageName': 'fledge-north-http-north'},
+         False, 'north'),
+        ({'name': "rms", 'version': "1.1", 'type': "filter", 'interface': "1.0",
+          'config': {'plugin': {'description': "RMS Filter plugin", 'type': 'string', 'default': 'rms'}}},
+         {'name': 'rms', 'type': 'filter', 'description': 'RMS Filter plugin', 'version': '1.1',
+          'installedDirectory': 'filter/rms', 'packageName': 'fledge-filter-rms'},
+         False, 'filter'),
+        ({'name': "Average", 'version': "1.1", 'type': "notificationRule", 'interface': "1.0",
+          'config': {'plugin': {'description': "Average Rule plugin", 'type': 'string', 'default': 'Average'}}},
+         {'name': 'Average', 'type': 'rule', 'description': 'Average Rule plugin', 'version': '1.1',
+          'installedDirectory': 'notificationRule/Average', 'packageName': 'fledge-rule-average'},
+         False, 'notificationRule'),
+        ({'name': "asset", 'version': "1.1", 'type': "notificationDelivery", 'interface': "1.0",
+          'config': {'plugin': {'description': "Asset Delivery plugin", 'type': 'string', 'default': 'asset'}}},
+         {'name': 'asset', 'type': 'notify', 'description': 'Asset Delivery plugin', 'version': '1.1',
+          'installedDirectory': 'notificationDelivery/asset', 'packageName': 'fledge-notify-asset'},
+         False, 'notificationDelivery')
     ])
-    def test_get_plugin_config(self, info, expected, is_config):
+    def test_get_plugin_config(self, info, expected, is_config, installed_dir_name):
         with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[info]):
-            actual = PluginDiscovery.get_plugin_config("modbus", "south", is_config)
+            actual = PluginDiscovery.get_plugin_config(info['config']['plugin']['default'], expected['type'],
+                                                       installed_dir_name, is_config)
             assert expected == actual
 
     @pytest.mark.parametrize("info, warn_count", [
@@ -437,7 +459,7 @@ class TestPluginDiscovery:
     def test_deprecated_python_plugins(self, info, warn_count, is_config=True):
         with patch.object(_logger, "warning") as patch_log_warn:
             with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[info]):
-                PluginDiscovery.get_plugin_config(info['name'], info['type'], is_config)
+                PluginDiscovery.get_plugin_config(info['name'], info['type'], info['type'], is_config)
         assert warn_count == patch_log_warn.call_count
         if warn_count:
             args, kwargs = patch_log_warn.call_args
@@ -459,7 +481,7 @@ class TestPluginDiscovery:
         }
         with patch.object(_logger, "warning") as patch_log_warn:
             with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[mock_plugin_info]):
-                actual = PluginDiscovery.get_plugin_config("http-north", "south", False)
+                actual = PluginDiscovery.get_plugin_config("http-north", "south", "http_north", False)
                 assert actual is None
         patch_log_warn.assert_called_once_with('Plugin http-north is discarded due to invalid type')
 
@@ -497,7 +519,11 @@ class TestPluginDiscovery:
         assert '"{}" plugin is deprecated'.format(info['name']) == args[0]
 
     def test_fetch_c_hybrid_plugins_installed(self):
-        info = {"version": "1.6.0", "name": "FlirAX8", "config": {"asset": {"description": "Default asset name", "default": "flir", "displayName": "Asset Name", "type": "string"}, "plugin": {"description": "A Modbus connected Flir AX8 infrared camera", "default": "FlirAX8", "readonly": "true", "type": "string"}}}
+        info = {"version": "1.6.0", "name": "FlirAX8",
+                "config": {"asset": {"description": "Default asset name", "default": "flir",
+                                     "displayName": "Asset Name", "type": "string"},
+                           "plugin": {"description": "A Modbus connected Flir AX8 infrared camera",
+                                      "default": "FlirAX8", "readonly": "true", "type": "string"}}}
         with patch.object(utils, "find_c_plugin_libs", return_value=[("FlirAX8", "json")]) as patch_plugin_lib:
             with patch.object(common, "load_and_fetch_c_hybrid_plugin_info", return_value=info) as patch_hybrid_plugin_info:
                 PluginDiscovery.fetch_c_plugins_installed('south', True, 'south')
@@ -539,7 +565,7 @@ class TestPluginDiscovery:
     def test_bad_get_south_plugin_config(self, exc_name, log_exc_name, msg):
         with patch.object(_logger, log_exc_name) as patch_log_exc:
             with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[exc_name]):
-                PluginDiscovery.get_plugin_config("modbus", "south", False)
+                PluginDiscovery.get_plugin_config("modbus", "south", "south", False)
         assert 1 == patch_log_exc.call_count
         args, kwargs = patch_log_exc.call_args
         assert msg in args[0]
@@ -551,7 +577,7 @@ class TestPluginDiscovery:
     def test_bad_get_north_plugin_config(self, exc_name, log_exc_name, msg):
         with patch.object(_logger, log_exc_name) as patch_log_exc:
             with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[exc_name]):
-                PluginDiscovery.get_plugin_config("http", "north", False)
+                PluginDiscovery.get_plugin_config("http", "north", "north", False)
         assert 1 == patch_log_exc.call_count
         args, kwargs = patch_log_exc.call_args
         assert msg in args[0]

--- a/tests/unit/python/fledge/common/test_plugin_discovery.py
+++ b/tests/unit/python/fledge/common/test_plugin_discovery.py
@@ -413,10 +413,12 @@ class TestPluginDiscovery:
     @pytest.mark.parametrize("info, expected, is_config", [
         ({'name': "furnace4", 'version': "1.1", 'type': "south", 'interface': "1.0",
           'config': {'plugin': {'description': "Modbus RTU plugin", 'type': 'string', 'default': 'modbus'}}},
-         {'name': 'modbus', 'type': 'south', 'description': 'Modbus RTU plugin', 'version': '1.1'}, False),
+         {'name': 'modbus', 'type': 'south', 'description': 'Modbus RTU plugin', 'version': '1.1',
+          'installedDirectory': 'south'}, False),
         ({'name': "furnace4", 'version': "1.1", 'type': "south", 'interface': "1.0",
           'config': {'plugin': {'description': "Modbus RTU plugin", 'type': 'string', 'default': 'modbus'}}},
          {'name': 'modbus', 'type': 'south', 'description': 'Modbus RTU plugin', 'version': '1.1',
+          'installedDirectory': 'south',
           'config': {'plugin': {'description': 'Modbus RTU plugin', 'type': 'string', 'default': 'modbus'}}}, True)
     ])
     def test_get_plugin_config(self, info, expected, is_config):
@@ -471,7 +473,7 @@ class TestPluginDiscovery:
     def test_fetch_c_plugins_installed(self, info, dir_name):
         with patch.object(utils, "find_c_plugin_libs", return_value=[(info['name'], "binary")]) as patch_plugin_lib:
             with patch.object(utils, "get_plugin_info", return_value=info) as patch_plugin_info:
-                PluginDiscovery.fetch_c_plugins_installed(dir_name, True)
+                PluginDiscovery.fetch_c_plugins_installed(dir_name, True, dir_name)
             patch_plugin_info.assert_called_once_with(info['name'], dir=dir_name)
         patch_plugin_lib.assert_called_once_with(dir_name)
 
@@ -487,7 +489,7 @@ class TestPluginDiscovery:
         with patch.object(_logger, "warning") as patch_log_warn:
             with patch.object(utils, "find_c_plugin_libs", return_value=[(info['name'], "binary")]) as patch_plugin_lib:
                 with patch.object(utils, "get_plugin_info", return_value=info) as patch_plugin_info:
-                    PluginDiscovery.fetch_c_plugins_installed(dir_name, True)
+                    PluginDiscovery.fetch_c_plugins_installed(dir_name, True, dir_name)
                 patch_plugin_info.assert_called_once_with(info['name'], dir=dir_name)
             patch_plugin_lib.assert_called_once_with(dir_name)
         assert 1 == patch_log_warn.call_count
@@ -498,7 +500,7 @@ class TestPluginDiscovery:
         info = {"version": "1.6.0", "name": "FlirAX8", "config": {"asset": {"description": "Default asset name", "default": "flir", "displayName": "Asset Name", "type": "string"}, "plugin": {"description": "A Modbus connected Flir AX8 infrared camera", "default": "FlirAX8", "readonly": "true", "type": "string"}}}
         with patch.object(utils, "find_c_plugin_libs", return_value=[("FlirAX8", "json")]) as patch_plugin_lib:
             with patch.object(common, "load_and_fetch_c_hybrid_plugin_info", return_value=info) as patch_hybrid_plugin_info:
-                PluginDiscovery.fetch_c_plugins_installed('south', True)
+                PluginDiscovery.fetch_c_plugins_installed('south', True, 'south')
             patch_hybrid_plugin_info.assert_called_once_with(info['name'], True)
         patch_plugin_lib.assert_called_once_with('south')
 
@@ -511,7 +513,7 @@ class TestPluginDiscovery:
         with patch.object(_logger, "exception") as patch_log_exc:
             with patch.object(utils, "find_c_plugin_libs", return_value=[("Random", "binary")]) as patch_plugin_lib:
                 with patch.object(utils, "get_plugin_info",  return_value=info) as patch_plugin_info:
-                    PluginDiscovery.fetch_c_plugins_installed("south", False)
+                    PluginDiscovery.fetch_c_plugins_installed("south", False, 'south')
                 patch_plugin_info.assert_called_once_with('Random', dir='south')
             patch_plugin_lib.assert_called_once_with('south')
             assert exc_count == patch_log_exc.call_count
@@ -525,7 +527,7 @@ class TestPluginDiscovery:
         with patch.object(_logger, "exception") as patch_log_exc:
             with patch.object(utils, "find_c_plugin_libs", return_value=[("PI_Server", "binary")]) as patch_plugin_lib:
                 with patch.object(utils, "get_plugin_info", return_value=info) as patch_plugin_info:
-                    PluginDiscovery.fetch_c_plugins_installed("north", False)
+                    PluginDiscovery.fetch_c_plugins_installed("north", False, 'north')
                 patch_plugin_info.assert_called_once_with('PI_Server', dir='north')
             patch_plugin_lib.assert_called_once_with('north')
             assert exc_count == patch_log_exc.call_count

--- a/tests/unit/python/fledge/services/core/api/plugins/test_discovery.py
+++ b/tests/unit/python/fledge/services/core/api/plugins/test_discovery.py
@@ -32,11 +32,14 @@ class TestPluginDiscoveryApi:
         return loop.run_until_complete(test_client(app))
 
     @pytest.mark.parametrize("method, result, is_config", [
-        ("/fledge/plugins/installed", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin"}, False),
+        ("/fledge/plugins/installed", {"name": "sinusoid", "version": "1.0", "type": "south",
+                                       "description": "sinusoid plugin"}, False),
         ("/fledge/plugins/installed?config=true",
          {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin", "config": {
-             "plugin": {"description": "sinusoid plugin", "type": "string", "default": "sinusoid", "readonly": "true"}}}, True),
-        ("/fledge/plugins/installed?config=false", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin"}, False)
+             "plugin": {"description": "sinusoid plugin", "type": "string", "default": "sinusoid",
+                        "readonly": "true"}}}, True),
+        ("/fledge/plugins/installed?config=false", {"name": "sinusoid", "version": "1.0", "type": "south",
+                                                    "description": "sinusoid plugin"}, False)
     ])
     async def test_get_plugins_installed(self, client, method, result, is_config):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value=result) as patch_get_plugin_installed:
@@ -48,7 +51,8 @@ class TestPluginDiscoveryApi:
         patch_get_plugin_installed.assert_called_once_with(None, is_config)
 
     @pytest.mark.parametrize("param", [
-        "north", "south", "North", "South", "NORTH", "SOUTH", "filter", "Filter", "FILTER", "notify", "Notify", "rule", "RULE"
+        "north", "North", "NORTH", "nOrTH", "south", "South", "SOUTH", "filter", "Filter", "FILTER", "notify", "Notify",
+        "rule", "RULE", "RuLe"
     ])
     async def test_get_plugins_installed_by_params(self, client, param):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value={}) as patch_get_plugin_installed:
@@ -60,21 +64,39 @@ class TestPluginDiscoveryApi:
         patch_get_plugin_installed.assert_called_once_with(param.lower(), False)
 
     @pytest.mark.parametrize("param, _type, result, is_config", [
-        ("?type=north&config=false", "north", {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin"}, False),
-        ("?type=south&config=false", "south", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin"}, False),
-        ("?type=filter&config=false", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin"}, False),
-        ("?type=notify&config=false", "notify", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin"}, False),
-        ("?type=rule&config=false", "rule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin"}, False),
-        ("?type=north&config=true", "north", {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin",
-                                              "config": {"plugin": {"description": "HTTP North-C plugin", "type": "string", "default": "http-north"}}}, True),
-        ("?type=south&config=true", "south", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin",
-                                              "config": {"plugin": {"description": "sinusoid plugin", "type": "string", "default": "sinusoid", "readonly": "true"}}}, True),
-        ("?type=filter&config=true", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin",
-                                                "config": {"offset": {"default": "0.0", "type": "float", "description": "A constant offset"}, "factor": {"default": "100.0", "type": "float", "description": "Scale factor for a reading."}, "plugin": {"default": "scale", "type": "string", "description": "Scale filter plugin"}, "enable": {"default": "false", "type": "boolean", "description": "A switch that can be used to enable or disable."}}}, True),
-        ("?type=notify&config=true", "notify", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin",
-                                                                            "config": {"plugin": {"type": "string", "description": "Email notification plugin", "default": "email"}}}, True),
-        ("?type=rule&config=true", "rule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin",
-                                                                    "config": {"plugin": {"type": "string", "description": "The OverMaxRule notification rule plugin", "default": "OverMaxRule"}}}, True)
+        ("?type=north&config=false", "north",
+         {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin"}, False),
+        ("?type=south&config=false", "south",
+         {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin"}, False),
+        ("?type=filter&config=false", "filter",
+         {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin"}, False),
+        ("?type=notify&config=false", "notify",
+         {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin"}, False),
+        ("?type=rule&config=false", "rule",
+         {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule plugin"}, False),
+        ("?type=north&config=true", "north",
+         {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin",
+          "config": {"plugin": {"description": "HTTP North-C plugin", "type": "string", "default": "http-north"}}},
+         True),
+        ("?type=south&config=true", "south",
+         {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin",
+          "config": {"plugin": {"description": "sinusoid plugin", "type": "string", "default": "sinusoid",
+                                "readonly": "true"}}}, True),
+        ("?type=filter&config=true", "filter",
+         {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin",
+          "config": {"offset": {"default": "0.0", "type": "float", "description": "A constant offset"},
+                     "factor": {"default": "100.0", "type": "float", "description": "Scale factor for a reading."},
+                     "plugin": {"default": "scale", "type": "string", "description": "Scale filter plugin"},
+                     "enable": {"default": "false", "type": "boolean",
+                                "description": "A switch that can be used to enable or disable."}}}, True),
+        ("?type=notify&config=true", "notify",
+         {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin",
+          "config": {"plugin": {"type": "string", "description": "Email notification plugin", "default": "email"}}},
+         True),
+        ("?type=rule&config=true", "rule",
+         {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule plugin",
+          "config": {"plugin": {"type": "string", "description": "The OverMaxRule notification rule plugin",
+                                "default": "OverMaxRule"}}}, True)
     ])
     async def test_get_plugins_installed_by_type_and_config(self, client, param, _type, result, is_config):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value=result) as patch_get_plugin_installed:

--- a/tests/unit/python/fledge/services/core/api/plugins/test_discovery.py
+++ b/tests/unit/python/fledge/services/core/api/plugins/test_discovery.py
@@ -47,43 +47,33 @@ class TestPluginDiscoveryApi:
             assert {'plugins': result} == json_response
         patch_get_plugin_installed.assert_called_once_with(None, is_config)
 
-    @pytest.mark.parametrize("param, _type", [
-        ("north", "north"),
-        ("south", "south"),
-        ("North", "north"),
-        ("South", "south"),
-        ("NORTH", "north"),
-        ("SOUTH", "south"),
-        ("filter", "filter"),
-        ("Filter", "filter"),
-        ("FILTER", "filter"),
-        ("notificationDelivery", "notificationDelivery"),
-        ("notificationRule", "notificationRule")
+    @pytest.mark.parametrize("param", [
+        "north", "south", "North", "South", "NORTH", "SOUTH", "filter", "Filter", "FILTER", "notify", "Notify", "rule", "RULE"
     ])
-    async def test_get_plugins_installed_by_params(self, client, param, _type):
+    async def test_get_plugins_installed_by_params(self, client, param):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value={}) as patch_get_plugin_installed:
             resp = await client.get('/fledge/plugins/installed?type={}'.format(param))
             assert 200 == resp.status
             r = await resp.text()
             json_response = json.loads(r)
             assert {'plugins': {}} == json_response
-        patch_get_plugin_installed.assert_called_once_with(_type, False)
+        patch_get_plugin_installed.assert_called_once_with(param.lower(), False)
 
     @pytest.mark.parametrize("param, _type, result, is_config", [
         ("?type=north&config=false", "north", {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin"}, False),
         ("?type=south&config=false", "south", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin"}, False),
         ("?type=filter&config=false", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin"}, False),
-        ("?type=notificationDelivery&config=false", "notificationDelivery", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin"}, False),
-        ("?type=notificationRule&config=false", "notificationRule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin"}, False),
+        ("?type=notify&config=false", "notify", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin"}, False),
+        ("?type=rule&config=false", "rule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin"}, False),
         ("?type=north&config=true", "north", {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin",
                                               "config": {"plugin": {"description": "HTTP North-C plugin", "type": "string", "default": "http-north"}}}, True),
         ("?type=south&config=true", "south", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin",
                                               "config": {"plugin": {"description": "sinusoid plugin", "type": "string", "default": "sinusoid", "readonly": "true"}}}, True),
         ("?type=filter&config=true", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin",
                                                 "config": {"offset": {"default": "0.0", "type": "float", "description": "A constant offset"}, "factor": {"default": "100.0", "type": "float", "description": "Scale factor for a reading."}, "plugin": {"default": "scale", "type": "string", "description": "Scale filter plugin"}, "enable": {"default": "false", "type": "boolean", "description": "A switch that can be used to enable or disable."}}}, True),
-        ("?type=notificationDelivery&config=true", "notificationDelivery", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin",
+        ("?type=notify&config=true", "notify", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin",
                                                                             "config": {"plugin": {"type": "string", "description": "Email notification plugin", "default": "email"}}}, True),
-        ("?type=notificationRule&config=true", "notificationRule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin",
+        ("?type=rule&config=true", "rule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin",
                                                                     "config": {"plugin": {"type": "string", "description": "The OverMaxRule notification rule plugin", "default": "OverMaxRule"}}}, True)
     ])
     async def test_get_plugins_installed_by_type_and_config(self, client, param, _type, result, is_config):
@@ -96,9 +86,9 @@ class TestPluginDiscoveryApi:
         patch_get_plugin_installed.assert_called_once_with(_type, is_config)
 
     @pytest.mark.parametrize("param, message", [
-        ("?type=blah", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notificationDelivery' or 'notificationRule'."),
-        ("?type=notify", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notificationDelivery' or 'notificationRule'."),
-        ("?type=rule", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notificationDelivery' or 'notificationRule'."),
+        ("?type=blah", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule'."),
+        ("?type=notifyDelivery", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule'."),
+        ("?type=notifyRule", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule'."),
         ("?config=blah", 'Only "true", "false", true, false are allowed for value of config.'),
         ("?config=False", 'Only "true", "false", true, false are allowed for value of config.'),
         ("?config=True", 'Only "true", "false", true, false are allowed for value of config.'),

--- a/tests/unit/python/fledge/services/core/api/plugins/test_install.py
+++ b/tests/unit/python/fledge/services/core/api/plugins/test_install.py
@@ -54,7 +54,7 @@ class TestPluginInstall:
         ({"url": "http://blah.co.in", "format": "tar", "checksum": "4015c2dea1cc71dbf70a23f6a203eeb6"},
          "Plugin type param is required"),
         ({"url": "http://blah.co.in", "format": "tar", "type": "blah", "checksum": "4015c2dea1cc71dbf70a23f6a203eeb6"},
-         "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notificationDelivery' or 'notificationRule'"),
+         "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule'"),
         ({"url": "http://blah.co.in", "format": "blah", "type": "filter", "checksum": "4015c2dea1cc71dbf70a23f6a203ee"},
          "Invalid format. Must be 'tar' or 'deb' or 'rpm' or 'repository'"),
         ({"url": "http://blah.co.in", "format": "tar", "type": "south", "checksum": "4015c2dea1cc71dbf70a23f6a203eeb6",


### PR DESCRIPTION
**Fixed items**
- [x] Changed type from notificationDelivery to *notify* & notificationRule to **rule**
- [x] installedDirectory KV pair added to response
- [x] DELETE updated
- [x] UPDATE updated
- [x] POST updated only in case file_format=tar
- [x] unit & system tests updated

**Regression check**
- south, north, filter, notification plugins (delivery & rule), hybrid plugin 
- GET
- POST - when file_format=tar (Skip this test as we never used this)
- DELETE
- PUT

**O/P Results**

**Get - Plugins installed**

```
// http://localhost:8081/fledge/plugins/installed

{
  "plugins": [
    {
      "name": "pi_server",
      "type": "north",
      "description": "PI Server North Plugin",
      "version": "1.0.0",
      "installedDirectory": "north/pi_server",
      "packageName": "fledge-north-pi-server"
    },
    {
      "name": "http_north",
      "type": "north",
      "description": "HTTP North Plugin",
      "version": "1.8.1",
       "installedDirectory": "north/http_north",
      "packageName": "fledge-north-http-north"
    },
    {
      "name": "ocs",
      "type": "north",
      "description": "OCS (OSIsoft Cloud Services) North Plugin",
      "version": "1.0.0",
      "installedDirectory": "north/ocs",
      "packageName": "fledge-north-ocs"
    },
    {
      "name": "httpc",
      "type": "north",
      "description": "HTTP North C Plugin",
      "version": "1.8.1",
      "installedDirectory": "north/httpc",
      "packageName": "fledge-north-httpc"
    },
    {
      "name": "OMF",
      "type": "north",
      "description": "PI Server North C Plugin",
      "version": "1.0.0",
      "installedDirectory": "north/OMF",
      "packageName": "fledge-north-omf"
    },
    {
      "name": "ThingSpeak",
      "type": "north",
      "description": "ThingSpeak North",
      "version": "1.8.1",
      "installedDirectory": "north/ThingSpeak",
      "packageName": "fledge-north-thingspeak"
    },
    {
      "name": "sinusoid",
      "type": "south",
      "description": "Sinusoid Poll Plugin which implements sine wave with data points",
      "version": "1.8.1",
      "installedDirectory": "south/sinusoid",
      "packageName": "fledge-south-sinusoid"
    },
    {
      "name": "FlirAX8",
      "type": "south",
      "description": "A Modbus connected Flir AX8 thermal imaging camera",
      "version": "1.8.1",
      "installedDirectory": "south/FlirAX8",
      "packageName": "fledge-south-flirax8"
    },
    {
      "name": "ModbusC",
      "type": "south",
      "description": "Modbus TCP and RTU C south plugin",
      "version": "1.8.1",
      "installedDirectory": "south/ModbusC",
      "packageName": "fledge-south-modbusc"
    },
    {
      "name": "Benchmark",
      "type": "south",
      "description": "Simulated data generation for benchmark tests",
      "version": "1.8.1",
      "installedDirectory": "south/Benchmark",
      "packageName": "fledge-south-benchmark"
    },
    {
      "name": "omfhint",
      "type": "filter",
      "description": "OMF Hint filter plugin, add OMF hints to one or more assets",
      "version": "1.8.1",
      "installedDirectory": "filter/omfhint",
      "packageName": "fledge-filter-omfhint"
    },
    {
      "name": "rms",
      "type": "filter",
      "description": "Calculate RMS & Peak values over a set of samples",
      "version": "1.8.1",
      "installedDirectory": "filter/rms",
      "packageName": "fledge-filter-rms"
    },
    {
      "name": "asset",
      "type": "notify",
      "description": "Asset notification plugin",
      "version": "1.8.1",
      "installedDirectory": "notificationDelivery/asset",
      "packageName": "fledge-notify-asset"
    },
    {
      "name": "slack",
      "type": "notify",
      "description": "Slack notification plugin",
      "version": "1.8.1",
      "installedDirectory": "notificationDelivery/slack",
      "packageName": "fledge-notify-slack"
    },
    {
      "name": "engine_failure",
      "type": "notificationRule",
      "description": "Notification rule plugin which detects imminent engine failure",
      "version": "1.8.1",
      "installedDirectory": "notificationRule/engine_failure",
      "packageName": "fledge-rule-engine-failure"
    },
    {
      "name": "Average",
      "type": "rule",
      "description": "Trigger if the current value deviates from the moving average by more than a defined percentage",
      "version": "1.8.1",
      "installedDirectory": "notificationRule/Average",
      "packageName": "fledge-rule-average"
    },
    {
      "name": "OutOfBound",
      "type": "rule",
      "description": "Generate a notifiction if the values of one or all the configured assets exceeds a configured value",
      "version": "1.8.1",
      "installedDirectory": "notificationRule/OutOfBound",
      "packageName": "fledge-rule-outofbound"
    }
  ]
}
```
**Get Plugins installed by type**
```
// 20200825220408
// http://localhost:8081/fledge/plugins/installed?type=rule

{
  "plugins": [
    {
      "name": "Average",
      "type": "rule",
      "description": "Trigger if the current value deviates from the moving average by more than a defined percentage",
      "version": "1.8.1",
      "installedDirectory": "notificationRule/Average",
      "packageName": "fledge-rule-average"
    },
    {
      "name": "OutOfBound",
      "type": "rule",
      "description": "Generate a notifiction if the values of one or all the configured assets exceeds a configured value",
      "version": "1.8.1",
      "installedDirectory": "notificationRule/OutOfBound",
      "packageName": "fledge-rule-outofbound"
    }
  ]
}
```
```
// 20200825220444
// http://localhost:8081/fledge/plugins/installed?type=notify&config=true

{
  "plugins": [
    {
      "name": "asset",
      "type": "notify",
      "description": "Asset notification plugin",
      "version": "1.8.1",
      "installedDirectory": "notificationDelivery/asset",
      "packageName": "fledge-notify-asset",
      "config": {
        "plugin": {
          "description": "Asset notification plugin",
          "type": "string",
          "default": "asset",
          "readonly": "true"
        },
        "asset": {
          "description": "The asset name to create for the notification",
          "type": "string",
          "default": "event",
          "order": "1",
          "displayName": "Asset"
        },
        "description": {
          "description": "The event description to add",
          "type": "string",
          "default": "Notification alert",
          "order": "2",
          "displayName": "Description"
        },
        "enable": {
          "description": "A switch that can be used to enable or disable delivery of the asset notification plugin.",
          "type": "boolean",
          "displayName": "Enabled",
          "default": "false",
          "order": "3"
        }
      }
    },
    {
      "name": "slack",
      "type": "notify",
      "description": "Slack notification plugin",
      "version": "1.8.1",
      "installedDirectory": "notificationDelivery/slack",
       "packageName": "fledge-notify-slack",
      "config": {
        "plugin": {
          "description": "Slack notification plugin",
          "type": "string",
          "default": "slack",
          "readonly": "true"
        },
        "enable": {
          "description": "A switch that can be used to enable or disable execution of the Slack notification plugin.",
          "type": "boolean",
          "displayName": "Enabled",
          "default": "false"
        },
        "webhook": {
          "description": "Slack WebHook URL",
          "type": "string",
          "default": "https://hooks.slack.com/services/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",
          "order": "1",
          "displayName": "Slack Webhook URL"
        },
        "text": {
          "description": "Static message text",
          "type": "string",
          "default": "",
          "order": "2",
          "displayName": "Message Text"
        }
      }
    }
  ]
}
```

**DELETE**

```
$ curl -X DELETE http://localhost:8081/fledge/plugins/rule/OutOfBound | jq
{
  "message": "OutOfBound plugin removed successfully"
}

$ curl -sX DELETE http://localhost:8081/fledge/plugins/notify/slack | jq
{
  "message": "slack plugin removed successfully"
}

$ curl -sX DELETE http://localhost:8081/fledge/plugins/north/ThingSpeak | jq
{
  "message": "ThingSpeak plugin removed successfully"
}
$ curl -sX DELETE http://localhost:8081/fledge/plugins/filter/metadata | jq
{
  "message": "metadata plugin removed successfully"
}
```

**UPDATE**
```
 $ curl -sX PUT http://localhost:8081/fledge/plugins/notify/asset/update | jq
{"message": "asset plugin update in process. Wait for few minutes to complete."}

$ curl -sX PUT http://localhost:8081/fledge/plugins/south/sinusoid/update
{"message": "sinusoid plugin update in process. Wait for few minutes to complete."}
```
Check Syslogs and data/logs for UPDATE as this is asynchronous in nature