### PR TITLE
FOGL-4444 Out of index range fixes in south API when schedule entry is missing for matching South child category

### DIFF
--- a/python/fledge/services/core/api/south.py
+++ b/python/fledge/services/core/api/south.py
@@ -91,7 +91,12 @@ async def _services_with_assets(storage_client, south_services):
                     if p["name"] == plugin:
                         plugin_version = p["version"]
                         break
-
+                # Handle schedule status when there is no schedule entry matching a South child category name
+                sch_status = 'unknown'
+                try:
+                    sch_status = await _get_schedule_status(storage_client, s_name)
+                except:
+                    pass
                 sr_list.append(
                     {
                         'name': s_name,
@@ -102,7 +107,7 @@ async def _services_with_assets(storage_client, south_services):
                         'status': '',
                         'assets': assets,
                         'plugin': {'name': plugin, 'version': plugin_version},
-                        'schedule_enabled': await _get_schedule_status(storage_client, s_name)
+                        'schedule_enabled': sch_status
                     })
     except:
         raise


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

```
// http://localhost:8081/foglamp/south?cached=false

{
  "services": [
    {
      "name": "sinusoid",
      "address": "",
      "management_port": "",
      "service_port": "",
      "protocol": "",
      "status": "",
      "assets": [
        
      ],
      "plugin": {
        "name": "",
        "version": ""
      },
      "schedule_enabled": "unknown"
    }
  ]
}
```