### PR TITLE
Fogl 4524

### DIFF
--- a/docs/plugin_developers_guide/01_Fledge_plugins.rst
+++ b/docs/plugin_developers_guide/01_Fledge_plugins.rst
@@ -41,11 +41,117 @@ Plugins
 In this version of Fledge you have six types of plugins:
 
 - **South Plugins** - They are responsible for communication between Fledge and the sensors and actuators they support. Each instance of a Fledge South microservice will use a plugin for the actual communication to the sensors or actuators that that instance of the South microservice supports.
-- **North Plugins** - They are responsible for taking reading data passed to them from the South bound service and doing any necessary conversion to the data and providing the protocol to send that converted data to a north-side task.
 - **Storage Plugins** - They sit between the Storage microservice and the physical data storage mechanism that stores the Fledge configuration and readings data. Storage plugins differ from other plugins in that they are written exclusively in C/C++, however they share the same common attributes and entry points that the other filter must support.
-- **Filter Plugins** - Filter plugins are used to modify data as it flows through Fledge. Filter plugins may be combined into a set of ordered filters that are applied as a pipeline to either the south ingress service or the north egress task that sends data to external systems.
-- **Notification Rule Plugins** - These are used by the optional notification service in order to evaluate data that flows into the notification service to determine if a notification should be sent.
-- **Notification Delivery Plugins** - These plugins are used by the optional notification service to deliver a notification to a system when a notification rule has triggered. These plugins allow the mechanisms to deliver notifications to be extended.
+- **Filter Plugins** - Filter plugins are used to modify data as it flows through Fledge. One or more filter plugins may compose a pipeline which modifies, either, data flowing out from the South ingress tasks into the Fledge Storage system, or out from Fledge storage into the North egress tasks.
+- **Notification Rule Plugins** - Notification plugins evaluate data after it has been entered into the Fledge Storage, before it enters the northbound Filter pipeline(s). If the notification evaluates to True, a rule associated with the condition is executed. (Notification rules require installation of the optional notification service.)
+- **Notification Delivery Plugins** - These plugins deliver a notification event; events, trigger "reason", and accompanying "message" are specified, and delivered to a given delivery channel (eg., email/sms/...). (Notification rules require installation of the optional notification service.)
+- **North Plugins** - These plugins take data, originated by South service(s), optionally transformed by filters, optionally triggering notifications, and export those data to the outside world.
+
+Fledge message contents
+=======================
+Information flows through fledge in "messages". Messages have a few "tags" which have well defined values. Messages may be extended to contain additional tags appropriate to particular plugins and data flows.
+
+Most messages include:
++------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| Tag        | Type            | Description                                                                                           |
++============+=================+============+==========================================================================================+
+| asset      | string          | Name under which this stream of data are placeed in Storage                                           |
++------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| ts         | string          | Timestamp when this asset was generated                                                               |
++------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| id         | string          | unique ID                                                                                             |
++------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| readings   | single dict |br|| {"user_ts": timestamp, <name>: <data-value>}  |br|                                                    |
+|            |  -or-    |br|   |                                               |br|                                                    |
+|            | json            | "data": "[{"user_ts": <timestamp1>; <name>: <data-value1>}, {"user_ts": <timestamp2>, <name>...]"     |
++------------+-----------------+-------------------------------------------------------------------------------------------------------+
+
+Fledge plugin configuration
+=======================
+Different plugin types (eg., north/south/...) have required configuration entries
+
+Required configuration entries include:
++------------------------+--------------------------+----------------------------------------------------------------------------------------------+
+| Entry                  | Required by              | Description                                                                                  |
++========================+==========================+==============================================================================================+
+| plugin                 | all                      | description: "<Describe plugin>" |br|                                                        |
+|                        |                          | type: "string" |br|                                                                          |
+|                        |                          | name: "<plugin name>" |br|                                                                   |
+|                        |                          | readonly: "true"      |br|                                                                   |
++------------------------+--------------------------+----------------------------------------------------------------------------------------------+
+| enable                 | filter                   | description: "<Describe plugin being enabled>" |br|                                          |
+|                        | |br| notification        | type: "boolean"                                |br|                                          |
+|                        | |br|notification delivery| default: "false"                               |br|                                          |
+|                        |                          | displayName: "<name for UI display>"           |br|                                          |
+|                        |                          | order: "<order of display in UI>"                                                            |
++------------------------+--------------------------+----------------------------------------------------------------------------------------------+
+| asset                  | south                    | description: "<name of asset being monitored>" |br|                                          |
+|                        | |br| notification        | type: "string"                                 |br|                                          |
+|                        |                          | default: ""                                    |br|                                          |
+|                        |                          | displayName: "<name for UI display>"           |br|                                          |
+|                        |                          | mandatory: "true"                              |br|                                          |
+|                        |                          | order: "<order of display in UI>"                                                            |
++------------------------+--------------------------+----------------------------------------------------------------------------------------------+
+| source                 | north                    | description: "<Describe resource being forwarded>" |br|                                      |
+|                        |                          | type: "enumeration"                                |br|                                      |
+|                        |                          | options: ["readings", "statistics"]                |br|                                      |
+|                        |                          | default: "readings"                                |br|                                      |
+|                        |                          | displayName: "<name for UI display>"               |br|                                      |
+|                        |                          | order: "<order of display in UI>"                                                            |
++------------------------+--------------------------+----------------------------------------------------------------------------------------------+
+| applyFilter            | north                    | description: "<Describe plugin being enabled>"     |br|                                      |
+|                        |                          | type: "boolean"                                    |br|                                      |
+|                        |                          | default: "false"                                   |br|                                      |
+|                        |                          | displayName: "<name for UI display>"               |br|                                      |
+|                        |                          | order: "<order of display in UI>"                                                            |
++------------------------+--------------------------+----------------------------------------------------------------------------------------------+
+| filterRule             | north                    | description: "<describe JQ north filter rule>"     |br|                                      |
+|                        |                          | type: "string"                                     |br|                                      |
+|                        |                          | default: "[]"                                      |br|                                      |
+|                        |                          | displayName: "<name for UI display>"               |br|                                      |
+|                        |                          | order: "<order of display in UI>"                                                            |
++------------------------+--------------------------+----------------------------------------------------------------------------------------------+
+
+Fledge plugin methods
+=======================
+Different plugin types (eg., north/south/...) have common and distinct APIs they must export.
+
+Required APIs include:
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| Entry                  | Required by     | Description                                                                                           |
++========================+=================+============+==========================================================================================+
+| plugin_info            | all             | Returns the info needed to load the plugin (interface spec, type, etc.)                               |
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| plugin_init            | all             | Takes the config values; one time initialization; returns opaque handle for this instance             |
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| plugin_shutdown        | all             | Destroys plugin and related state                                                                     |
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| plugin_reconfigure     | all             | Replaces existing configuration with new values; may need to call shutdown/init                       |
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| plugin_ingest          | filter          | Provides data which is modified, then sent on to ingest callback                                      |
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| plugin_eval            | notification    | Takes JSON asset document to eval; Returns True if should "notify"                                    |
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| plugin_triggers        | notification    | Returns JSON asset document describing what notification triggers have fired                          |
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| plugin_reason          | notification    | Takes JSON asset document describing why notifications have fired                                     |
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| plugin_deliver         | notification    | Takes name/notification/trigger/message strings to be sent to notification target                     |
+|                        | |br| delivery   |                                                                                                       |
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| plugin_send            | north           | Provides data,input_ref to be sent to North plugin target                                             |
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| plugin_start           | south           | Initiates async "pumping" of data (typically threaded)                                                |
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+| plugin_register_ingest | south           | Registers callback and ingest "ref" which receive new data as available                               |
++------------------------+-----------------+-------------------------------------------------------------------------------------------------------+
+
+
+
+
+Existing plugins and plugin extensions
+======================================
+Fledge comes pre-loaded with a number of plugins. Additional plugins may be loaded from the standard Fledge collection, from third pary collections, or from code developed by users.
 
 
 Plugins in this version of Fledge

--- a/python/fledge/common/iprpc.py
+++ b/python/fledge/common/iprpc.py
@@ -1,0 +1,370 @@
+# -*- coding: utf-8 -*-
+
+# FLEDGE_BEGIN
+# See: http://fledge.readthedocs.io/
+# FLEDGE_END
+
+""" interprocess rpc """
+
+
+__author__ = "Douglas Orr"
+__copyright__ = "Copyright (c) 2020 Dianomic Systems"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+import os
+import sys
+import io
+import subprocess
+import threading
+
+import time
+
+import traceback
+
+import json
+import pickle
+import re
+import tempfile
+
+import time
+import logging
+
+import fcntl
+from utils import eprint
+
+import mmap
+
+try:
+    from fledge.common import logger
+
+except:
+    # if invoked outside of fledge, fake up a logger environment
+    class Logger():
+        def __init__(self):
+            self.CONSOLE = 0
+            self.SYSLOG = 1
+            self.default_destination = self.CONSOLE
+            
+        def setup(self, name, level):
+            logger = logging.getLogger(name)
+            logger.setLevel(level)
+            return logger
+    logger = Logger()
+
+def is_server_process():
+    # temp backward compatibility: if we have a default
+    # destination of SYSLOG, we are a server process
+    return not hasattr(logger, 'default_destination') or \
+        (logger.default_destination == logger.SYSLOG)
+
+
+_LOGGER = logger.setup(__name__, level=logging.INFO)  # yyy
+
+
+# IPC overview:
+#   The basic structure we have is a client which spawns a server in another process, then
+# do simple ipc to send procedure calls from client to server, then results back to client
+#
+# InterProcessRPC is spawned with a pipe to the client. Writes and reads on the pipe are used to
+# synchronize work that is done in the server. Servers are required to be single threaded.
+#
+# The basic mechanism is to send a newline-terminated "length" to the server which signals
+# new method/arguments are available. (In a pure-pipe implementation, the length precedes
+# a "length"-sized encoded dict. In mapped file implementation, the "length" is merely
+# used for signaling.)
+#
+# Arguments are sent in an encoded dict: {'method': <method-name>, 'args': <list of arguments>}
+#
+# In the mapped file implementation, there is a tmpfile of ARGFILE_SIZE mapped into client and
+# server where the arguments are written using pickle. Results are written back the same way.
+#
+# For the process receiving the results, the length indicates a couple of special things:
+# >0 -> standard dict
+# =0 -> None
+# <0 -> exception, which is re-constituted and re-raised, so the client receives it
+#
+# Argfile is a temp file (mkstemp) which is created by the client. The name is sent
+# to the server as the first pipe message; it is opened and unlinked once opened so
+# that it will disappear on close.
+#
+# The InterProcessRPCClient class will invoke a subprocess to create the server. Special
+# care is taken to read stderr if the client is a server, so that error messages written to
+# stderr (usually before the server starts) aren't lost.
+#
+# The IPCModuleClient derives from InterProcessRPCClient and  specifically
+# invokes a named python module as a server.
+
+ARGFILE_SIZE=1024*1024*20
+
+class InterProcessRPC():
+    def __init__(self,
+                 infd=io.BufferedReader(io.FileIO(os.dup(sys.stdin.fileno()))),
+                 outfd=io.BufferedWriter(io.FileIO(os.dup(sys.stdout.fileno()), mode='w')),
+                 errfd=sys.stderr,
+                 name="",
+                 argfile_fd=None):
+        self.infd = infd    # for direct i/o between client/server
+        self.outfd = outfd
+
+        self.errfd = errfd
+        self.name = name
+
+
+        if argfile_fd == None:
+            # server
+            
+            # close 0/1/2 in case client is trying to do i/o on them. use stderr for output
+            os.close(0)
+            os.close(1)
+            os.dup2(2, 1)
+            
+            # special protocol for server process: first line read is the name of our mapped arg file
+            _argfile_name = self.infd.readline()[:-1].decode('utf-8')
+            eprint("SERVER: argfile name={}".format(_argfile_name))
+            self.argfile_fd = os.open(_argfile_name, os.O_RDWR)
+            os.unlink(_argfile_name)  # delete on close
+        else:
+            # client process opens the file then passes it up to superclass
+            eprint("CLIENT: argfile fd={}".format(argfile_fd))
+            self.argfile_fd = argfile_fd
+            
+        self.mfile = mmap.mmap(self.argfile_fd, ARGFILE_SIZE)  # assume input > output
+        
+    def call(self, rpcobj):
+        """ call - local instance of rpc call """
+        if not ('method' in rpcobj and 'args' in rpcobj):
+            _LOGGER.error("invalid rpc object missing fields {}".format(str(rpcobj.keys())))
+            raise ValueError
+
+        _method = getattr(self, rpcobj['method'])
+        _args = rpcobj['args']
+        # eprint("about to call {} with {}".format(rpcobj['method'], _args))
+        
+        return _method(*_args)
+    
+    
+    def rpc_read(self):
+        """ rpc_read - read len/buf from the remote host
+        protocol:
+        each call is preceded by an ascii - <len>\n
+          len == '' : EOF from remote side
+          len > 0   : len sized buffer with json method + args follows
+          len == 0  : None
+          len < 0   : len sized buffer with named exception plus arg follows
+        Returns:
+            json dict if method or exception
+            None if len == 0
+        Raises:
+            EOFError if pipe closes
+        """
+
+        # protocol: pipe produces a length of next object
+        _len = self.infd.readline()  # assume small enough to not deadlock
+        self.mfile.seek(0)
+        
+        if _len == b'':
+            # closed fd on one side or the other of the pipe
+            raise EOFError
+        
+        
+        # _len = int(_len.decode('ascii'))
+        _len = int(_len)
+        if _len > 0:
+            # len > 0 -> json object
+
+            # eprint("read >0")
+            obj = pickle.loads(self.mfile)
+            return obj
+
+        elif _len < 0:
+            # _len < 0 -> Exception
+            _ex = pickle.loads(self.mfile)
+
+            # reconstitute the exception, pass server exception through locally
+            _ex_class, _ex_msg = _ex['class'], _ex['message']
+            _builtins = globals()['__builtins__']
+            if _ex_class in _builtins:
+                raise _builtins[_ex_class](_ex_msg)
+
+            # raise unknown exception
+            _LOGGER.warning("unknown local exception {}".format(_ex_class))
+            raise Exception("{}: {}".format(_ex_class, _ex_msg))
+
+        # else _len == 0:
+        # len == 0 -> None
+        # eprint("read: none")
+        return None
+
+
+    def rpc_write(self, obj, is_exception=False):
+        """ rpc_write -- write an rpc return value to the receiver 
+        protocol:
+        each call is preceded by an ascii - <len>\n
+          len > 0   : len sized buffer with json method + args follows
+          len == 0  : None
+          len < 0   : len sized buffer with named exception plus arg follows
+        Returns:
+        Raises:
+        """
+
+        _lenmult = 1
+        if is_exception:
+            # replace exception object with something that can be turned into JSON
+            _class = obj.__class__.__name__
+            obj = { 'class': str(_class), 'message': str(obj) }
+            _lenmult = -1
+
+        if obj != None:
+
+            # put the dict into shared memory
+            self.mfile.seek(0)
+            pickle.dump(obj, self.mfile)
+
+            # write a leading "len", positive (object) or negative (exception)
+            # and signal to the server there's something to do
+            _lenstr = str(_lenmult * 1)+'\n'
+            self.outfd.write(_lenstr.encode('utf-8', 'ignore'))
+        else:
+            # no payload for None return
+            # eprint("rpc write none")
+            _lenstr = '0\n'
+            self.outfd.write(_lenstr.encode('utf-8', 'ignore'))
+            
+        self.outfd.flush()
+
+    
+
+    def rpc_exception(self, ex):
+        """ exception -- write an exception object to client to represent internal error """
+
+        # exception sent so that it will be raised in client
+        self.rpc_write(ex, is_exception=True)
+
+        
+    def serve(self):
+        """ receive "methods" to invoke on infd, return results on outfd
+
+        each method is represented using (string) len followed by "len" worth of JSON packet
+        JSON input packet is {method: methodname, args: args}
+
+        return values and exceptions are written back on outfd in the same format; 
+
+        . None returns have a zero length and are not JSON
+        . Exceptions are JSON objects with exception type and message, and have a negative length
+        . A length which is null string indicates closed channel
+        """
+
+
+        while True:
+
+            _obj = self.rpc_read()
+            
+            # eprint("RECEIVE: {}".format(str(_obj)[:200]))
+            try:
+
+                _ret = self.call(_obj)  # local "call" - returns json-able value; may raise
+
+            except Exception as ex:
+                _LOGGER.error("exception in rpc backend: {}".format(traceback.format_exc()))
+
+                # return the exception
+                self.rpc_exception(ex)
+                
+            else:
+                # return the result of the call
+                self.rpc_write(_ret)
+
+
+        os._exit(0)
+
+class InterProcessRPCClient(InterProcessRPC):
+    """
+    InterProcessRPCClient: companion to InterProcessRPC, client code that calls into a server in a separate process
+    """
+
+    def __init__(self, server_args, env=None):
+
+        # trap and send stderr to syslog if we are in a server process
+        _is_server = is_server_process()
+        _stderr = subprocess.PIPE if _is_server else None
+
+        # set up a big shared memory file for argument transfer
+        (_argfile_fd, _argfile_path) = tempfile.mkstemp()
+        os.pwrite(_argfile_fd, b' ', ARGFILE_SIZE-1)
+        eprint("client, created file {} {}".format(_argfile_fd, _argfile_path))
+
+        p = subprocess.Popen(server_args,
+                             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                             stderr=_stderr,
+                             env=env)
+        super().__init__(infd=p.stdout, outfd=p.stdin, errfd=p.stderr, argfile_fd=_argfile_fd)
+        
+        if _is_server:
+            def log_errors(fd):
+                """ log_errors - vacuum up error output that would otherwise be lost """
+                while True:
+                    err_str = fd.read().decode('utf-8')  # blocking read for error output
+                    if err_str == '':
+                        break
+                    _LOGGER.error("python module error: {}".format(err_str))
+                return
+
+            # pull off and log errors that would disappear on stderr
+            self.log_err_thread = threading.Thread(target=log_errors, args=(self.errfd,))
+            self.log_err_thread.start()
+        
+        # check for module immediate exit -- shouldn't happen
+        for _ in range(2):
+            # Wait until process terminates (without using p.wait())
+            if p.poll() is not None:
+                _LOGGER.error("{} module load exited with return code {}".format(name, p.returncode))
+                raise RuntimeError(p.returncode)
+            # Process hasn't exited yet, let's wait some
+            time.sleep(0.5)
+
+
+        # special prtocol, now tell the server the name of the mapped arg file
+        self.outfd.write('{}\n'.format(_argfile_path).encode('utf-8'))
+
+        
+    def call(self, rpcobj):
+        """ call - rpc client writes rpc request, reads and returns the result 
+        Args:
+            rpcobj : dict() with:
+            'method': name of remote method to invoke
+            'args': JSON-able list of arguments to be sent to remote object
+        Returns:
+            de-JSON-ified return result from remote execution
+        Raises:
+            Exception with appropriate message raised in remote execution (xxx -- reinstantiate exception class)
+        """
+        # eprint("calling: ", str(rpcobj)[:200])
+        
+        self.rpc_write(rpcobj)
+        return self.rpc_read()
+
+    
+class IPCModuleClient(InterProcessRPCClient):
+    """ IPCModuleClient - specifically invoke python to create a server from a python module """
+    def __init__(self, module_name, module_dir):
+
+        env = os.environ.copy()
+        # make sure the new environment can find modules in cwd
+        _LOGGER.info("NOW STARTING {} for {}".format(__name__, __file__))
+        env['PYTHONPATH'] = env.get('PYTHONPATH', '') + ":"+module_dir
+
+        _LOGGER.info("STARTING module {} path={}".format(module_name, env['PYTHONPATH']))
+        super().__init__(['python3', '-m', module_name], env=env)
+
+
+    def __getattr__(self, method_name):
+        """ __getattr__  - override getattr so that we can proxy function calls by name """
+
+        # NOTE: this is a dangerous game since we are comandeering all function/slot accesses
+        # it's also not the most efficient thing in the world... but we're about to do a pipe rpc
+        # so it's probalby also not the weakest link
+        
+        _super = super() # bind super outside of the lambda
+        return lambda x: _super.call({'method': method_name, 'args': [x]})

--- a/python/fledge/common/logger.py
+++ b/python/fledge/common/logger.py
@@ -23,12 +23,31 @@ r"""Send log entries to /var/log/syslog
 
 """
 CONSOLE = 1
-"""Send log entries to STDOUT"""
+"""Send log entries to STDERR"""
+
+
+FLEDGE_LOGS_DESTINATION='FLEDGE_LOGS_DESTINATION'  # env variable
+default_destination = SYSLOG    # default for fledge
+
+def set_default_destination(destination: int):
+    """ set_default_destination - allow a global default to be set, once, for all fledge modules
+        also, set env variable FLEDGE_LOGS_DESTINATION for communication with related, spawned
+        processes. (makes logging consistent for interactive stderr vs server syslog applications """
+    global default_destination
+    default_destination = destination
+    os.environ[FLEDGE_LOGS_DESTINATION] = str(destination)
+
+
+if (FLEDGE_LOGS_DESTINATION in os.environ) and \
+   os.environ[FLEDGE_LOGS_DESTINATION] in [str(CONSOLE), str(SYSLOG)]:
+    # inherit (valid) default from the environment
+    set_default_destination(int(os.environ[FLEDGE_LOGS_DESTINATION]))
+    
 
 
 def setup(logger_name: str = None,
-          destination: int = SYSLOG,
-          level: int = logging.WARNING,
+          destination: int = None,
+          level: int = None,
           propagate: bool = False) -> logging.Logger:
     """Configures a `logging.Logger`_ object
 
@@ -45,7 +64,7 @@ def setup(logger_name: str = None,
 
         level:
             The `logging level`_ to use when filtering log entries.
-            Defaults to logging.WARNING.
+            Use None to maintain the default level
 
         propagate:
             Whether to send log entries to ancestor loggers. Defaults to False.
@@ -53,7 +72,7 @@ def setup(logger_name: str = None,
         destination:
             - SYSLOG: (the default) Send messages to syslog.
                 - View with: ``tail -f /var/log/syslog | sed 's/#012/\n\t/g'``
-            - CONSOLE: Send message to stdout
+            - CONSOLE: Send message to stderr
 
     Returns:
         A `logging.Logger`_ object
@@ -76,19 +95,27 @@ def setup(logger_name: str = None,
 
     logger = logging.getLogger(logger_name)
 
+    # if no destination is set, use the fledge default
+    if destination is None:
+        destination = default_destination
+
     if destination == SYSLOG:
         handler = SysLogHandler(address='/dev/log')
     elif destination == CONSOLE:
-        handler = logging.StreamHandler(sys.stdout)
+        handler = logging.StreamHandler()  # stderr
     else:
         raise ValueError("Invalid destination {}".format(destination))
 
-    # TODO: Consider using %r with message when using syslog .. \n looks better than #
     process_name = _get_process_name()
+    # TODO: Consider using %r with message when using syslog .. \n looks better than #
     fmt = '{}[%(process)d] %(levelname)s: %(module)s: %(name)s: %(message)s'.format(process_name)
     formatter = logging.Formatter(fmt=fmt)
+
     handler.setFormatter(formatter)
-    logger.setLevel(level)
-    logger.propagate = propagate
+    if level is not None:
+        logger.setLevel(level)
+        
     logger.addHandler(handler)
+
+    logger.propagate = propagate
     return logger

--- a/python/fledge/common/utils.py
+++ b/python/fledge/common/utils.py
@@ -13,6 +13,7 @@ __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
+import sys
 
 def check_reserved(string):
     """
@@ -64,3 +65,21 @@ def local_timestamp():
     :example '2018-05-08 14:06:40.517313+05:30'
     """
     return str(datetime.datetime.now(datetime.timezone.utc).astimezone())
+
+
+def add_functions_as_methods(functions):
+    """ add_functions_as_methods - add the given functions to a class (to allow multi-file definition) 
+        Type: class decorator
+        Arguments:
+            functions: list of functions (which expect a "self" argument) to be added to class namespace
+    """
+    
+    def decorator(Class):
+        for function in functions:
+            setattr(Class, function.__name__, function)
+        return Class
+    return decorator
+
+def eprint(*args, **kwargs):
+    """ eprintf -- convenience print function that prints to stderr """
+    print(*args, *kwargs, file=sys.stderr)


### PR DESCRIPTION
I'd like to add this iprpc as a general python facility. It allows spinning up a module in a separate process that you can do rpc calls into. This allows coarse grained parallelism, some performance isolation, and, most importantly, it allows having multiple instances of packages like numpy which can't be included in multiple subinterpreters.