### PR TITLE
Fogl 4367 multidatapoints: adds array support to datapoint

### DIFF
--- a/C/common/asset_tracking.cpp
+++ b/C/common/asset_tracking.cpp
@@ -116,7 +116,10 @@ void AssetTracker::addAssetTrackingTuple(string plugin, string asset, string eve
 	// in case of "Filter" event, 'plugin' input argument is category name, so remove service name (prefix) & '_' from it
 	if (event == string("Filter"))
 	{
-		plugin.erase(plugin.begin(), plugin.begin() + m_service.length() + 1);
+		string pattern  = m_service + "_";
+		if (plugin.find(pattern) != string::npos)
+			plugin.erase(plugin.begin(), plugin.begin() + m_service.length() + 1);
+
 	}
 	
 	AssetTrackingTuple tuple(m_service, plugin, asset, event);

--- a/C/plugins/north/OMF/omfhints.cpp
+++ b/C/plugins/north/OMF/omfhints.cpp
@@ -73,36 +73,75 @@ OMFHints::OMFHints(const string& hints)
 			else if (strcmp(name, "datapoint") == 0)
 			{
 				const Value &child = itr->value;
-				if (child.HasMember("name"))
+				if (child.IsArray())
 				{
-					const string dpname = child["name"].GetString();
-					vector<OMFHint *> hints;
-					for (Value::ConstMemberIterator dpitr = child.MemberBegin();
-						dpitr != child.MemberEnd(); ++dpitr)
+					for (Value::ConstValueIterator dpitr2 = child.Begin(); dpitr2 != child.End(); ++dpitr2)
 					{
-						const char *name = dpitr->name.GetString();
-						if (strcmp(name, "number") == 0)
+						if (dpitr2->HasMember("name"))
 						{
-							hints.push_back(new OMFNumberHint(dpitr->value.GetString()));
-						}
-						else if (strcmp(name, "integer") == 0)
-						{
-							hints.push_back(new OMFIntegerHint(dpitr->value.GetString()));
-						}
-						else if (strcmp(name, "typeName") == 0)
-						{
-							hints.push_back(new OMFTypeNameHint(dpitr->value.GetString()));
-						}
-						else if (strcmp(name, "tagName") == 0)
-						{
-							hints.push_back(new OMFTagNameHint(dpitr->value.GetString()));
-						}
-						else if (strcmp(name, "tag") == 0)
-						{
-							hints.push_back(new OMFTagHint(dpitr->value.GetString()));
+							const string dpname = (*dpitr2)["name"].GetString();
+							vector<OMFHint *> hints;
+							for (Value::ConstMemberIterator dpitr = dpitr2->MemberBegin(); dpitr != dpitr2->MemberEnd(); ++dpitr)
+							{
+								const char *name = dpitr->name.GetString();
+								if (strcmp(name, "number") == 0)
+								{
+									hints.push_back(new OMFNumberHint(dpitr->value.GetString()));
+								}
+								else if (strcmp(name, "integer") == 0)
+								{
+									hints.push_back(new OMFIntegerHint(dpitr->value.GetString()));
+								}
+								else if (strcmp(name, "typeName") == 0)
+								{
+									hints.push_back(new OMFTypeNameHint(dpitr->value.GetString()));
+								}
+								else if (strcmp(name, "tagName") == 0)
+								{
+									hints.push_back(new OMFTagNameHint(dpitr->value.GetString()));
+								}
+								else if (strcmp(name, "tag") == 0)
+								{
+									hints.push_back(new OMFTagHint(dpitr->value.GetString()));
+								}
+							}
+							m_datapointHints.insert(std::pair<string,vector<OMFHint *>>(dpname, hints));
 						}
 					}
-					m_datapointHints.insert(std::pair<string,vector<OMFHint *>>(dpname, hints));
+
+				}
+				else
+				{
+					if (child.HasMember("name"))
+					{
+						const string dpname = child["name"].GetString();
+						vector<OMFHint *> hints;
+						for (Value::ConstMemberIterator dpitr = child.MemberBegin(); dpitr != child.MemberEnd(); ++dpitr)
+						{
+							const char *name = dpitr->name.GetString();
+							if (strcmp(name, "number") == 0)
+							{
+								hints.push_back(new OMFNumberHint(dpitr->value.GetString()));
+							}
+							else if (strcmp(name, "integer") == 0)
+							{
+								hints.push_back(new OMFIntegerHint(dpitr->value.GetString()));
+							}
+							else if (strcmp(name, "typeName") == 0)
+							{
+								hints.push_back(new OMFTypeNameHint(dpitr->value.GetString()));
+							}
+							else if (strcmp(name, "tagName") == 0)
+							{
+								hints.push_back(new OMFTagNameHint(dpitr->value.GetString()));
+							}
+							else if (strcmp(name, "tag") == 0)
+							{
+								hints.push_back(new OMFTagHint(dpitr->value.GetString()));
+							}
+						}
+						m_datapointHints.insert(std::pair<string,vector<OMFHint *>>(dpname, hints));
+					}
 				}
 			}
 			else

--- a/tests/unit/C/CMakeLists.txt
+++ b/tests/unit/C/CMakeLists.txt
@@ -31,6 +31,7 @@ pkg_check_modules(PYTHON REQUIRED python3)
 
 include_directories(../../../C/common/include)
 include_directories(../../../C/plugins/common/include)
+include_directories(../../../C/plugins/north/OMF/include)
 include_directories(../../../C/services/common/include)
 include_directories(../../../C/thirdparty/rapidjson/include)
 include_directories(../../../C/thirdparty/Simple-Web-Server)
@@ -71,6 +72,23 @@ target_link_libraries(plugins-common-lib ${Boost_LIBRARIES} common-lib services-
 target_link_libraries(plugins-common-lib ${LIBCURL_LIB})
 
 set_target_properties(plugins-common-lib PROPERTIES SOVERSION 1)
+
+#
+# OMF library
+#
+set(LIB_NAME OMF)
+file(GLOB OMF_LIB_SOURCES
+        ../../../C/plugins/north/OMF/omf.cpp
+        ../../../C/plugins/north/OMF/omfhints.cpp)
+
+add_library(${LIB_NAME}  SHARED ${OMF_LIB_SOURCES})
+target_link_libraries(${LIB_NAME}
+                        common-lib
+                        plugins-common-lib
+                        ssl
+                        crypto)
+
+set_target_properties(${LIB_NAME}  PROPERTIES SOVERSION 1)
 
 #
 # storage-common-lib

--- a/tests/unit/C/plugins/common/CMakeLists.txt
+++ b/tests/unit/C/plugins/common/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
 include_directories(../../../../../C/common/include)
 include_directories(../../../../../C/plugins/common/include)
+include_directories(../../../../../C/plugins/north/OMF/include)
 include_directories(../../../../../C/services/common/include)
 include_directories(../../../../../C/thirdparty/rapidjson/include)
 include_directories(../../../../../C/thirdparty/Simple-Web-Server)
@@ -36,6 +37,7 @@ include_directories(../../../../../C/thirdparty/Simple-Web-Server)
 set(COMMON_LIB common-lib)
 set(SERVICE_COMMON_LIB services-common-lib)
 set(PLUGINS_COMMON_LIB plugins-common-lib)
+set(OMF_LIB OMF)
 
 file(GLOB unittests "*.cpp")
  
@@ -60,6 +62,7 @@ target_link_libraries(RunTests -lssl -lcrypto -lz)
 target_link_libraries(RunTests ${COMMON_LIB})
 target_link_libraries(RunTests ${SERVICE_COMMON_LIB})
 target_link_libraries(RunTests ${PLUGINS_COMMON_LIB})
+target_link_libraries(RunTests ${OMF_LIB})
 target_link_libraries(RunTests ${LIBCURL_LIB})
 
 # Add Python 3.x library


### PR DESCRIPTION
Signed-off-by: Stefano <stefano@dianomic.com>
tested using the cases:

```

curl -sX POST http://localhost:8081/fledge/filter -d @- <<EOF
{
  "name":"acce_h",
  "plugin":"omfhint",
  "filter_config":{
    "hints":{

              "fogbench_accelerometer": {
                "datapoint":
                  {
                    "name": "x",
                    "integer": "int64"
                  }
              }

    }
  }
}
EOF



curl -sX POST http://localhost:8081/fledge/filter -d @- <<EOF
{
  "name":"acce_h",
  "plugin":"omfhint",
  "filter_config":{
    "hints":{

              "fogbench_accelerometer": {
                "datapoint": [
                  {
                    "name": "x",
                    "integer": "int64"
                  },
                  {
                    "name": "y",
                    "integer":"int32"
                  }
                ]
              }

    }
  }
}
EOF


    curl -sX POST http://localhost:8081/fledge/filter -d @- <<EOF
{
    "name": "acce_h",
    "plugin": "omfhint",
    "filter_config": {
        "hints": {
            "fogbench_luxometer": {
                "number": "float32"
            },
            "fogbench_accelerometer": {
                "number": "float32",
                "datapoint": [
                    {
                        "name": "x",
                        "integer": "int64"
                    },
                    {
                        "name": "y",
                        "integer": "int32"
                    }
                ]
            }
        }
    }
}
EOF


```