### PR TITLE
FOGL-4584 Improve error reporting for bad plugins

### DIFF
--- a/python/fledge/services/core/api/service.py
+++ b/python/fledge/services/core/api/service.py
@@ -374,9 +374,14 @@ def load_c_plugin(plugin: str, service_type: str) -> Dict:
         plugin_config = plugin_info['config']
     except Exception:
         # Now looking for hybrid plugins if exists
-        plugin_info = common.load_and_fetch_c_hybrid_plugin_info(plugin, True)
-        if plugin_info:
-            plugin_config = plugin_info['config']
+        try:
+            plugin_info = common.load_and_fetch_c_hybrid_plugin_info(plugin, True)
+            if plugin_info:
+                plugin_config = plugin_info['config']
+        except Exception:
+            # This case if C-plugin is not found either in hybrid path. Hence treated as bad plugin
+            _logger.error("No {} plugin found".format(plugin))
+            plugin_config = {}
     return plugin_config
 
 

--- a/python/fledge/services/core/api/task.py
+++ b/python/fledge/services/core/api/task.py
@@ -160,13 +160,20 @@ async def add_task(request):
             # Checking for C-type plugins
             script = '["tasks/north_c"]'
             plugin_info = apiutils.get_plugin_info(plugin, dir=task_type)
-            if not 'type' in plugin_info:
+            if not plugin_info:
                 msg = "Plugin {} does not appear to be a valid plugin".format(plugin)
-                _logger.exception(msg)
-                return web.HTTPBadRequest(reason=msg, body=json.dumps({"message":msg}))
+                _logger.error(msg)
+                return web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+            valid_c_plugin_info_keys = ['name', 'version', 'type', 'interface', 'flag', 'config']
+            for k in valid_c_plugin_info_keys:
+                if k not in list(plugin_info.keys()):
+                    msg = "Plugin info does not appear to be a valid for {} plugin. '{}' item not found".format(
+                        plugin, k)
+                    _logger.error(msg)
+                    return web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
             if plugin_info['type'] != task_type:
                 msg = "Plugin of {} type is not supported".format(plugin_info['type'])
-                _logger.exception(msg)
+                _logger.error(msg)
                 return web.HTTPBadRequest(reason=msg)
             plugin_config = plugin_info['config']
             process_name = 'north_c'

--- a/python/fledge/services/core/api/task.py
+++ b/python/fledge/services/core/api/task.py
@@ -5,6 +5,7 @@
 # FLEDGE_END
 
 import datetime
+import json
 import uuid
 from aiohttp import web
 
@@ -159,6 +160,10 @@ async def add_task(request):
             # Checking for C-type plugins
             script = '["tasks/north_c"]'
             plugin_info = apiutils.get_plugin_info(plugin, dir=task_type)
+            if not 'type' in plugin_info:
+                msg = "Plugin {} does not appear to be a valid plugin".format(plugin)
+                _logger.exception(msg)
+                return web.HTTPBadRequest(reason=msg, body=json.dumps({"message":msg}))
             if plugin_info['type'] != task_type:
                 msg = "Plugin of {} type is not supported".format(plugin_info['type'])
                 _logger.exception(msg)

--- a/python/fledge/services/core/api/utils.py
+++ b/python/fledge/services/core/api/utils.py
@@ -20,13 +20,22 @@ def get_plugin_info(name, dir):
     try:
         arg1 = _find_c_util('get_plugin_info')
         arg2 = _find_c_lib(name, dir)
+        if arg2 is None:
+            _logger.error("The plugin %s does not exist", name)
+            return {}
         cmd_with_args = [arg1, arg2, "plugin_info"]
         p = subprocess.Popen(cmd_with_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
         res = out.decode("utf-8")
         jdoc = json.loads(res)
-    except (OSError, subprocess.CalledProcessError, Exception) as ex:
+    except (OSError, Exception) as ex:
         _logger.exception("%s C plugin get info failed due to %s", name, ex)
+        return {}
+    except (subprocess.CalledProcessError) as ex:
+        if ex.output is not None:
+            _logger.exception("%s C plugin get info failed '%s' due to %s", name, ex.output, ex)
+        else:
+            _logger.exception("%s C plugin get info failed due to %s", name, ex)
         return {}
     else:
         return jdoc

--- a/python/fledge/services/core/api/utils.py
+++ b/python/fledge/services/core/api/utils.py
@@ -21,21 +21,26 @@ def get_plugin_info(name, dir):
         arg1 = _find_c_util('get_plugin_info')
         arg2 = _find_c_lib(name, dir)
         if arg2 is None:
-            _logger.error("The plugin %s does not exist", name)
-            return {}
+            raise ValueError('The plugin {} does not exist'.format(name))
         cmd_with_args = [arg1, arg2, "plugin_info"]
         p = subprocess.Popen(cmd_with_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
         res = out.decode("utf-8")
         jdoc = json.loads(res)
-    except (OSError, Exception) as ex:
-        _logger.exception("%s C plugin get info failed due to %s", name, ex)
+    except OSError as err:
+        _logger.error("%s C plugin get info failed due to %s", name, str(err))
         return {}
-    except (subprocess.CalledProcessError) as ex:
-        if ex.output is not None:
-            _logger.exception("%s C plugin get info failed '%s' due to %s", name, ex.output, ex)
+    except subprocess.CalledProcessError as err:
+        if err.output is not None:
+            _logger.error("%s C plugin get info failed '%s' due to %s", name, err.output, str(err))
         else:
-            _logger.exception("%s C plugin get info failed due to %s", name, ex)
+            _logger.error("%s C plugin get info failed due to %s", name, str(err))
+        return {}
+    except ValueError as err:
+        _logger.error(str(err))
+        return {}
+    except Exception as ex:
+        _logger.exception("%s C plugin get info failed due to %s", name, str(ex))
         return {}
     else:
         return jdoc

--- a/tests/unit/python/fledge/services/core/api/test_api_utils.py
+++ b/tests/unit/python/fledge/services/core/api/test_api_utils.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from unittest.mock import MagicMock, patch
 import pytest
 
@@ -31,26 +33,51 @@ class TestUtils:
 
             assert plugin_name, plugin_type == utils.find_c_plugin_libs(direction)
 
-    def test_get_plugin_info_exception(self):
+    def test_get_plugin_info_value_error(self):
         plugin_name = 'Random'
-        with patch.object(utils, '_find_c_util', return_value=None) as patch_util:
+        with patch.object(utils, '_find_c_util', return_value='plugins/utils/get_plugin_info') as patch_util:
             with patch.object(utils, '_find_c_lib', return_value=None) as patch_lib:
-                with patch.object(utils.subprocess, "Popen", side_effect=Exception):
-                    with patch.object(utils._logger, 'exception') as patch_logger:
+                with patch.object(utils._logger, 'error') as patch_logger:
+                    assert {} == utils.get_plugin_info(plugin_name, dir='south')
+                assert 1 == patch_logger.call_count
+                args, kwargs = patch_logger.call_args
+                assert 'The plugin {} does not exist'.format(plugin_name) == args[0]
+            patch_lib.assert_called_once_with(plugin_name, 'south')
+        patch_util.assert_called_once_with('get_plugin_info')
+
+    @pytest.mark.parametrize("exc_name", [Exception, OSError, subprocess.CalledProcessError])
+    def test_get_plugin_info_exception(self, exc_name):
+        plugin_name = 'OMF'
+        plugin_lib_path = 'fledge/plugins/north/{}/lib{}'.format(plugin_name, plugin_name)
+        with patch.object(utils, '_find_c_util', return_value='plugins/utils/get_plugin_info') as patch_util:
+            with patch.object(utils, '_find_c_lib', return_value=plugin_lib_path) as patch_lib:
+                with patch.object(utils.subprocess, "Popen", side_effect=exc_name):
+                    with patch.object(utils._logger, 'error') as patch_logger:
                         assert {} == utils.get_plugin_info(plugin_name, dir='south')
-                    assert 0 == patch_logger.call_count
+                    assert 1 == patch_logger.call_count
+                    args, kwargs = patch_logger.call_args
+                    assert '%s C plugin get info failed due to %s' == args[0]
+                    assert plugin_name == args[1]
             patch_lib.assert_called_once_with(plugin_name, 'south')
         patch_util.assert_called_once_with('get_plugin_info')
 
     @patch('subprocess.Popen')
     def test_get_plugin_info(self, mock_subproc_popen):
-        with patch.object(utils, '_find_c_util', return_value=['']) as patch_util:
-            with patch.object(utils, '_find_c_lib', return_value=['']) as patch_lib:
+        with patch.object(utils, '_find_c_util', return_value='plugins/utils/get_plugin_info') as patch_util:
+            with patch.object(utils, '_find_c_lib', return_value='fledge/plugins/south/Random/libRandom') as patch_lib:
                 process_mock = MagicMock()
-                attrs = {'communicate.return_value': (b'{"name": "Random", "version": "1.0.0", "type": "south", "interface": "1.0.0", "config": {"plugin" : { "description" : "Random C south plugin", "type" : "string", "default" : "Random" }, "asset" : { "description" : "Asset name", "type" : "string", "default" : "Random" } } }\n', 'error')}
+                attrs = {'communicate.return_value': (b'{"name": "Random", "version": "1.0.0", "type": "south", '
+                                                      b'"interface": "1.0.0", "config": {"plugin" : '
+                                                      b'{ "description" : "Random C south plugin", "type" : "string", '
+                                                      b'"default" : "Random" }, "asset" : { "description" : '
+                                                      b'"Asset name", "type" : "string", '
+                                                      b'"default" : "Random" } } }\n', 'error')}
                 process_mock.configure_mock(**attrs)
                 mock_subproc_popen.return_value = process_mock
                 j = utils.get_plugin_info('Random', dir='south')
-                assert {'name': 'Random', 'type': 'south', 'version': '1.0.0', 'interface': '1.0.0', 'config': {'plugin': {'description': 'Random C south plugin', 'type': 'string', 'default': 'Random'}, 'asset': {'description': 'Asset name', 'type': 'string', 'default': 'Random'}}} == j
+                assert {'name': 'Random', 'type': 'south', 'version': '1.0.0', 'interface': '1.0.0',
+                        'config': {'plugin': {'description': 'Random C south plugin', 'type': 'string',
+                                              'default': 'Random'},
+                                   'asset': {'description': 'Asset name', 'type': 'string', 'default': 'Random'}}} == j
             patch_lib.assert_called_once_with('Random', 'south')
         patch_util.assert_called_once_with('get_plugin_info')

--- a/tests/unit/python/fledge/services/core/api/test_api_utils.py
+++ b/tests/unit/python/fledge/services/core/api/test_api_utils.py
@@ -38,7 +38,7 @@ class TestUtils:
                 with patch.object(utils.subprocess, "Popen", side_effect=Exception):
                     with patch.object(utils._logger, 'exception') as patch_logger:
                         assert {} == utils.get_plugin_info(plugin_name, dir='south')
-                    assert 1 == patch_logger.call_count
+                    assert 0 == patch_logger.call_count
             patch_lib.assert_called_once_with(plugin_name, 'south')
         patch_util.assert_called_once_with('get_plugin_info')
 


### PR DESCRIPTION
foglamp@foglamp-18:~/fledge$ curl -sX POST http://localhost:8081/fledge/scheduled/task -d \
     '{
        "name": "opcuabad",
        "plugin": "opcuabad",
        "type": "north",
        "schedule_type": 3,
        "schedule_day": 0,
        "schedule_time": 0,
        "schedule_repeat": 30,
        "schedule_enabled": true
     }'
{"message": "Plugin opcuabad does not appear to be a valid plugin"}

foglamp@foglamp-18:~/fledge$ curl -sX POST http://localhost:8081/fledge/service -d '{"name": "op", "plugin": "blah", "type": "south", "enabled": false}'
404: Plugin "blah" import problem from path "/home/aj/fledge/python/fledge/plugins/south/blah"