### PR TITLE
FOGL-4602

### DIFF
--- a/C/common/JSONPath.cpp
+++ b/C/common/JSONPath.cpp
@@ -1,5 +1,5 @@
 /*
- * Fledge storage service client
+ * Fledge RapaidJSON JSONPath search helper
  *
  * Copyright (c) 2020 Dianomic Systems
  *

--- a/C/common/JSONPath.cpp
+++ b/C/common/JSONPath.cpp
@@ -1,0 +1,199 @@
+/*
+ * Fledge storage service client
+ *
+ * Copyright (c) 2020 Dianomic Systems
+ *
+ * Released under the Apache 2.0 Licence
+ *
+ * Author: Mark Riddoch
+ */
+#include <JSONPath.h>
+#include <logger.h>
+#include <cstring>
+
+using namespace std;
+using namespace rapidjson;
+
+JSONPath::JSONPath(const string& path) : m_path(path)
+{
+	m_logger = Logger::getLogger();
+}
+
+/**
+ * Destructor for the JSONPath
+ *
+ * Reclaim the vector of components.
+ */
+JSONPath::~JSONPath()
+{
+}
+
+/**
+ * Find the matching node in the JSON document
+ *
+ * param node	The node to search from
+ * @return the matching node. Throws an exception if there was no match
+ */
+Value& JSONPath::findNode(Value& node)
+{
+	if (m_parsed.size() == 0)
+	{
+		parse();
+	}
+	for (int i = 0; i < m_parsed.size(); i++)
+	{
+		node = m_parsed[i]->match(node);
+	}
+	return node;
+}
+
+/**
+ * Parse the m_path JSON path. Throws an exception if there
+ * was a parse error.
+ *
+ * The supported elements are
+ * 	Literal object name		/a
+ * 	Array Index			a[1]
+ * 	Array with matching predicate	a[name==value]
+ */
+void JSONPath::parse()
+{
+char *path, *ptr, *sp;
+
+	path = strdup(m_path.c_str());
+	ptr = strtok_r(path, "/", &sp);
+	while (ptr)
+	{
+		char *p = ptr;
+		char *bstart = NULL, *bend = NULL, *bequal = NULL;
+		while (*p)
+		{
+			if (*p == '[')
+			{
+				bstart = p + 1;
+			}
+			if (*p == ']')
+			{
+				bend = p - 1;
+			}
+			if (*p == '=' && *(p+1) == '=')
+			{
+				bequal = p;
+			}
+			p++;
+		}
+		if (bstart == NULL && bend == NULL && bequal == NULL)
+		{
+			string s(ptr);
+			m_parsed.push_back(new LiteralPathComponent(s));
+		}
+		if (bstart != NULL && bend != NULL)
+		{
+			if (bstart > bend)
+			{
+				m_logger->error("Invalid JSONPath '%s', malformed selector", path);
+				goto done;
+			}
+			*(bstart - 1) = 0;
+			string name(ptr);
+			if (bequal == NULL)
+			{
+				char *eptr;
+				long index = strtol(bstart, &eptr, 10);
+				if (eptr != bend + 1)
+				{
+					m_logger->error("Invalid JSONPath '%s', expected numeric selector");
+					goto done;
+				}
+				m_parsed.push_back(new IndexPathComponent(name, index));
+			}
+			else
+			{
+				char *property = bstart;
+				char *value = bequal + 2;
+				*(bend + 1) = 0;
+				*bequal = 0;
+				string p(property), v(value);
+				m_parsed.push_back(new MatchPathComponent(name, p, v));
+			}
+		}
+
+
+		ptr = strtok_r(NULL, "/", &sp);
+	}
+done:
+	free(path);
+}
+
+/**
+ * A match against a literal path component
+ */
+JSONPath::LiteralPathComponent::LiteralPathComponent(string& name) : m_name(name)
+{
+}
+
+/**
+ * Return the child object of node that matchs the literal name given
+ */
+rapidjson::Value& JSONPath::LiteralPathComponent::match(rapidjson::Value& node)
+{
+	if (node.IsObject() && node.HasMember(m_name.c_str()))
+	{
+		return node[m_name.c_str()];
+	}
+	throw runtime_error("Document has no member " + m_name);
+}
+
+/**
+ * A match against an array index
+ */
+JSONPath::IndexPathComponent::IndexPathComponent(string& name, int index) : m_name(name), m_index(index)
+{
+}
+
+/**
+ * Return the object at the index position of the specified array
+ */
+rapidjson::Value& JSONPath::IndexPathComponent::match(rapidjson::Value& node)
+{
+	if (node.IsObject() && node.HasMember(m_name.c_str()))
+	{
+		Value& n  = node[m_name.c_str()];
+		if (n.IsArray())
+		{
+			return n[m_index];
+		}
+	}
+	throw runtime_error("Document has no member ");
+}
+
+/**
+ * Amatch against an object that hase a particular name/value pair
+ */
+JSONPath::MatchPathComponent::MatchPathComponent(string& name, string& property, string& value) : m_name(name), m_property(property), m_value(value)
+{
+}
+
+rapidjson::Value& JSONPath::MatchPathComponent::match(rapidjson::Value& node)
+{
+	if (node.IsObject() && node.HasMember(m_name.c_str()))
+	{
+		Value& n  = node[m_name.c_str()];
+		if (n.IsArray())
+		{
+			for (auto& v : n.GetArray())
+			{
+				if (v.IsObject())
+				{
+					if (v.HasMember(m_property.c_str()))
+					{
+						if (v[m_property.c_str()].IsString() 
+								&& m_value.compare(v[m_property.c_str()].GetString()) == 0)
+							return v;
+					}
+				}
+			}
+		}
+	}
+	throw runtime_error("Document has no member ");
+}

--- a/C/common/include/JSONPath.h
+++ b/C/common/include/JSONPath.h
@@ -1,0 +1,63 @@
+/*
+ * Fledge RapaidJSON JSONPath search helper
+ *
+ * Copyright (c) 2020 Dianomic Systems
+ *
+ * Released under the Apache 2.0 Licence
+ *
+ * Author: Mark Riddoch
+ */
+#ifndef _JSONPATH_H
+#define _JSONPATH_H
+
+#include <rapidjson/document.h>
+#include <string>
+#include <vector>
+#include <logger.h>
+
+/**
+ * A simple implementation of a JSON Path search mechanism to use
+ * alongside RapidJSON
+ */
+class JSONPath {
+	public:
+		JSONPath(const std::string& path);
+		~JSONPath();
+		rapidjson::Value& findNode(rapidjson::Value& root);
+	private:
+		class PathComponent {
+			public:
+				virtual rapidjson::Value& match(rapidjson::Value& node) = 0;
+		};
+		class LiteralPathComponent : public PathComponent {
+			public:
+				LiteralPathComponent(std::string& name);
+				rapidjson::Value& match(rapidjson::Value& node);
+			private:
+				std::string	m_name;
+		};
+		class IndexPathComponent : public PathComponent {
+			public:
+				IndexPathComponent(std::string& name, int index);
+				rapidjson::Value& match(rapidjson::Value& node);
+			private:
+				std::string	m_name;
+				int		m_index;
+		};
+		class MatchPathComponent : public PathComponent {
+			public:
+				MatchPathComponent(std::string& name, std::string& property, std::string& value);
+				rapidjson::Value& match(rapidjson::Value& node);
+			private:
+				std::string	m_name;
+				std::string	m_property;
+				std::string	m_value;
+		};
+		void		parse();
+		std::string	m_path;
+		std::vector<PathComponent *>
+				m_parsed;
+		Logger		*m_logger;
+};
+
+#endif

--- a/tests/unit/C/common/test_JSONPath.cpp
+++ b/tests/unit/C/common/test_JSONPath.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include <JSONPath.h>
+#include <rapidjson/document.h>
+#include <string.h>
+#include <string>
+
+using namespace std;
+using namespace rapidjson;
+
+const char *testdoc = "{ \"a\" : { \"b\" : \"x\" }, " \
+		        "\"c\" : [ \"d\", \"e\" ], " \
+			"\"f\" : [ { \"g\" : \"h\", \"i\" : \"j\" }, " \
+			"          { \"k\" : \"l\", \"m\" : \"n\" }, " \
+			"          { \"o\" : \"p\", \"q\" : \"r\" } ], " \
+			"\"data\" : { \"child\" : [ { \"item\" : 1 } ] } " \
+			"}";
+
+/**
+ * Simple literal path test
+ */
+TEST(LiterialJSONPathTest, JSON)
+{
+	string path("/a/b");
+	JSONPath jpath(path);
+	Document doc;
+	doc.Parse(testdoc);
+	Value& v = jpath.findNode(doc);
+	ASSERT_TRUE(v.IsString());
+}
+
+/**
+ * Simple index path test
+ */
+TEST(IndexJSONPath, JSON)
+{
+	string path("/c[0]");
+	JSONPath jpath(path);
+	Document doc;
+	doc.Parse(testdoc);
+	Value& v = jpath.findNode(doc);
+	ASSERT_TRUE(v.IsString());
+	ASSERT_EQ(0, strcmp(v.GetString(), "d"));
+}
+
+/**
+ * Simple index path test with nested objects
+ */
+TEST(IndexIntJSONPath, JSON)
+{
+	string path("/data/child[0]/item");
+	JSONPath jpath(path);
+	Document doc;
+	doc.Parse(testdoc);
+	Value& v = jpath.findNode(doc);
+	ASSERT_TRUE(v.IsInt());
+	ASSERT_EQ(1, v.GetInt());
+}
+
+
+/**
+ * Simple index path test
+ */
+TEST(MatchJSONPath, JSON)
+{
+	string path("/f[k==l]");
+	JSONPath jpath(path);
+	Document doc;
+	doc.Parse(testdoc);
+	Value& v = jpath.findNode(doc);
+	ASSERT_TRUE(v.IsObject());
+	ASSERT_TRUE(v.HasMember("k"));
+	ASSERT_TRUE(v.HasMember("m"));
+}
+


### PR DESCRIPTION
Add a simple JSONPath expression mechanism to the common library that can be used with RapidJSON to specify objects in a JSON document