### PR TITLE
FOGL-4690 north service type added for POST service API and related changes

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 fledge_version=1.8.2
-fledge_schema=36
+fledge_schema=37

--- a/python/fledge/common/service_record.py
+++ b/python/fledge/common/service_record.py
@@ -26,6 +26,7 @@ class ServiceRecord(object):
         Southbound = 3
         Notification = 4
         Management = 5
+        Northbound = 6
 
     class Status(IntEnum):
         """Enumeration for Service Status"""

--- a/python/fledge/services/core/api/service.py
+++ b/python/fledge/services/core/api/service.py
@@ -158,6 +158,8 @@ async def add_service(request):
              curl -X POST http://localhost:8081/fledge/service -d '{"name": "DHT 11", "plugin": "dht11", "type": "south", "enabled": true}'
              curl -sX POST http://localhost:8081/fledge/service -d '{"name": "Sine", "plugin": "sinusoid", "type": "south", "enabled": true, "config": {"dataPointsPerSec": {"value": "10"}}}' | jq
              curl -X POST http://localhost:8081/fledge/service -d '{"name": "NotificationServer", "type": "notification", "enabled": true}' | jq
+             curl -X POST http://localhost:8081/fledge/service -d '{"name": "HTC", "plugin": "httpc", "type": "north", "enabled": true}' | jq
+             curl -sX POST http://localhost:8081/fledge/service -d '{"name": "HT", "plugin": "http_north", "type": "north", "enabled": true, "config": {"verifySSL": {"value": "false"}}}' | jq
 
              curl -sX POST http://localhost:8081/fledge/service?action=install -d '{"format":"repository", "name": "fledge-service-notification"}'
              curl -sX POST http://localhost:8081/fledge/service?action=install -d '{"format":"repository", "name": "fledge-service-notification", "version":"1.6.0"}'
@@ -216,12 +218,12 @@ async def add_service(request):
             raise web.HTTPBadRequest(reason='Missing type property in payload.')
 
         service_type = str(service_type).lower()
-        if service_type == 'north':
-            raise web.HTTPNotAcceptable(reason='north type is not supported for the time being.')
-        if service_type not in ['south', 'notification', 'management']:
-            raise web.HTTPBadRequest(reason='Only south, notification and management types are supported.')
+        if service_type not in ['south', 'north', 'notification', 'management']:
+            raise web.HTTPBadRequest(reason='Only south, north, notification and management types are supported.')
         if plugin is None and service_type == 'south':
             raise web.HTTPBadRequest(reason='Missing plugin property for type south in payload.')
+        if plugin is None and service_type == 'north':
+            raise web.HTTPBadRequest(reason='Missing plugin property for type north in payload.')
         if plugin and utils.check_reserved(plugin) is False:
             raise web.HTTPBadRequest(reason='Invalid plugin property in payload.')
 
@@ -234,28 +236,27 @@ async def add_service(request):
 
         # Check if a valid plugin has been provided
         plugin_module_path, plugin_config, process_name, script = "", {}, "", ""
-        if service_type == 'south':
+        if service_type == 'south' or service_type == 'north':
             # "plugin_module_path" is fixed by design. It is MANDATORY to keep the plugin in the exactly similar named
             # folder, within the plugin_module_path.
             # if multiple plugin with same name are found, then python plugin import will be tried first
             plugin_module_path = "{}/python/fledge/plugins/{}/{}".format(_FLEDGE_ROOT, service_type, plugin)
+            process_name = 'south_c' if service_type == 'south' else 'north_C'
+            script = '["services/south_c"]' if service_type == 'south' else '["services/north_C"]'
             try:
                 plugin_info = common.load_and_fetch_python_plugin_info(plugin_module_path, plugin, service_type)
                 plugin_config = plugin_info['config']
                 if not plugin_config:
                     _logger.exception("Plugin %s import problem from path %s", plugin, plugin_module_path)
-                    raise web.HTTPNotFound(reason='Plugin "{}" import problem from path "{}".'.format(plugin, plugin_module_path))
-                process_name = 'south_c'
-                script = '["services/south_c"]'
+                    raise web.HTTPNotFound(reason='Plugin "{}" import problem from path "{}".'.format(
+                        plugin, plugin_module_path))
             except FileNotFoundError as ex:
                 # Checking for C-type plugins
                 plugin_config = load_c_plugin(plugin, service_type)
                 if not plugin_config:
                     _logger.exception("Plugin %s import problem from path %s. %s", plugin, plugin_module_path, str(ex))
-                    raise web.HTTPNotFound(reason='Plugin "{}" import problem from path "{}".'.format(plugin, plugin_module_path))
-
-                process_name = 'south_c'
-                script = '["services/south_c"]'
+                    raise web.HTTPNotFound(reason='Plugin "{}" import problem from path "{}".'.format(
+                        plugin, plugin_module_path))
             except TypeError as ex:
                 _logger.exception(str(ex))
                 raise web.HTTPBadRequest(reason=str(ex))
@@ -268,7 +269,6 @@ async def add_service(request):
         elif service_type == 'management':
             process_name = 'management'
             script = '["services/management"]'
-
         storage = connect.get_storage_async()
         config_mgr = ConfigurationManager(storage)
 
@@ -283,7 +283,7 @@ async def add_service(request):
             raise web.HTTPBadRequest(reason='A service with this name already exists.')
 
         # Check that the process name is not already registered
-        count = await check_scheduled_processes(storage, process_name)
+        count = await check_scheduled_processes(storage, process_name, script)
         if count == 0:
             # Now first create the scheduled process entry for the new service
             payload = PayloadBuilder().INSERT(name=process_name, script=script).payload()
@@ -308,7 +308,7 @@ async def add_service(request):
             for ps in res['rows']:
                 if 'management' in ps['process_name']:
                     raise web.HTTPBadRequest(reason='A Management service schedule already exists.')
-        elif service_type == 'south':
+        elif service_type == 'south' or service_type == 'north':
             try:
                 # Create a configuration category from the configuration defined in the plugin
                 category_desc = plugin_config['plugin']['description']
@@ -317,8 +317,9 @@ async def add_service(request):
                                                  category_value=plugin_config,
                                                  keep_original_items=True)
                 # Create the parent category for all South services
-                await config_mgr.create_category("South", {}, "South microservices", True)
-                await config_mgr.create_child_category("South", [name])
+                parent_cat_name = service_type.capitalize()
+                await config_mgr.create_category(parent_cat_name, {}, "{} microservices".format(parent_cat_name), True)
+                await config_mgr.create_child_category(parent_cat_name, [name])
 
                 # If config is in POST data, then update the value for each config item
                 if config is not None:
@@ -385,8 +386,8 @@ def load_c_plugin(plugin: str, service_type: str) -> Dict:
     return plugin_config
 
 
-async def check_scheduled_processes(storage, process_name):
-    payload = PayloadBuilder().SELECT("name").WHERE(['name', '=', process_name]).payload()
+async def check_scheduled_processes(storage, process_name, script):
+    payload = PayloadBuilder().SELECT("name").WHERE(['name', '=', process_name]).AND_WHERE(['script', '=', script]).payload()
     result = await storage.query_tbl_with_payload('scheduled_processes', payload)
     return result['count']
 

--- a/scripts/fledge
+++ b/scripts/fledge
@@ -514,6 +514,7 @@ fledge_status() {
                 fledge_log "info" "fledge.services.core" "outonly" "pretty"
                 ps -ef | grep "fledge.services.storage" | grep -v 'grep' | grep -v awk | awk '{print "fledge.services.storage " $9 " " $10}' || true
                 ps -ef | grep "fledge.services.south " |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.south "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' || true
+                ps -ef | grep "fledge.services.north " |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.north "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' || true
                 ps -ef | grep "fledge.services.notification" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.notification "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' || true
                 # Show Python services (except core)
                 ps -ef | grep -o 'python3 -m fledge.services.*' | grep -o 'fledge.services.*' | grep -v 'fledge.services.core' | grep -v 'fledge.services\.\*' || true

--- a/scripts/plugins/storage/postgres/downgrade/36.sql
+++ b/scripts/plugins/storage/postgres/downgrade/36.sql
@@ -1,0 +1,1 @@
+-- No action is required

--- a/scripts/plugins/storage/postgres/init.sql
+++ b/scripts/plugins/storage/postgres/init.sql
@@ -869,6 +869,7 @@ INSERT INTO fledge.scheduled_processes (name, script)   VALUES ( 'south_c',     
 INSERT INTO fledge.scheduled_processes (name, script)   VALUES ( 'notification_c', '["services/notification_c"]' );
 INSERT INTO fledge.scheduled_processes (name, script)   VALUES ( 'north_c',        '["tasks/north_c"]'           );
 INSERT INTO fledge.scheduled_processes (name, script)   VALUES ( 'north',          '["tasks/north"]'             );
+INSERT INTO fledge.scheduled_processes (name, script)   VALUES ( 'north_C',        '["services/north_C"]'        );
 
 --
 -- Schedules

--- a/scripts/plugins/storage/postgres/upgrade/37.sql
+++ b/scripts/plugins/storage/postgres/upgrade/37.sql
@@ -1,0 +1,4 @@
+-- Scheduled process entry north microservice
+
+INSERT INTO fledge.scheduled_processes ( name, script )
+     VALUES ( 'north_C', '["services/north_C"]' );

--- a/scripts/plugins/storage/sqlite/downgrade/36.sql
+++ b/scripts/plugins/storage/sqlite/downgrade/36.sql
@@ -1,0 +1,1 @@
+-- No action is required

--- a/scripts/plugins/storage/sqlite/init.sql
+++ b/scripts/plugins/storage/sqlite/init.sql
@@ -662,6 +662,7 @@ INSERT INTO fledge.scheduled_processes (name, script)   VALUES ( 'south_c',     
 INSERT INTO fledge.scheduled_processes (name, script)   VALUES ( 'notification_c', '["services/notification_c"]' );
 INSERT INTO fledge.scheduled_processes (name, script)   VALUES ( 'north_c',        '["tasks/north_c"]'           );
 INSERT INTO fledge.scheduled_processes (name, script)   VALUES ( 'north',          '["tasks/north"]'             );
+INSERT INTO fledge.scheduled_processes (name, script)   VALUES ( 'north_C',        '["services/north_C"]'        );
 --
 -- Schedules
 --

--- a/scripts/plugins/storage/sqlite/upgrade/37.sql
+++ b/scripts/plugins/storage/sqlite/upgrade/37.sql
@@ -1,0 +1,4 @@
+-- Scheduled process entry north microservice
+
+INSERT INTO fledge.scheduled_processes ( name, script )
+     VALUES ( 'north_C', '["services/north_C"]' );

--- a/scripts/services/north_C
+++ b/scripts/services/north_C
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Run a Fledge north service written in C/C++
+if [ "${FLEDGE_ROOT}" = "" ]; then
+	FLEDGE_ROOT=/usr/local/fledge
+fi
+
+if [ ! -d "${FLEDGE_ROOT}" ]; then
+	logger "Fledge home directory missing or incorrectly set environment"
+	exit 1
+fi
+
+cd "${FLEDGE_ROOT}/services"
+./fledge.services.north "$@"


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

- [x] Northbound type used to information regarding a registered north microservice
- [x] Support added for new type "north" in POST service API
- [x] Unit & System tests
- [x] scheduled process entry ('north_C',        '["services/north_C"]') added in schema likewise others. And north & north_c process name already taken via old python/C tasks. Hence I have added with "north_C"
- [x] Parent Category "North" is used and north service is attached with it (parent-child realtionship)
- [x] fledge status output updated (as newly north microservice)
- [x] scripts/services/north_C added and will run with path `fledge.services.north` and binary comes from FOGL-4655
- [ ] Add more system tests once FOGL-4655 is ready

**Curl Examples**
```
# Service API with north type and http_north python plugin
$ curl -X POST http://localhost:8081/fledge/service -d '{"name": "HT", "plugin": "http_north", "type": "north", "enabled": true}'
{"name": "HT", "id": "56b74fad-051c-49eb-b5d0-255fe348be20"}

# category
$ curl -sX GET http://localhost:8081/fledge/category | jq
{
  "categories": [....
 {
      "key": "HT",
      "description": "HTTP North Plugin",
      "displayName": "HT"
    },
    {
      "key": "North",
      "description": "North microservices",
      "displayName": "North"
    },
]
}

# parent category
$ curl -sX GET http://localhost:8081/fledge/category/North | jq
{}

# parent-child relationship
$ curl -sX GET http://localhost:8081/fledge/category/North/children | jq
{
  "categories": [
    {
      "key": "HT",
      "description": "HTTP North Plugin",
      "displayName": "HT"
    }
  ]
}

# scheduled_processes
$ curl -sX GET http://localhost:8081/fledge/schedule/process | jq
{
  "processes": [......
    "north_C"
  ]
}

# schedule

$ curl -sX GET http://localhost:8081/fledge/schedule | jq
{
  "schedules": [.....
{
      "id": "56b74fad-051c-49eb-b5d0-255fe348be20",
      "name": "HT",
      "processName": "north_C",
      "type": "STARTUP",
      "repeat": 0,
      "time": 0,
      "day": null,
      "exclusive": true,
      "enabled": true
    }
]
}

$ curl -sX GET http://localhost:8081/fledge/service/installed | jq
{
  "services": [
    "storage",
    "south"
  ]
}
north entry will appear once FOGL-4655 ready
```

```
# with http-c north plugin
 $ curl -X POST http://localhost:8081/fledge/service -d '{"name": "HTC", "plugin": "httpc", "type": "north", "enabled": true}'
{"name": "HTC", "id": "1dc2a94a-cad5-4094-b8a4-804f230b79ca"}

@ with thingspeak plugin
$ curl -X POST http://localhost:8081/fledge/service -d '{"name": "Thing", "plugin": "ThingSpeak", "type": "north", "enabled": true}'
{"name": "Thing", "id": "63bd8c49-1c3c-47fc-a4c8-232f5248cc85"}
```

**Note** - On-demand CI job ran successfully; Results can be find here `Fledge%20Nightly%20Jobs/job/fledge_nightly_build_ub1804/418/`