### PR TITLE
FOGL-4717 upgrade scripts 36.sql & 37.sql unique constraint fixes and creates only if doesnot exist

### DIFF
--- a/scripts/plugins/storage/postgres/upgrade/36.sql
+++ b/scripts/plugins/storage/postgres/upgrade/36.sql
@@ -1,4 +1,6 @@
 -- Scheduled process entries for south, notification, north tasks
 
-INSERT INTO fledge.scheduled_processes ( name, script )
-     VALUES ( 'south_c', '["services/south_c"]' ), ( 'notification_c', '["services/notification_c"]' ), ( 'north_c', '["tasks/north_c"]' ), ( 'north', '["tasks/north"]' );
+INSERT INTO fledge.scheduled_processes SELECT 'south_c', '["services/south_c"]' WHERE NOT EXISTS (SELECT 1 FROM fledge.scheduled_processes WHERE name = 'south_c');
+INSERT INTO fledge.scheduled_processes SELECT 'notification_c', '["services/notification_c"]' WHERE NOT EXISTS (SELECT 1 FROM fledge.scheduled_processes WHERE name = 'notification_c');
+INSERT INTO fledge.scheduled_processes SELECT 'north_c', '["tasks/north_c"]' WHERE NOT EXISTS (SELECT 1 FROM fledge.scheduled_processes WHERE name = 'north_c');
+INSERT INTO fledge.scheduled_processes SELECT 'north', '["tasks/north"]' WHERE NOT EXISTS (SELECT 1 FROM fledge.scheduled_processes WHERE name = 'north');

--- a/scripts/plugins/storage/postgres/upgrade/37.sql
+++ b/scripts/plugins/storage/postgres/upgrade/37.sql
@@ -1,4 +1,4 @@
 -- Scheduled process entry north microservice
 
-INSERT INTO fledge.scheduled_processes ( name, script )
-     VALUES ( 'north_C', '["services/north_C"]' );
+INSERT INTO fledge.scheduled_processes SELECT 'north_C', '["services/north_C"]' WHERE NOT EXISTS (SELECT 1 FROM fledge.scheduled_processes WHERE name = 'north_C');
+

--- a/scripts/plugins/storage/sqlite/upgrade/36.sql
+++ b/scripts/plugins/storage/sqlite/upgrade/36.sql
@@ -1,4 +1,6 @@
 -- Scheduled process entries for south, notification, north tasks
 
-INSERT INTO fledge.scheduled_processes ( name, script )
-     VALUES ( 'south_c', '["services/south_c"]' ), ( 'notification_c', '["services/notification_c"]' ), ( 'north_c', '["tasks/north_c"]' ), ( 'north', '["tasks/north"]' );
+INSERT INTO fledge.scheduled_processes SELECT 'south_c', '["services/south_c"]' WHERE NOT EXISTS (SELECT 1 FROM fledge.scheduled_processes WHERE name = 'south_c');
+INSERT INTO fledge.scheduled_processes SELECT 'notification_c', '["services/notification_c"]' WHERE NOT EXISTS (SELECT 1 FROM fledge.scheduled_processes WHERE name = 'notification_c');
+INSERT INTO fledge.scheduled_processes SELECT 'north_c', '["tasks/north_c"]' WHERE NOT EXISTS (SELECT 1 FROM fledge.scheduled_processes WHERE name = 'north_c');
+INSERT INTO fledge.scheduled_processes SELECT 'north', '["tasks/north"]' WHERE NOT EXISTS (SELECT 1 FROM fledge.scheduled_processes WHERE name = 'north');

--- a/scripts/plugins/storage/sqlite/upgrade/37.sql
+++ b/scripts/plugins/storage/sqlite/upgrade/37.sql
@@ -1,4 +1,3 @@
 -- Scheduled process entry north microservice
 
-INSERT INTO fledge.scheduled_processes ( name, script )
-     VALUES ( 'north_C', '["services/north_C"]' );
+INSERT INTO fledge.scheduled_processes SELECT 'north_C', '["services/north_C"]' WHERE NOT EXISTS (SELECT 1 FROM fledge.scheduled_processes WHERE name = 'north_C');


### PR DESCRIPTION

Signed-off-by: ashish-jabble <ashish@dianomic.com>

**Sqlite**
```
upgrade

$ ./scripts/fledge start
Detected 'sqlite' Fledge DB schema change from version [35] to [37], applying Upgrade/Downgrade ...
Fledge DB schema has been upgraded to version [37]
Starting Fledge v1.8.2.......
Fledge started.

downgrade

 $ ./scripts/fledge start
Detected 'sqlite' Fledge DB schema change from version [37] to [35], applying Upgrade/Downgrade ...
Fledge DB schema has been downgraded to version [35]
Starting Fledge v1.8.2.......
Fledge started.

```
**PostgreSql**
```
upgrade

$ ./scripts/fledge start
Detected 'postgres' Fledge DB schema change from version [35] to [37], applying Upgrade/Downgrade ...
Fledge DB schema has been upgraded to version [37]
Starting Fledge v1.8.2.......
Fledge started.

downgrade

$ ./scripts/fledge start
Detected 'postgres' Fledge DB schema change from version [37] to [35], applying Upgrade/Downgrade ...
Fledge DB schema has been downgraded to version [35]
Starting Fledge v1.8.2.......
Fledge started.

```