### PR TITLE
FOGL-4689 scheduler process_script corruption fixes which causes scheduler gets stopped

### DIFF
--- a/python/fledge/services/core/api/scheduler.py
+++ b/python/fledge/services/core/api/scheduler.py
@@ -105,7 +105,7 @@ async def post_scheduled_process(request: web.Request) -> web.Response:
             script - path for the script
 
     :Example:
-             curl -d '{"process_name": "sleep30", "script": "[services/test]"}' -sX POST  http://localhost:8081/fledge/schedule/process
+             curl -d '{"process_name": "sleep30", "script": "[\"services/test\"]"}' -sX POST  http://localhost:8081/fledge/schedule/process
     """
     data = await request.json()
     process_name = data.get('process_name', None)
@@ -133,7 +133,7 @@ async def post_scheduled_process(request: web.Request) -> web.Response:
         try:
             await storage.insert_into_tbl("scheduled_processes", payload)
             # Update _process_scripts dict of scheduler
-            server.Server.scheduler._process_scripts.update({process_name: script})
+            await server.Server.scheduler._get_process_scripts()
         except StorageServerError as err:
             msg = str(err)
             raise web.HTTPInternalServerError(body=json.dumps(


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

Root cause was found by @praveen-garg 

On POST scheduled process entry scheduler gets stucked (corrupted scheduler process script dict)
Also We don't need to add south to see scheduler gets stopped, it gets corrupted as soon as service agent make an entry for FogMan Agent Poll task. 