### PR TITLE
FOGL-3921 version info added to ping JSON response along with their unit/system tests

### DIFF
--- a/python/fledge/services/core/api/common.py
+++ b/python/fledge/services/core/api/common.py
@@ -20,6 +20,7 @@ from fledge.services.core import connect
 from fledge.common.configuration_manager import ConfigurationManager
 from fledge.services.core.service_registry.service_registry import ServiceRegistry
 from fledge.common.service_record import ServiceRecord
+from fledge.common.common import _FLEDGE_ROOT
 
 __author__ = "Amarendra K. Sinha, Ashish Jabble"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -85,6 +86,12 @@ async def ping(request):
 
     status_color = services_health_litmus_test()
     safe_mode = True if server.Server.running_in_safe_mode else False
+    version = ""
+    with open(_FLEDGE_ROOT + '/VERSION') as f:
+        for line in f:
+            if 'fledge_version=' in line:
+                key, value = line.strip().split('=')
+                version = value
 
     return web.json_response({'uptime': int(since_started),
                               'dataRead': data_read,
@@ -95,7 +102,8 @@ async def ping(request):
                               'hostName': host_name,
                               'ipAddresses': ip_addresses,
                               'health': status_color,
-                              'safeMode': safe_mode
+                              'safeMode': safe_mode,
+                              'version': version
                               })
 
 

--- a/python/fledge/services/core/api/common.py
+++ b/python/fledge/services/core/api/common.py
@@ -86,12 +86,9 @@ async def ping(request):
 
     status_color = services_health_litmus_test()
     safe_mode = True if server.Server.running_in_safe_mode else False
-    version = ""
     with open(_FLEDGE_ROOT + '/VERSION') as f:
-        for line in f:
-            if 'fledge_version=' in line:
-                key, value = line.strip().split('=')
-                version = value
+        # Read only the first line of a VERSION file and grab the release version number
+        version = f.readline().split('=')[1].strip()
 
     return web.json_response({'uptime': int(since_started),
                               'dataRead': data_read,

--- a/python/fledge/services/core/api/common.py
+++ b/python/fledge/services/core/api/common.py
@@ -12,6 +12,7 @@ import socket
 import subprocess
 
 from aiohttp import web
+from functools import lru_cache
 
 from fledge.common import logger
 from fledge.services.core import server
@@ -38,6 +39,13 @@ _help = """
     | PUT             | /fledge/restart                                          |
     -------------------------------------------------------------------------------
 """
+
+
+@lru_cache(maxsize=1, typed=True)
+def get_version() -> str:
+    with open(_FLEDGE_ROOT + '/VERSION') as f:
+        # Read only the first line of a VERSION file and grab the release version number
+        return f.readline().split('=')[1].strip()
 
 
 async def ping(request):
@@ -86,10 +94,7 @@ async def ping(request):
 
     status_color = services_health_litmus_test()
     safe_mode = True if server.Server.running_in_safe_mode else False
-    with open(_FLEDGE_ROOT + '/VERSION') as f:
-        # Read only the first line of a VERSION file and grab the release version number
-        version = f.readline().split('=')[1].strip()
-
+    version = get_version()
     return web.json_response({'uptime': int(since_started),
                               'dataRead': data_read,
                               'dataSent': data_sent,

--- a/tests/system/python/api/test_common.py
+++ b/tests/system/python/api/test_common.py
@@ -61,6 +61,7 @@ class TestCommon:
         assert 'green' == jdoc['health']
         assert jdoc['authenticationOptional'] is True
         assert jdoc['safeMode'] is False
+        assert '1.8.2' == jdoc['version']
 
     def test_ping_when_auth_mandatory_allow_ping_true(self, fledge_url, wait_time):
         conn = http.client.HTTPConnection(fledge_url)

--- a/tests/system/python/api/test_common.py
+++ b/tests/system/python/api/test_common.py
@@ -61,7 +61,7 @@ class TestCommon:
         assert 'green' == jdoc['health']
         assert jdoc['authenticationOptional'] is True
         assert jdoc['safeMode'] is False
-        assert '1.8.2' == jdoc['version']
+        assert 'version' in jdoc
 
     def test_ping_when_auth_mandatory_allow_ping_true(self, fledge_url, wait_time):
         conn = http.client.HTTPConnection(fledge_url)

--- a/tests/unit/python/fledge/services/core/api/test_common_ping.py
+++ b/tests/unit/python/fledge/services/core/api/test_common_ping.py
@@ -105,6 +105,7 @@ async def test_ping_http_allow_ping_true(aiohttp_server, aiohttp_client, loop, g
                     assert content_dict['ipAddresses'] == ip_addresses
                     assert content_dict['health'] == "green"
                     assert content_dict['safeMode'] is False
+                    assert '1.8.2' == content_dict['version']
             query_patch.assert_called_once_with('statistics', payload)
         log_params = 'Received %s request for %s', 'GET', '/fledge/ping'
         logger_info.assert_called_once_with(*log_params)
@@ -156,6 +157,7 @@ async def test_ping_http_allow_ping_false(aiohttp_server, aiohttp_client, loop, 
                     assert content_dict['ipAddresses'] == ip_addresses
                     assert content_dict['health'] == "green"
                     assert content_dict['safeMode'] is False
+                    assert '1.8.2' == content_dict['version']
             query_patch.assert_called_once_with('statistics', payload)
         log_params = 'Received %s request for %s', 'GET', '/fledge/ping'
         logger_info.assert_called_once_with(*log_params)
@@ -211,6 +213,7 @@ async def test_ping_http_auth_required_allow_ping_true(aiohttp_server, aiohttp_c
                     assert content_dict['ipAddresses'] == ip_addresses
                     assert content_dict['health'] == "green"
                     assert content_dict['safeMode'] is False
+                    assert '1.8.2' == content_dict['version']
                 mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
             query_patch.assert_called_once_with('statistics', payload)
         log_params = 'Received %s request for %s', 'GET', '/fledge/ping'
@@ -321,6 +324,7 @@ async def test_ping_https_allow_ping_true(aiohttp_server, ssl_ctx, aiohttp_clien
                     assert content_dict['ipAddresses'] == ip_addresses
                     assert content_dict['health'] == "green"
                     assert content_dict['safeMode'] is False
+                    assert '1.8.2' == content_dict['version']
             query_patch.assert_called_once_with('statistics', payload)
         logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/fledge/ping')
 
@@ -379,7 +383,7 @@ async def test_ping_https_allow_ping_false(aiohttp_server, ssl_ctx, aiohttp_clie
                     assert content_dict['hostName'] == host_name
                     assert content_dict['ipAddresses'] == ip_addresses
                     assert content_dict['health'] == "green"
-
+                    assert '1.8.2' == content_dict['version']
             query_patch.assert_called_once_with('statistics', payload)
         logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/fledge/ping')
 
@@ -448,6 +452,7 @@ async def test_ping_https_auth_required_allow_ping_true(aiohttp_server, ssl_ctx,
                     assert content_dict['ipAddresses'] == ip_addresses
                     assert content_dict['health'] == "green"
                     assert content_dict['safeMode'] is False
+                    assert '1.8.2' == content_dict['version']
                     mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
                 query_patch.assert_called_once_with('statistics', payload)
             logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/fledge/ping')

--- a/tests/unit/python/fledge/services/core/api/test_common_ping.py
+++ b/tests/unit/python/fledge/services/core/api/test_common_ping.py
@@ -105,7 +105,7 @@ async def test_ping_http_allow_ping_true(aiohttp_server, aiohttp_client, loop, g
                     assert content_dict['ipAddresses'] == ip_addresses
                     assert content_dict['health'] == "green"
                     assert content_dict['safeMode'] is False
-                    assert '1.8.2' == content_dict['version']
+                    assert 'version' in content_dict
             query_patch.assert_called_once_with('statistics', payload)
         log_params = 'Received %s request for %s', 'GET', '/fledge/ping'
         logger_info.assert_called_once_with(*log_params)
@@ -157,7 +157,7 @@ async def test_ping_http_allow_ping_false(aiohttp_server, aiohttp_client, loop, 
                     assert content_dict['ipAddresses'] == ip_addresses
                     assert content_dict['health'] == "green"
                     assert content_dict['safeMode'] is False
-                    assert '1.8.2' == content_dict['version']
+                    assert 'version' in content_dict
             query_patch.assert_called_once_with('statistics', payload)
         log_params = 'Received %s request for %s', 'GET', '/fledge/ping'
         logger_info.assert_called_once_with(*log_params)
@@ -213,7 +213,7 @@ async def test_ping_http_auth_required_allow_ping_true(aiohttp_server, aiohttp_c
                     assert content_dict['ipAddresses'] == ip_addresses
                     assert content_dict['health'] == "green"
                     assert content_dict['safeMode'] is False
-                    assert '1.8.2' == content_dict['version']
+                    assert 'version' in content_dict
                 mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
             query_patch.assert_called_once_with('statistics', payload)
         log_params = 'Received %s request for %s', 'GET', '/fledge/ping'
@@ -324,7 +324,7 @@ async def test_ping_https_allow_ping_true(aiohttp_server, ssl_ctx, aiohttp_clien
                     assert content_dict['ipAddresses'] == ip_addresses
                     assert content_dict['health'] == "green"
                     assert content_dict['safeMode'] is False
-                    assert '1.8.2' == content_dict['version']
+                    assert 'version' in content_dict
             query_patch.assert_called_once_with('statistics', payload)
         logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/fledge/ping')
 
@@ -383,7 +383,7 @@ async def test_ping_https_allow_ping_false(aiohttp_server, ssl_ctx, aiohttp_clie
                     assert content_dict['hostName'] == host_name
                     assert content_dict['ipAddresses'] == ip_addresses
                     assert content_dict['health'] == "green"
-                    assert '1.8.2' == content_dict['version']
+                    assert 'version' in content_dict
             query_patch.assert_called_once_with('statistics', payload)
         logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/fledge/ping')
 
@@ -452,7 +452,7 @@ async def test_ping_https_auth_required_allow_ping_true(aiohttp_server, ssl_ctx,
                     assert content_dict['ipAddresses'] == ip_addresses
                     assert content_dict['health'] == "green"
                     assert content_dict['safeMode'] is False
-                    assert '1.8.2' == content_dict['version']
+                    assert 'version' in content_dict
                     mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
                 query_patch.assert_called_once_with('statistics', payload)
             logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/fledge/ping')


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

```
// http://192.168.1.9:8081/fledge/ping

{
  "uptime": 59,
  "dataRead": 29,
  "dataSent": 0,
  "dataPurged": 0,
  "authenticationOptional": true,
  "serviceName": "Fledge",
  "hostName": "aj",
  "ipAddresses": [
    "192.168.1.9"
  ],
  "health": "green",
  "safeMode": false,
  "version": "1.8.2"
}
```

**NOTE** -  ~Onwards with bump/next released version we need to update these tests as well (as per released version number) to make sure version info verification is fine with bumped version in /ping~