### PR TITLE
FOGL-4783 Prevent bad readings clogging up ingest queue

### DIFF
--- a/C/services/south/include/ingest.h
+++ b/C/services/south/include/ingest.h
@@ -71,6 +71,10 @@ private:
 						std::lock_guard<std::mutex> guard(m_statsMutex);
 						m_statsCv.notify_all();
 					};
+	void				logDiscardedStat() {
+						std::lock_guard<std::mutex> guard(m_statsMutex);
+						m_discardedReadings++;
+					};
 
 	StorageClient&			m_storage;
 	long				m_timeout;

--- a/C/services/south/ingest.cpp
+++ b/C/services/south/ingest.cpp
@@ -400,10 +400,11 @@ void Ingest::processQueue()
 					for (int cnt = 5; cnt > 0 && q->size() > 0; cnt--)
 					{
 						Reading *reading = q->front();
-						m_logger->warn("Remove reading: %s",
+						m_logger->info("Remove reading: %s",
 								reading->toJSON().c_str());
 						delete reading;
 						q->erase(q->begin());
+						logDiscardedStat();
 					}
 					if (q->size() == 0)
 					{


### PR DESCRIPTION
Readings that fail to insert into the storage layer cause the south service to retry them forever. This increases the memory usage of the south service and eventually causes a failure to occur when memory is exhausted.