### PR TITLE
FOGL-4883 Add support for non-string types in JSONPath matching

### DIFF
--- a/C/common/JSONPath.cpp
+++ b/C/common/JSONPath.cpp
@@ -175,7 +175,7 @@ rapidjson::Value *JSONPath::IndexPathComponent::match(rapidjson::Value *node)
 			return &n[m_index];
 		}
 	}
-	throw runtime_error("Document has no member ");
+	throw runtime_error("Document has no member " + m_name + " or it is not an array");
 }
 
 /**
@@ -207,10 +207,32 @@ rapidjson::Value *JSONPath::MatchPathComponent::match(rapidjson::Value *node)
 						if (v[m_property.c_str()].IsString() 
 								&& m_value.compare(v[m_property.c_str()].GetString()) == 0)
 							return &v;
+						if (v[m_property.c_str()].IsInt())
+						{
+							long val = v[m_property.c_str()].GetInt();
+							long tval = strtol(m_value.c_str(), NULL, 10);
+							if (val == tval)
+								return &v;
+						}
+						else if (v[m_property.c_str()].IsDouble())
+						{
+							double val = v[m_property.c_str()].GetDouble();
+							double tval = strtod(m_value.c_str(), NULL);
+							if (val == tval)
+								return &v;
+						}
+						else if (v[m_property.c_str()].IsBool())
+						{
+							bool val = v[m_property.c_str()].GetBool();
+							if (val && (m_value.compare("true") == 0 || m_value.compare("TRUE") == 0))
+								return &v;
+							if (val == false && (m_value.compare("false") == 0 || m_value.compare("FALSE") == 0))
+								return &v;
+						}
 					}
 				}
 			}
 		}
 	}
-	throw runtime_error("Document has no member ");
+	throw runtime_error(string("Document has no member ") + m_name + string(" or it does not have a ") + m_property + " property");
 }

--- a/C/common/string_utils.cpp
+++ b/C/common/string_utils.cpp
@@ -285,7 +285,6 @@ void StringEscapeQuotes(std::string& str)
 {
 	for (size_t i = 0; i < str.length(); i++)
 	{
-		Logger::getLogger()->fatal("becomes '%s'", str.c_str());
 		if (str[i] == '\"' && (i == 0 || str[i-1] != '\\'))
 		{
 			str.replace(i, 1, "\\\"");

--- a/tests/unit/C/common/test_JSONPath.cpp
+++ b/tests/unit/C/common/test_JSONPath.cpp
@@ -12,7 +12,9 @@ const char *testdoc = "{ \"a\" : { \"b\" : \"x\" }, " \
 			"\"f\" : [ { \"g\" : \"h\", \"i\" : \"j\" }, " \
 			"          { \"k\" : \"l\", \"m\" : \"n\" }, " \
 			"          { \"o\" : \"p\", \"q\" : \"r\" } ], " \
-			"\"data\" : { \"child\" : [ { \"item\" : 1 } ] } " \
+			"\"data\" : { \"child\" : [ { \"item\" : 1 } ] }, " \
+			"\"numeric\" : [ { \"id\" : 1, \"child\" : { \"item\" : 1 } }, " \
+			             " { \"id\" : 2, \"child\" : { \"item\" : 2 } } ] " \
 			"}";
 
 /**
@@ -77,3 +79,19 @@ TEST(MatchJSONPath, JSON)
 	ASSERT_TRUE(v->HasMember("m"));
 }
 
+
+/**
+ * Simple index path test
+ */
+TEST(MatchNumericJSONPath, JSON)
+{
+	string path("/numeric[id==1]/child");
+	JSONPath jpath(path);
+	Document doc;
+	doc.Parse(testdoc);
+	Value *v = jpath.findNode(doc);
+	ASSERT_TRUE(v->IsObject());
+	ASSERT_TRUE(v->HasMember("item"));
+	ASSERT_TRUE((*v)["item"].IsInt());
+	ASSERT_EQ(1, (*v)["item"].GetInt());
+}


### PR DESCRIPTION
Signed-off-by: Mark Riddoch <mark@dianomic.com>

Add support for non-string types inn JSONPath match, e.g. /device[id==1]/name,
and Improve error reporting.