### PR TITLE
FOGL-4882: memory leak fix

### DIFF
--- a/C/plugins/storage/sqlite/common/connection_manager.cpp
+++ b/C/plugins/storage/sqlite/common/connection_manager.cpp
@@ -159,6 +159,7 @@ bool ConnectionManager::attachNewDb(std::string &path, std::string &alias)
 			if (rc != SQLITE_OK)
 			{
 				Logger::getLogger()->error("attachNewDb - It was not possible to attach the db :%s: to an idle connection, error :%s:", path.c_str(), zErrMsg);
+				sqlite3_free(zErrMsg);
 				result = false;
 				break;
 			}
@@ -180,6 +181,7 @@ bool ConnectionManager::attachNewDb(std::string &path, std::string &alias)
 				if (rc != SQLITE_OK)
 				{
 					Logger::getLogger()->error("attachNewDb - It was not possible to attach the db :%s: to an inUse connection, error :%s:", path.c_str() ,zErrMsg);
+					sqlite3_free(zErrMsg);
 					result = false;
 					break;
 				}
@@ -223,6 +225,7 @@ bool ConnectionManager::detachNewDb(std::string &alias)
 			if (rc != SQLITE_OK)
 			{
 				Logger::getLogger()->error("detachNewDb - It was not possible to detach the db :%s: from an idle connection, error :%s:", alias.c_str(), zErrMsg);
+				sqlite3_free(zErrMsg);
 				result = false;
 				break;
 			}
@@ -242,6 +245,7 @@ bool ConnectionManager::detachNewDb(std::string &alias)
 				if (rc != SQLITE_OK)
 				{
 					Logger::getLogger()->error("detachNewDb - It was not possible to detach the db :%s: from an inUse connection, error :%s:", alias.c_str() ,zErrMsg);
+					sqlite3_free(zErrMsg);
 					result = false;
 					break;
 				}

--- a/C/plugins/storage/sqlite/common/include/connection.h
+++ b/C/plugins/storage/sqlite/common/include/connection.h
@@ -20,7 +20,7 @@
 #include <vector>
 #include <atomic>
 
-#define _DB_NAME                  "/fledge.sqlite"
+#define _DB_NAME                  "/fledge.db"
 #define READINGS_DB_NAME_BASE     "readings"
 #define READINGS_DB_FILE_NAME     "/" READINGS_DB_NAME_BASE "_1.db"
 #define READINGS_DB               READINGS_DB_NAME_BASE "_1"

--- a/C/plugins/storage/sqlite/common/readings.cpp
+++ b/C/plugins/storage/sqlite/common/readings.cpp
@@ -1887,6 +1887,8 @@ vector<string>  assetCodes;
 			&midRowId,
 			&zErrMsg);
 
+			delete[] query;
+
 			if (rc != SQLITE_OK)
 			{
 	 			raiseError("purge - phase 1, fetching midRowId ", zErrMsg);

--- a/C/plugins/storage/sqlite/common/readings_catalogue.cpp
+++ b/C/plugins/storage/sqlite/common/readings_catalogue.cpp
@@ -621,6 +621,7 @@ bool ReadingsCatalogue::attachDb(sqlite3 *dbHandle, std::string &path, std::stri
 	if (rc != SQLITE_OK)
 	{
 		Logger::getLogger()->error("attachDb - It was not possible to attach the db :%s: to the connection :%X:, error :%s:", path.c_str(), dbHandle, zErrMsg);
+		sqlite3_free(zErrMsg);
 		result = false;
 	}
 
@@ -646,6 +647,7 @@ void ReadingsCatalogue::detachDb(sqlite3 *dbHandle, std::string &alias)
 	if (rc != SQLITE_OK)
 	{
 		Logger::getLogger()->error("%s - It was not possible to detach the db :%s: from the connection :%X:, error :%s:", __FUNCTION__, alias.c_str(), dbHandle, zErrMsg);
+		sqlite3_free(zErrMsg);
 	}
 }
 
@@ -1985,6 +1987,7 @@ int  ReadingsCatalogue::purgeAllReadings(sqlite3 *dbHandle, const char *sqlCmdBa
 
 			if (rc != SQLITE_OK)
 			{
+				sqlite3_free(zErrMsg);
 				break;
 			}
 			if  (rowsAffected != nullptr)

--- a/C/services/storage/configuration.cpp
+++ b/C/services/storage/configuration.cpp
@@ -296,12 +296,6 @@ DefaultConfigCategory *StorageConfiguration::getDefaultCategory()
  */
 void StorageConfiguration::checkCache()
 {
-	//# FIXME_I
-	Logger::getLogger()->setMinLevel("debug");
-	Logger::getLogger()->debug("xxx2 %s ", __FUNCTION__);
-	Logger::getLogger()->setMinLevel("warning");
-
-
 	if (document->HasMember("plugin"))
 	{
 		Value& item = (*document)["plugin"];

--- a/C/services/storage/configuration.cpp
+++ b/C/services/storage/configuration.cpp
@@ -302,7 +302,7 @@ void StorageConfiguration::checkCache()
 		if (item.HasMember("type"))
 		{
 			const char *val = getValue("plugin");
-			item["default"].SetString(strdup(val), strlen(val));
+			item["default"].SetString(val, strlen(val));
 			Value& rp = (*document)["readingPlugin"];
 			const char *rval = getValue("readingPlugin");
 			rp["default"].SetString(rval, strlen(rval));

--- a/C/services/storage/configuration.cpp
+++ b/C/services/storage/configuration.cpp
@@ -296,16 +296,23 @@ DefaultConfigCategory *StorageConfiguration::getDefaultCategory()
  */
 void StorageConfiguration::checkCache()
 {
-	if (document->HasMember("plugin"))	
+	//# FIXME_I
+	Logger::getLogger()->setMinLevel("debug");
+	Logger::getLogger()->debug("xxx2 %s ", __FUNCTION__);
+	Logger::getLogger()->setMinLevel("warning");
+
+
+	if (document->HasMember("plugin"))
 	{
 		Value& item = (*document)["plugin"];
 		if (item.HasMember("type"))
 		{
 			const char *val = getValue("plugin");
-			item["default"].SetString(strdup(val), strlen(val));
+			item["default"].SetString(val, strlen(val));
+
 			Value& rp = (*document)["readingPlugin"];
 			const char *rval = getValue("readingPlugin");
-			rp["default"].SetString(strdup(rval), strlen(rval));
+			rp["default"].SetString(rval, strlen(rval));
 			logger->info("Storage configuration cache is up to date");
 			return;
 		}
@@ -327,15 +334,15 @@ void StorageConfiguration::checkCache()
 		if (hasValue(name))
 		{
 			const char *val = getValue(name);
-			newval["value"].SetString(strdup(val), strlen(val));
+			newval["value"].SetString(val, strlen(val));
 			if (strcmp(name, "plugin") == 0)
 			{
-				newval["default"].SetString(strdup(val), strlen(val));
+				newval["default"].SetString(val, strlen(val));
 				logger->warn("Set default of %s to %s", name, val);
 			}
 			if (strcmp(name, "readingPlugin") == 0)
 			{
-				newval["default"].SetString(strdup(val), strlen(val));
+				newval["default"].SetString(val, strlen(val));
 				logger->warn("Set default of %s to %s", name, val);
 			}
 		}

--- a/C/services/storage/configuration.cpp
+++ b/C/services/storage/configuration.cpp
@@ -302,8 +302,7 @@ void StorageConfiguration::checkCache()
 		if (item.HasMember("type"))
 		{
 			const char *val = getValue("plugin");
-			item["default"].SetString(val, strlen(val));
-
+			item["default"].SetString(strdup(val), strlen(val));
 			Value& rp = (*document)["readingPlugin"];
 			const char *rval = getValue("readingPlugin");
 			rp["default"].SetString(rval, strlen(rval));
@@ -328,15 +327,15 @@ void StorageConfiguration::checkCache()
 		if (hasValue(name))
 		{
 			const char *val = getValue(name);
-			newval["value"].SetString(val, strlen(val));
+			newval["value"].SetString(strdup(val), strlen(val));
 			if (strcmp(name, "plugin") == 0)
 			{
-				newval["default"].SetString(val, strlen(val));
+				newval["default"].SetString(strdup(val), strlen(val));
 				logger->warn("Set default of %s to %s", name, val);
 			}
 			if (strcmp(name, "readingPlugin") == 0)
 			{
-				newval["default"].SetString(val, strlen(val));
+				newval["default"].SetString(strdup(val), strlen(val));
 				logger->warn("Set default of %s to %s", name, val);
 			}
 		}

--- a/C/services/storage/storage.cpp
+++ b/C/services/storage/storage.cpp
@@ -265,6 +265,9 @@ void StorageService::start(string& coreAddress, unsigned short corePort)
 		{
 			sleep(2 * retryCount);
 		}
+
+		delete conf;
+
 		vector<string> children1;
 		children1.push_back(STORAGE_CATEGORY);
 		ConfigCategories categories = client->getCategories();
@@ -310,6 +313,8 @@ void StorageService::start(string& coreAddress, unsigned short corePort)
 			// Regsiter for configuration chanegs to our category
 			ConfigHandler *configHandler = ConfigHandler::getInstance(client);
 			configHandler->registerCategory(this, conf->getName());
+
+			delete conf;
 		}
 		if (readingPlugin)
 		{


### PR DESCRIPTION
Signed-off-by: Stefano <stefano@dianomic.com>

checking C unit tests:

![image](https://user-images.githubusercontent.com/4919069/106159358-fb9ed580-6184-11eb-8bc5-9f6135e7dab8.png)


valgrind output:
```
==00:00:02:09.662 24458== LEAK SUMMARY:
==00:00:02:09.662 24458==    definitely lost: 0 bytes in 0 blocks
==00:00:02:09.662 24458==    indirectly lost: 0 bytes in 0 blocks
==00:00:02:09.662 24458==      possibly lost: 625,176 bytes in 147 blocks
==00:00:02:09.662 24458==    still reachable: 5,599,860 bytes in 2,279 blocks
==00:00:02:09.662 24458==                       of which reachable via heuristic:
==00:00:02:09.662 24458==                         length64           : 635,160 bytes in 2,012 blocks
==00:00:02:09.662 24458==         suppressed: 0 bytes in 0 blocks

```

