### PR TITLE
FOGL-4611 plugins/available fixes on RPM platform when we cached available list…

### DIFF
--- a/python/fledge/services/core/api/plugins/common.py
+++ b/python/fledge/services/core/api/plugins/common.py
@@ -158,7 +158,7 @@ async def fetch_available_packages(package_type: str = "") -> tuple:
     tmp_log_output_fp = stdout_file_path.split('logs/')[:1][0] + "logs/output.txt"
     _platform = platform.platform()
     pkg_type = "" if package_type is None else package_type
-    pkg_mgt = 'apt'
+    pkg_mgt = 'yum' if 'centos' in _platform or 'redhat' in _platform else 'apt'
     ret_code = 0
     category = await server.Server._configuration_manager.get_category_all_items("Installation")
     max_update_cat_item = category['maxUpdate']
@@ -212,7 +212,7 @@ async def fetch_available_packages(package_type: str = "") -> tuple:
         os.remove(tmp_log_output_fp)
 
     # relative log file link
-    link = "log/" + stdout_file_path.split("/")[-1]
+    link = "logs/" + stdout_file_path.split("/")[-1]
     if ret_code != 0:
         raise PackageError(link)
     return available_packages, link


### PR DESCRIPTION
…; Also fixed the relative log file directory name

Signed-off-by: ashish-jabble <ashish@dianomic.com>


```
**First hit**

$ curl -sX GET http://localhost:8081/fledge/plugins/available | jq
{
  "plugins": [
    "fledge-filter-asset",
    "fledge-filter-change",
    "fledge-filter-delta",
    "fledge-filter-expression",
    "fledge-filter-fft",
    "fledge-filter-flirvalidity",
    "fledge-filter-metadata",
    "fledge-filter-python35",
    "fledge-filter-rate",
    "fledge-filter-rms",
    "fledge-filter-scale",
    "fledge-filter-scale-set",
    "fledge-filter-threshold",
    "fledge-north-harperdb",
    "fledge-north-http-north",
    "fledge-north-httpc",
    "fledge-north-kafka",
    "fledge-north-kafka-python",
    "fledge-north-opcua",
    "fledge-north-thingspeak",
    "fledge-notify-alexa",
    "fledge-notify-asset",
    "fledge-notify-blynk",
    "fledge-notify-email",
    "fledge-notify-hangouts",
    "fledge-notify-ifttt",
    "fledge-notify-python35",
    "fledge-notify-slack",
    "fledge-notify-telegram",
    "fledge-rule-average",
    "fledge-rule-outofbound",
    "fledge-rule-simple-expression",
    "fledge-south-CSV-Async",
    "fledge-south-benchmark",
    "fledge-south-cc2650",
    "fledge-south-coap",
    "fledge-south-csv",
    "fledge-south-dnp3",
    "fledge-south-expression",
    "fledge-south-flirax8",
    "fledge-south-http-south",
    "fledge-south-modbus",
    "fledge-south-modbustcp",
    "fledge-south-mqtt-sparkplug",
    "fledge-south-opcua",
    "fledge-south-openweathermap",
    "fledge-south-playback",
    "fledge-south-random",
    "fledge-south-randomwalk",
    "fledge-south-roxtec",
    "fledge-south-sensorphone",
    "fledge-south-sinusoid",
    "fledge-south-systeminfo"
  ],
  "link": "logs/210202-10-30-17-list.log"
}

**Second hit**
$ curl -sX GET http://localhost:8081/fledge/plugins/available | jq
{
  "plugins": [
    "fledge-filter-asset",
    "fledge-filter-change",
    "fledge-filter-delta",
    "fledge-filter-expression",
    "fledge-filter-fft",
    "fledge-filter-flirvalidity",
    "fledge-filter-metadata",
    "fledge-filter-python35",
    "fledge-filter-rate",
    "fledge-filter-rms",
    "fledge-filter-scale",
    "fledge-filter-scale-set",
    "fledge-filter-threshold",
    "fledge-north-harperdb",
    "fledge-north-http-north",
    "fledge-north-httpc",
    "fledge-north-kafka",
    "fledge-north-kafka-python",
    "fledge-north-opcua",
    "fledge-north-thingspeak",
    "fledge-notify-alexa",
    "fledge-notify-asset",
    "fledge-notify-blynk",
    "fledge-notify-email",
    "fledge-notify-hangouts",
    "fledge-notify-ifttt",
    "fledge-notify-python35",
    "fledge-notify-slack",
    "fledge-notify-telegram",
    "fledge-rule-average",
    "fledge-rule-outofbound",
    "fledge-rule-simple-expression",
    "fledge-south-CSV-Async",
    "fledge-south-benchmark",
    "fledge-south-cc2650",
    "fledge-south-coap",
    "fledge-south-csv",
    "fledge-south-dnp3",
    "fledge-south-expression",
    "fledge-south-flirax8",
    "fledge-south-http-south",
    "fledge-south-modbus",
    "fledge-south-modbustcp",
    "fledge-south-mqtt-sparkplug",
    "fledge-south-opcua",
    "fledge-south-openweathermap",
    "fledge-south-playback",
    "fledge-south-random",
    "fledge-south-randomwalk",
    "fledge-south-roxtec",
    "fledge-south-sensorphone",
    "fledge-south-sinusoid",
    "fledge-south-systeminfo"
  ],
  "link": "logs/210202-10-30-18-list.log"
}

**Third attempt**
$ curl -sX GET http://localhost:8081/fledge/plugins/available | jq
{
  "plugins": [
    "fledge-filter-asset",
    "fledge-filter-change",
    "fledge-filter-delta",
    "fledge-filter-expression",
    "fledge-filter-fft",
    "fledge-filter-flirvalidity",
    "fledge-filter-metadata",
    "fledge-filter-python35",
    "fledge-filter-rate",
    "fledge-filter-rms",
    "fledge-filter-scale",
    "fledge-filter-scale-set",
    "fledge-filter-threshold",
    "fledge-north-harperdb",
    "fledge-north-http-north",
    "fledge-north-httpc",
    "fledge-north-kafka",
    "fledge-north-kafka-python",
    "fledge-north-opcua",
    "fledge-north-thingspeak",
    "fledge-notify-alexa",
    "fledge-notify-asset",
    "fledge-notify-blynk",
    "fledge-notify-email",
    "fledge-notify-hangouts",
    "fledge-notify-ifttt",
    "fledge-notify-python35",
    "fledge-notify-slack",
    "fledge-notify-telegram",
    "fledge-rule-average",
    "fledge-rule-outofbound",
    "fledge-rule-simple-expression",
    "fledge-south-CSV-Async",
    "fledge-south-benchmark",
    "fledge-south-cc2650",
    "fledge-south-coap",
    "fledge-south-csv",
    "fledge-south-dnp3",
    "fledge-south-expression",
    "fledge-south-flirax8",
    "fledge-south-http-south",
    "fledge-south-modbus",
    "fledge-south-modbustcp",
    "fledge-south-mqtt-sparkplug",
    "fledge-south-opcua",
    "fledge-south-openweathermap",
    "fledge-south-playback",
    "fledge-south-random",
    "fledge-south-randomwalk",
    "fledge-south-roxtec",
    "fledge-south-sensorphone",
    "fledge-south-sinusoid",
    "fledge-south-systeminfo"
  ],
  "link": "logs/210202-10-30-20-list.log"
}
```

**Content**
```
$ cat /usr/local/fledge/data/logs/210202-10-30-17-list.log 
fledge-filter-asset 
fledge-filter-change 
fledge-filter-delta 
fledge-filter-expression 
fledge-filter-fft 
fledge-filter-flirvalidity 
fledge-filter-metadata 
fledge-filter-python35 
fledge-filter-rate 
fledge-filter-rms 
fledge-filter-scale 
fledge-filter-scale-set 
fledge-filter-threshold 
fledge-gui 
fledge-north-harperdb 
fledge-north-http-north 
fledge-north-httpc 
fledge-north-kafka 
fledge-north-kafka-python 
fledge-north-opcua 
fledge-north-thingspeak 
fledge-notify-alexa 
fledge-notify-asset 
fledge-notify-blynk 
fledge-notify-email 
fledge-notify-hangouts 
fledge-notify-ifttt 
fledge-notify-python35 
fledge-notify-slack 
fledge-notify-telegram 
fledge-rule-average 
fledge-rule-outofbound 
fledge-rule-simple-expression 
fledge-service-notification 
fledge-south-CSV-Async 
fledge-south-benchmark 
fledge-south-cc2650 
fledge-south-coap 
fledge-south-csv 
fledge-south-dnp3 
fledge-south-expression 
fledge-south-flirax8 
fledge-south-http-south 
fledge-south-modbus 
fledge-south-modbustcp 
fledge-south-mqtt-sparkplug 
fledge-south-opcua 
fledge-south-openweathermap 
fledge-south-playback 
fledge-south-random 
fledge-south-randomwalk 
fledge-south-roxtec 
fledge-south-sensorphone 
fledge-south-sinusoid 
```