### PR TITLE
FOGL-5053: Added the schema while creating the packages table

### DIFF
--- a/scripts/plugins/storage/postgres/init.sql
+++ b/scripts/plugins/storage/postgres/init.sql
@@ -760,7 +760,7 @@ CREATE TABLE fledge.plugin_data (
 	CONSTRAINT plugin_data_pkey PRIMARY KEY (key) );
 
 -- Create packages table
-CREATE TABLE packages (
+CREATE TABLE fledge.packages (
              id                uuid                   NOT NULL, -- PK
              name              character varying(255) NOT NULL, -- Package name
              action            character varying(10)  NOT NULL, -- APT actions:

--- a/scripts/plugins/storage/sqlite/init.sql
+++ b/scripts/plugins/storage/sqlite/init.sql
@@ -560,7 +560,7 @@ CREATE TABLE fledge.plugin_data (
 	CONSTRAINT plugin_data_pkey PRIMARY KEY (key) );
 
 -- Create packages table
-CREATE TABLE packages (
+CREATE TABLE fledge.packages (
              id                uuid                   NOT NULL, -- PK
              name              character varying(255) NOT NULL, -- Package name
              action            character varying(10) NOT NULL, -- APT actions:


### PR DESCRIPTION
Note: For sqlite init.sql added the schema details for the sake of consistency although it is not required.