### PR TITLE
FOGL-5216 Workaround removal from doc script; instead should fix it from plugin…

### DIFF
--- a/docs/scripts/plugin_documentation
+++ b/docs/scripts/plugin_documentation
@@ -116,5 +116,3 @@ ln -s ../../images plugins/fledge-north-OMF/images
 sed -e 's|OMF.rst|../../OMF.rst|' < fledge-north-OMF.rst > plugins/fledge-north-OMF/index.rst
 mkdir plugins/fledge-rule-Threshold
 cp -r fledge-rule-Threshold/* plugins/fledge-rule-Threshold/.
-
-ln -s plugins/fledge-south-lathe plugins/fledge-south-lathesim


### PR DESCRIPTION
… itself as GUI client relies on plugin installed directory when we clicked on help icon from dropdown list

Signed-off-by: ashish-jabble <ashish@dianomic.com>


Related plugin PR https://github.com/fledge-iot/fledge-south-lathesim/pull/5