### PR TITLE
FOGL-5439: avoid handling unsupported types

### DIFF
--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -2901,11 +2901,7 @@ void OMF::setMapObjectTypes(const vector<Reading*>& readings,
 			if (!isTypeSupported((*it)->getData()))
 			{
 				omfType = OMF_TYPE_UNSUPPORTED;
-
-				//# FIXME_I
-				Logger::getLogger()->setMinLevel("debug");
-				Logger::getLogger()->debug("xxx2 v2 - The type of the datapoint " + assetName + "/" + datapointName + " is unsupported, it will be ignored");
-				Logger::getLogger()->setMinLevel("warning");
+				Logger::getLogger()->debug("%s - The type of the datapoint " + assetName + "/" + datapointName + " is unsupported, it will be ignored", __FUNCTION__);
 			}
 			else
 			{
@@ -3003,15 +2999,12 @@ void OMF::setMapObjectTypes(const vector<Reading*>& readings,
 			}
 			else if ((*dp).second.compare(OMF_TYPE_UNSUPPORTED) == 0)
 			{
-				//# FIXME_I
-				Logger::getLogger()->setMinLevel("debug");
-				Logger::getLogger()->debug("xxx3 v3 - Asset '" + assetName + " has unsupported type, those datapoint will be ignored");
-				Logger::getLogger()->setMinLevel("warning");
+				Logger::getLogger()->debug("%s - The asset '" + assetName + " has a datapoint having an unsupported type, it will be ignored", __FUNCTION__);
 
-				// FIXME_I:
-//				std::vector<double> vData = {0};
-//				DatapointValue vArray(vData);
-//				values.push_back(new Datapoint((*dp).first, vArray));
+				// Avoids to handled PI-Server unsupported datapoint type
+				// std::vector<double> vData = {0};
+				// DatapointValue vArray(vData);
+				// values.push_back(new Datapoint((*dp).first, vArray));
 			}
 		}
 

--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -2872,7 +2872,7 @@ bool OMF::handleTypeErrors(const string& keyComplete, const Reading& reading, OM
  * @param    dataSuperSet	Map to store all datapoints for an assetname
  */
 void OMF::setMapObjectTypes(const vector<Reading*>& readings,
-							std::map<std::string, Reading*>& dataSuperSet)
+			    std::map<std::string, Reading*>& dataSuperSet)
 {
 	// Temporary map for [asset][datapoint] = type
 	std::map<string, map<string, string>> readingAllDataPoints;
@@ -2880,8 +2880,8 @@ void OMF::setMapObjectTypes(const vector<Reading*>& readings,
 	// Fetch ALL Reading pointers in the input vector
 	// and create a map of [assetName][datapoint1 .. datapointN] = type
 	for (vector<Reading *>::const_iterator elem = readings.begin();
-		 elem != readings.end();
-		 ++elem)
+						elem != readings.end();
+						++elem)
 	{
 		// Get asset name
 		string assetName = ApplyPIServerNamingRulesObj((**elem).getAssetName(), nullptr);
@@ -2892,8 +2892,8 @@ void OMF::setMapObjectTypes(const vector<Reading*>& readings,
 		const vector<Datapoint*> data = (**elem).getReadingData();
 		// Iterate through datapoints
 		for (vector<Datapoint*>::const_iterator it = data.begin();
-			 it != data.end();
-			 ++it)
+							it != data.end();
+							++it)
 		{
 			string omfType;
 			string datapointName = (*it)->getName();
@@ -2976,15 +2976,15 @@ void OMF::setMapObjectTypes(const vector<Reading*>& readings,
 
 	// Loop now only the elements found in the per asset types map
 	for (auto it = readingAllDataPoints.begin();
-		 it != readingAllDataPoints.end();
-		 ++it)
+		  it != readingAllDataPoints.end();
+		  ++it)
 	{
 		string assetName = (*it).first;
 		vector<Datapoint *> values;
 		// Set fake datapoints values
 		for (auto dp = (*it).second.begin();
-			 dp != (*it).second.end();
-			 ++dp)
+			  dp != (*it).second.end();
+			  ++dp)
 		{
 			if ((*dp).second.compare(OMF_TYPE_FLOAT) == 0)
 			{


### PR DESCRIPTION
Signed-off-by: Stefano <stefano@dianomic.com>

Log samples
```
North_Readings_to_PI[22905]: DEBUG: setMapObjectTypes - The type of the datapoint tuesday/maxPosition is unsupported, it will be ignored
North_Readings_to_PI[22905]: DEBUG: setMapObjectTypes - The type of the datapoint tuesday/minPosition is unsupported, it will be ignored

```

![image](https://user-images.githubusercontent.com/4919069/118149769-2817ee00-b412-11eb-9781-171237c9ae11.png)


![image](https://user-images.githubusercontent.com/4919069/118150857-4df1c280-b413-11eb-9188-d023a4d9b640.png)
