### PR TITLE
FOGL-5490 deleteNestedDPV called twice, once from Datapoint destructor

### DIFF
--- a/C/common/include/datapoint.h
+++ b/C/common/include/datapoint.h
@@ -82,7 +82,6 @@ class DatapointValue {
 		 */
 		~DatapointValue();
 
-		void deleteNestedDPV();
 		
 		/**
 		 * Set the value of a datapoint, this may
@@ -175,6 +174,7 @@ class DatapointValue {
 		}
 
 	private:
+		void deleteNestedDPV();
 		union data_t {
 			std::string*		str;
 			long			i;
@@ -200,7 +200,6 @@ class Datapoint {
 
 		~Datapoint()
 		{
-			m_value.deleteNestedDPV();
 		}
 		/**
 		 * Return asset reading data point as a JSON


### PR DESCRIPTION
and once from DatapointValue destructor

Signed-off-by: Mark Riddoch <mark@dianomic.com>