### PR TITLE
FOGL-5546 support added for binary .der format in cert store API

### DIFF
--- a/python/fledge/services/core/api/certificate_store.py
+++ b/python/fledge/services/core/api/certificate_store.py
@@ -41,11 +41,12 @@ async def get_certs(request):
     keys = []
 
     key_valid_extensions = ('.key', '.pem')
+    short_cert_name_valid_extensions = ('.cert', '.cer', '.crt', '.der')
     certs_root_dir = _get_certs_dir('/etc/certs')
     for root, dirs, files in os.walk(certs_root_dir):
         if not root.endswith(("pem", "json")):
             for f in files:
-                if f.endswith('.cert') or f.endswith('.cer') or f.endswith('.crt'):
+                if f.endswith(short_cert_name_valid_extensions):
                     certs.append(f)
                 if f.endswith(key_valid_extensions):
                     keys.append(f)
@@ -75,6 +76,7 @@ async def upload(request):
         curl -F "cert=@filename.cert" http://localhost:8081/fledge/certificate
         curl -F "cert=@filename.cer" http://localhost:8081/fledge/certificate
         curl -F "cert=@filename.crt" http://localhost:8081/fledge/certificate
+        curl -F "cert=@filename.der" http://localhost:8081/fledge/certificate
         curl -F "key=@filename.key" -F "cert=@filename.cert" -F "overwrite=1" http://localhost:8081/fledge/certificate
     """
     data = await request.post()
@@ -118,7 +120,7 @@ async def upload(request):
             raise web.HTTPForbidden(reason=msg, body=json.dumps({"message": msg}))
 
     key_valid_extensions = ('.key', '.pem')
-    cert_valid_extensions = ('.cert', '.cer', '.crt', '.json', '.pem')
+    cert_valid_extensions = ('.cert', '.cer', '.crt', '.der', '.json', '.pem')
 
     key_filename = None
     if key_file:
@@ -175,13 +177,14 @@ async def delete_certificate(request):
           curl -X DELETE http://localhost:8081/fledge/certificate/user.cert
           curl -X DELETE http://localhost:8081/fledge/certificate/filename.cer
           curl -X DELETE http://localhost:8081/fledge/certificate/filename.crt
+          curl -sX DELETE http://localhost:8081/fledge/certificate/filename.der
           curl -X DELETE http://localhost:8081/fledge/certificate/fledge.json?type=cert
           curl -X DELETE http://localhost:8081/fledge/certificate/fledge.pem?type=cert
           curl -X DELETE http://localhost:8081/fledge/certificate/fledge.pem
           curl -X DELETE http://localhost:8081/fledge/certificate/fledge.pem?type=key
     """
     file_name = request.match_info.get('name', None)
-    valid_extensions = ('.cert', '.cer', '.crt', '.json', '.key', '.pem')
+    valid_extensions = ('.cert', '.cer', '.crt', '.der', '.json', '.key', '.pem')
     if not file_name.endswith(valid_extensions):
         msg = "Accepted file extensions are {}".format(valid_extensions)
         raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
@@ -211,7 +214,7 @@ async def delete_certificate(request):
     cert_path = list()
 
     if _type and _type == 'cert':
-        short_cert_name_valid_extensions = ('.cert', '.cer', '.crt')
+        short_cert_name_valid_extensions = ('.cert', '.cer', '.crt', '.der')
         if not file_name.endswith(short_cert_name_valid_extensions):
             if os.path.isfile(certs_dir + 'pem/' + file_name):
                 is_found = True

--- a/tests/unit/python/fledge/services/core/api/test_certificate_store.py
+++ b/tests/unit/python/fledge/services/core/api/test_certificate_store.py
@@ -115,7 +115,7 @@ class TestCertificateStore:
         assert 'Cert file is missing' == resp.reason
 
     async def test_bad_extension_cert_file_upload(self, client, certs_path):
-        cert_valid_extensions = ('.cert', '.cer', '.crt', '.json', '.pem')
+        cert_valid_extensions = ('.cert', '.cer', '.crt', '.der', '.json', '.pem')
         files = {'cert': open(str(certs_path / 'certs/fledge.txt'), 'rb'),
                  'key': open(str(certs_path / 'certs/fledge.key'), 'rb')}
         resp = await client.post('/fledge/certificate', data=files)
@@ -161,7 +161,7 @@ class TestCertificateStore:
             patch_get_cat_all_items.assert_called_once_with(category_name='rest_api')
 
     @pytest.mark.parametrize("cert_name, actual_code, actual_reason", [
-        ('root.txt', 400, "Accepted file extensions are ('.cert', '.cer', '.crt', '.json', '.key', '.pem')")
+        ('root.txt', 400, "Accepted file extensions are ('.cert', '.cer', '.crt', '.der', '.json', '.key', '.pem')")
     ])
     async def test_bad_delete_cert(self, client, cert_name, actual_code, actual_reason):
         resp = await client.delete('/fledge/certificate/{}'.format(cert_name))
@@ -499,7 +499,7 @@ class TestDeleteCertStoreIfAuthenticationIsMandatory:
                                                   '/fledge/certificate/{}'.format(cert_name))
 
     @pytest.mark.parametrize("cert_name, actual_code, actual_reason", [
-        ('root.txt', 400, "Accepted file extensions are ('.cert', '.cer', '.crt', '.json', '.key', '.pem')")
+        ('root.txt', 400, "Accepted file extensions are ('.cert', '.cer', '.crt', '.der', '.json', '.key', '.pem')")
     ])
     async def test_bad_delete_cert(self, client, mocker, cert_name, actual_code, actual_reason):
         patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

**Example**
1) Upload **.der** binary cert
```
$ curl -F "cert=@aj.der" http://localhost:8081/fledge/certificate
  {"result": "aj.der has been uploaded successfully"}
```
2) Get certs - See **aj.der** entry is there
```
$ curl -sX GET http://localhost:8081/fledge/certificate | jq
{
  "certs": [
    "user.cert",
    "ca.cert",
    "fledge.cert",
    "aj.der",
    "admin.cert",
    "fledge.pem"
  ],
  "keys": [
    "admin.key",
    "ca.key",
    "fledge.key",
    "user.key"
  ]
}

```
3) DELETE **aj.der** cert

```
$ curl -sX DELETE http://localhost:8081/fledge/certificate/aj.der | jq
{
  "result": "aj.der has been deleted successfully"
}
```

4) GET certs - There is no **aj.der** entry exists after deletion

```
$ curl -sX GET http://localhost:8081/fledge/certificate | jq
{
  "certs": [
    "user.cert",
    "ca.cert",
    "fledge.cert",
    "admin.cert",
    "fledge.pem"
  ],
  "keys": [
    "admin.key",
    "ca.key",
    "fledge.key",
    "user.key"
  ]
}
```

**NOTE** - Backend API done.
We need to add support in GUI as well, client-side validations check.