### PR TITLE
FOGL-5480 more short cert extensions support added in certificate store API

### DIFF
--- a/python/fledge/services/core/api/certificate_store.py
+++ b/python/fledge/services/core/api/certificate_store.py
@@ -41,7 +41,7 @@ async def get_certs(request):
     keys = []
 
     key_valid_extensions = ('.key', '.pem')
-    short_cert_name_valid_extensions = ('.cert', '.cer', '.crt', '.der')
+    short_cert_name_valid_extensions = ('.cert', '.cer', '.csr', '.crl', '.crt', '.der', '.p12', '.pfx')
     certs_root_dir = _get_certs_dir('/etc/certs')
     for root, dirs, files in os.walk(certs_root_dir):
         if not root.endswith(("pem", "json")):
@@ -75,8 +75,12 @@ async def upload(request):
         curl -F "key=@filename.key" -F "cert=@filename.cert" http://localhost:8081/fledge/certificate
         curl -F "cert=@filename.cert" http://localhost:8081/fledge/certificate
         curl -F "cert=@filename.cer" http://localhost:8081/fledge/certificate
+        curl -F "cert=@filename.csr" http://localhost:8081/fledge/certificate
+        curl -F "cert=@filename.crl" http://localhost:8081/fledge/certificate
         curl -F "cert=@filename.crt" http://localhost:8081/fledge/certificate
         curl -F "cert=@filename.der" http://localhost:8081/fledge/certificate
+        curl -F "cert=@filename.p12" http://localhost:8081/fledge/certificate
+        curl -F "cert=@filename.pfx" http://localhost:8081/fledge/certificate
         curl -F "key=@filename.key" -F "cert=@filename.cert" -F "overwrite=1" http://localhost:8081/fledge/certificate
     """
     data = await request.post()
@@ -120,7 +124,7 @@ async def upload(request):
             raise web.HTTPForbidden(reason=msg, body=json.dumps({"message": msg}))
 
     key_valid_extensions = ('.key', '.pem')
-    cert_valid_extensions = ('.cert', '.cer', '.crt', '.der', '.json', '.pem')
+    cert_valid_extensions = ('.cert', '.cer', '.csr', '.crl', '.crt', '.der', '.json', '.pem', '.p12', '.pfx')
 
     key_filename = None
     if key_file:
@@ -176,15 +180,20 @@ async def delete_certificate(request):
           curl -X DELETE http://localhost:8081/fledge/certificate/user.key
           curl -X DELETE http://localhost:8081/fledge/certificate/user.cert
           curl -X DELETE http://localhost:8081/fledge/certificate/filename.cer
+          curl -X DELETE http://localhost:8081/fledge/certificate/filename.csr
+          curl -X DELETE http://localhost:8081/fledge/certificate/filename.crl
           curl -X DELETE http://localhost:8081/fledge/certificate/filename.crt
           curl -sX DELETE http://localhost:8081/fledge/certificate/filename.der
+          curl -X DELETE http://localhost:8081/fledge/certificate/filename.p12
+          curl -X DELETE http://localhost:8081/fledge/certificate/filename.pfx
           curl -X DELETE http://localhost:8081/fledge/certificate/fledge.json?type=cert
           curl -X DELETE http://localhost:8081/fledge/certificate/fledge.pem?type=cert
           curl -X DELETE http://localhost:8081/fledge/certificate/fledge.pem
           curl -X DELETE http://localhost:8081/fledge/certificate/fledge.pem?type=key
     """
     file_name = request.match_info.get('name', None)
-    valid_extensions = ('.cert', '.cer', '.crt', '.der', '.json', '.key', '.pem')
+    valid_extensions = ('.cert', '.cer', '.csr', '.crl', '.crt', '.der', '.json', '.key', '.pem', '.p12', '.pfx')
+
     if not file_name.endswith(valid_extensions):
         msg = "Accepted file extensions are {}".format(valid_extensions)
         raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
@@ -214,7 +223,7 @@ async def delete_certificate(request):
     cert_path = list()
 
     if _type and _type == 'cert':
-        short_cert_name_valid_extensions = ('.cert', '.cer', '.crt', '.der')
+        short_cert_name_valid_extensions = ('.cert', '.cer', '.csr', '.crl', '.crt', '.der', '.p12', '.pfx')
         if not file_name.endswith(short_cert_name_valid_extensions):
             if os.path.isfile(certs_dir + 'pem/' + file_name):
                 is_found = True

--- a/tests/unit/python/fledge/services/core/api/test_certificate_store.py
+++ b/tests/unit/python/fledge/services/core/api/test_certificate_store.py
@@ -115,7 +115,7 @@ class TestCertificateStore:
         assert 'Cert file is missing' == resp.reason
 
     async def test_bad_extension_cert_file_upload(self, client, certs_path):
-        cert_valid_extensions = ('.cert', '.cer', '.crt', '.der', '.json', '.pem')
+        cert_valid_extensions = ('.cert', '.cer', '.csr', '.crl', '.crt', '.der', '.json', '.pem', '.p12', '.pfx')
         files = {'cert': open(str(certs_path / 'certs/fledge.txt'), 'rb'),
                  'key': open(str(certs_path / 'certs/fledge.key'), 'rb')}
         resp = await client.post('/fledge/certificate', data=files)
@@ -161,7 +161,8 @@ class TestCertificateStore:
             patch_get_cat_all_items.assert_called_once_with(category_name='rest_api')
 
     @pytest.mark.parametrize("cert_name, actual_code, actual_reason", [
-        ('root.txt', 400, "Accepted file extensions are ('.cert', '.cer', '.crt', '.der', '.json', '.key', '.pem')")
+        ('root.txt', 400, "Accepted file extensions are "
+                          "('.cert', '.cer', '.csr', '.crl', '.crt', '.der', '.json', '.key', '.pem', '.p12', '.pfx')")
     ])
     async def test_bad_delete_cert(self, client, cert_name, actual_code, actual_reason):
         resp = await client.delete('/fledge/certificate/{}'.format(cert_name))
@@ -499,7 +500,8 @@ class TestDeleteCertStoreIfAuthenticationIsMandatory:
                                                   '/fledge/certificate/{}'.format(cert_name))
 
     @pytest.mark.parametrize("cert_name, actual_code, actual_reason", [
-        ('root.txt', 400, "Accepted file extensions are ('.cert', '.cer', '.crt', '.der', '.json', '.key', '.pem')")
+        ('root.txt', 400, "Accepted file extensions are "
+                          "('.cert', '.cer', '.csr', '.crl', '.crt', '.der', '.json', '.key', '.pem', '.p12', '.pfx')")
     ])
     async def test_bad_delete_cert(self, client, mocker, cert_name, actual_code, actual_reason):
         patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

**Curl Examples**
1) $ curl -F "cert=@aj.p" http://localhost:8081/fledge/certificate
```
400: Accepted file extensions are ('.cert', '.cer', '.csr', '.crl', '.crt', '.der', '.json', '.pem', '.p12', '.pfx') for cert file
```
2) $ curl -sF "cert=@aj.crl" http://localhost:8081/fledge/certificate | jq
```
{
  "result": "aj.crl has been uploaded successfully"
}
```
3) $ curl -sF "cert=@aj.csr" http://localhost:8081/fledge/certificate | jq
```
{
  "result": "aj.csr has been uploaded successfully"
}
```
4) $ curl -sF "cert=@aj.p12" http://localhost:8081/fledge/certificate | jq
```
{
  "result": "aj.p12 has been uploaded successfully"
}
```
5) $ curl -sF "cert=@aj.pfx" http://localhost:8081/fledge/certificate | jq
```
{
  "result": "aj.pfx has been uploaded successfully"
}
```
6) $ curl -sF "cert=@aj.der" http://localhost:8081/fledge/certificate
```
400: Certificate with the same name already exists! To overwrite, set the overwrite flag
``` 
7) $ curl -sX GET http://localhost:8081/fledge/certificate | jq
```
{
  "certs": [
    "user.cert",
    "ca.cert",
    "fledge.cert",
    "aj.csr",
    "user.csr",
    "aj.der",
    "aj.crl",
    "fledge.csr",
    "admin.cert",
    "admin.csr",
    "aj.pfx",
    "aj.p12",
    "fledge.pem"
  ],
  "keys": [
    "admin.key",
    "ca.key",
    "fledge.key",
    "user.key"
  ]
}
```
8) $ curl -sX DELETE http://localhost:8081/fledge/certificate/aj.blah
```
{"message": "Accepted file extensions are ('.cert', '.cer', '.csr', '.crl', '.crt', '.der', '.json', '.key', '.pem', '.p12', '.pfx')"}
```
9) $ curl -sX DELETE http://localhost:8081/fledge/certificate/aj.der | jq
```
{
  "result": "aj.der has been deleted successfully"
}
```
10) $ curl -sX DELETE http://localhost:8081/fledge/certificate/aj.der
```
{"message": "Certificate with name aj.der does not exist"}
```
11) $ curl -sX DELETE http://localhost:8081/fledge/certificate/aj.csr | jq
```
{
  "result": "aj.csr has been deleted successfully"
}
```
12) $ curl -sX DELETE http://localhost:8081/fledge/certificate/aj.crl | jq
```
{
  "result": "aj.crl has been deleted successfully"
}
```
13) $ curl -sX DELETE http://localhost:8081/fledge/certificate/aj.p12 | jq
```
{
  "result": "aj.p12 has been deleted successfully"
}
```
14) $ curl -sX DELETE http://localhost:8081/fledge/certificate/aj.pfx | jq
```
{
  "result": "aj.pfx has been deleted successfully"
}
```
15) $ curl -sX GET http://localhost:8081/fledge/certificate | jq
```
{
  "certs": [
    "user.cert",
    "ca.cert",
    "fledge.cert",
    "user.csr",
    "fledge.csr",
    "admin.cert",
    "admin.csr",
    "fledge.pem"
  ],
  "keys": [
    "admin.key",
    "ca.key",
    "fledge.key",
    "user.key"
  ]
}
```