### PR TITLE
FOGL-5474: System test for OMF as north service

### DIFF
--- a/tests/system/python/conftest.py
+++ b/tests/system/python/conftest.py
@@ -213,8 +213,8 @@ def start_north_pi_v2_web_api():
 
 
 @pytest.fixture
-def start_north_pi_v2_web_api_service():
-    def _start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_db="Dianomic", auth_method='basic',
+def start_north_omf_as_a_service():    
+    def _start_north_omf_as_a_service(fledge_url, pi_host, pi_port, pi_db="Dianomic", auth_method='basic',
                                          pi_user=None, pi_pwd=None, north_plugin="OMF",
                                          service_name="NorthReadingsToPI_WebAPI", start=True):
         """Start north service"""
@@ -241,12 +241,11 @@ def start_north_pi_v2_web_api_service():
         assert 200 == r.status
         retval = json.loads(r.read().decode())
         return retval
-    return _start_north_pi_server_c_web_api_service
+    return _start_north_omf_as_a_service
 
 
 start_north_pi_server_c = start_north_pi_v2
 start_north_pi_server_c_web_api = start_north_pi_v2_web_api
-start_north_pi_server_c_web_api_service = start_north_pi_v2_web_api_service
 
 @pytest.fixture
 def read_data_from_pi():

--- a/tests/system/python/conftest.py
+++ b/tests/system/python/conftest.py
@@ -18,6 +18,7 @@ import ssl
 import shutil
 import pytest
 from urllib.parse import quote
+from pathlib import Path
 
 __author__ = "Vaibhav Singhal"
 __copyright__ = "Copyright (c) 2019 Dianomic Systems"
@@ -30,18 +31,21 @@ sys.path.append(os.path.join(os.path.dirname(__file__)))
 
 @pytest.fixture
 def clean_setup_fledge_packages(package_build_version):
-    assert os.environ.get('FLEDGE_ROOT') is not None
+    # This  gives the path of directory where fledge is cloned. conftest_file < python < system < tests < ROOT
+    PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
+    SCRIPTS_DIR_ROOT = "{}/tests/system/python/scripts/package/".format(PROJECT_ROOT)
 
     try:
-        subprocess.run(["cd $FLEDGE_ROOT/tests/system/lab && ./remove"], shell=True, check=True)
+        subprocess.run(["cd {} && ./remove"
+                       .format(SCRIPTS_DIR_ROOT)], shell=True, check=True)    
     except subprocess.CalledProcessError:
         assert False, "remove package script failed!"
 
     try:
-        subprocess.run(["$FLEDGE_ROOT/tests/system/python/scripts/package/setup {}".format(package_build_version)],
-                       shell=True, check=True)
+        subprocess.run(["cd {} && ./setup {}"
+                       .format(SCRIPTS_DIR_ROOT, package_build_version)], shell=True, check=True)
     except subprocess.CalledProcessError:
-        assert False, "install package script failed"
+        assert False, "setup package script failed"
 
 
 @pytest.fixture
@@ -208,8 +212,41 @@ def start_north_pi_v2_web_api():
     return _start_north_pi_server_c_web_api
 
 
+@pytest.fixture
+def start_north_pi_v2_web_api_service():
+    def _start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_db="Dianomic", auth_method='basic',
+                                         pi_user=None, pi_pwd=None, north_plugin="OMF",
+                                         service_name="NorthReadingsToPI_WebAPI", start=True):
+        """Start north service"""
+
+        _enabled = True if start else False
+        conn = http.client.HTTPConnection(fledge_url)
+        data = {"name": service_name,
+                "plugin": "{}".format(north_plugin),
+                "enabled": _enabled,
+                "type": "north",
+                "config": {"PIServerEndpoint": {"value": "PI Web API"},
+                           "PIWebAPIAuthenticationMethod": {"value": auth_method},
+                           "PIWebAPIUserId":  {"value": pi_user},
+                           "PIWebAPIPassword": {"value": pi_pwd},
+                           "ServerHostname": {"value": pi_host},
+                           "ServerPort": {"value": str(pi_port)},
+                           "compression": {"value": "true"},
+                           "DefaultAFLocation": {"value": "fledge/room1/machine1"}
+                           }
+                }
+
+        conn.request("POST", '/fledge/service', json.dumps(data))
+        r = conn.getresponse()
+        assert 200 == r.status
+        retval = json.loads(r.read().decode())
+        return retval
+    return _start_north_pi_server_c_web_api_service
+
+
 start_north_pi_server_c = start_north_pi_v2
 start_north_pi_server_c_web_api = start_north_pi_v2_web_api
+start_north_pi_server_c_web_api_service = start_north_pi_v2_web_api_service
 
 @pytest.fixture
 def read_data_from_pi():
@@ -393,7 +430,7 @@ def read_data_from_pi_web_api():
 
 @pytest.fixture
 def add_filter():
-    def _add_filter(filter_plugin, filter_plugin_branch, filter_name, filter_config, fledge_url, filter_user_svc_task):
+    def _add_filter(filter_plugin, filter_plugin_branch, filter_name, filter_config, fledge_url, filter_user_svc_task, installation_type='make'):
         """
 
         :param filter_plugin: filter plugin `fledge-filter-?`
@@ -404,11 +441,21 @@ def add_filter():
         :param filter_user_svc_task: south service or north task instance name
         """
 
-        try:
-            subprocess.run(["$FLEDGE_ROOT/tests/system/python/scripts/install_c_plugin {} filter {}".format(
-                filter_plugin_branch, filter_plugin)], shell=True, check=True)
-        except subprocess.CalledProcessError:
-            assert False, "{} filter plugin installation failed".format(filter_plugin)
+        if installation_type == 'make':
+            try:
+                subprocess.run(["$FLEDGE_ROOT/tests/system/python/scripts/install_c_plugin {} filter {}".format(
+                    filter_plugin_branch, filter_plugin)], shell=True, check=True)
+            except subprocess.CalledProcessError:
+                assert False, "{} filter plugin installation failed".format(filter_plugin)
+        elif installation_type == 'package':
+            try:
+                os_platform = platform.platform()
+                pkg_mgr = 'yum' if 'centos' in os_platform or 'redhat' in os_platform else 'apt'
+                subprocess.run(["sudo {} install -y fledge-filter-{}".format(pkg_mgr, filter_plugin)], shell=True, check=True)
+            except subprocess.CalledProcessError:
+                assert False, "{} package installation failed!".format(filter_plugin)
+        else:
+            print("Skipped {} plugin installation. Installation mechanism is set to {}.".format(filter_plugin, installation_type))
 
         data = {"name": "{}".format(filter_name), "plugin": "{}".format(filter_plugin), "filter_config": filter_config}
         conn = http.client.HTTPConnection(fledge_url)

--- a/tests/system/python/helpers/utils.py
+++ b/tests/system/python/helpers/utils.py
@@ -56,3 +56,12 @@ def put_request(fledge_url, put_url, payload = None):
     assert 200 == res.status, "ERROR! PUT {} request failed".format(put_url)
     r = json.loads(res.read().decode())
     return r
+
+
+def delete_request(fledge_url, delete_url):
+    con = http.client.HTTPConnection(fledge_url)
+    con.request("DELETE", delete_url)
+    res = con.getresponse()
+    assert 200 == res.status, "ERROR! GET {} request failed".format(delete_url)
+    r = json.loads(res.read().decode())
+    return r

--- a/tests/system/python/packages/test_omf_north_service.py
+++ b/tests/system/python/packages/test_omf_north_service.py
@@ -1,0 +1,304 @@
+# FLEDGE_BEGIN
+# See: http://fledge-iot.readthedocs.io/
+# FLEDGE_END
+
+""" Test OMF North Service System tests:
+        Tests OMF as a north service along with reconfiguration.
+"""
+
+__author__ = "Yash Tatkondawar"
+__copyright__ = "Copyright (c) 2021 Dianomic Systems, Inc."
+
+import subprocess
+import http.client
+import json
+import os
+import time
+import urllib.parse
+from pathlib import Path
+import pytest
+import utils
+
+
+south_plugin = "sinusoid"
+south_asset_name = "sinusoid"
+south_service_name="Sine #1"
+north_plugin = "OMF"
+north_service_name="NorthReadingsToPI_WebAPI"
+north_schedule_id=""
+# This  gives the path of directory where fledge is cloned. test_file < packages < python < system < tests < ROOT
+PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.parent
+SCRIPTS_DIR_ROOT = "{}/tests/system/python/scripts/package/".format(PROJECT_ROOT)
+
+
+@pytest.fixture
+def reset_fledge(wait_time):
+    try:
+        subprocess.run(["cd {} && ./reset"
+                       .format(SCRIPTS_DIR_ROOT)], shell=True, check=True)
+    except subprocess.CalledProcessError:
+        assert False, "reset package script failed!"
+
+    # Wait for fledge server to start
+    time.sleep(wait_time)
+
+
+@pytest.fixture
+#def start_south_north(clean_setup_fledge_packages, add_south, start_north_pi_server_c_web_api_service, fledge_url, 
+#                        pi_host, pi_port, pi_admin, pi_passwd):
+def start_south_north(add_south, start_north_pi_server_c_web_api_service, fledge_url, 
+                        pi_host, pi_port, pi_admin, pi_passwd):    
+    global north_schedule_id
+    
+    add_south(south_plugin, None, fledge_url, service_name="{}".format(south_service_name), installation_type='package')
+    
+    response = start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_user=pi_admin, pi_pwd=pi_passwd)
+    north_schedule_id = response["id"]
+
+    yield start_south_north
+
+
+def verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries):
+    get_url = "/fledge/ping"
+    ping_result = utils.get_request(fledge_url, get_url)
+    assert "dataRead" in ping_result
+    assert "dataSent" in ping_result
+    assert 0 < ping_result['dataRead'], "South data NOT seen in ping header"
+        
+    retry_count = 1
+    sent = 0
+    if not skip_verify_north_interface:
+        while retries > retry_count:
+            sent = ping_result["dataSent"]
+            if sent >= 1:
+                break
+            else:
+                time.sleep(wait_time)
+
+            retry_count += 1
+            ping_result = utils.get_request(fledge_url, get_url)
+
+        assert 1 <= sent, "Failed to send data via PI Web API using Basic auth"
+    return ping_result
+
+
+def verify_statistics_map(fledge_url, skip_verify_north_interface):
+    get_url = "/fledge/statistics"
+    jdoc = utils.get_request(fledge_url, get_url)
+    actual_stats_map = utils.serialize_stats_map(jdoc)
+    assert 1 <= actual_stats_map[south_asset_name.upper()]
+    assert 1 <= actual_stats_map['READINGS']
+    if not skip_verify_north_interface:
+        assert 1 <= actual_stats_map['Readings Sent']
+        assert 1 <= actual_stats_map[north_service_name]
+
+
+def verify_service_added(fledge_url):
+    get_url = "/fledge/south"
+    result = utils.get_request(fledge_url, get_url)
+    assert len(result["services"])
+    assert south_service_name in [s["name"] for s in result["services"]]
+    
+    get_url = "/fledge/service"
+    result = utils.get_request(fledge_url, get_url)
+    assert len(result["services"])
+    assert south_service_name in [s["name"] for s in result["services"]]
+    assert north_service_name in [s["name"] for s in result["services"]]
+
+
+def verify_asset(fledge_url):
+    get_url = "/fledge/asset"
+    result = utils.get_request(fledge_url, get_url)
+    assert len(result), "No asset found"
+    assert south_asset_name in [s["assetCode"] for s in result]
+
+
+def verify_asset_tracking_details(fledge_url):
+    tracking_details = utils.get_asset_tracking_details(fledge_url, "Ingest")
+    assert len(tracking_details["track"]), "Failed to track Ingest event"
+    tracked_item = tracking_details["track"][0]
+    assert south_service_name == tracked_item["service"]
+    assert south_asset_name == tracked_item["asset"]
+    assert south_asset_name == tracked_item["plugin"]
+
+    egress_tracking_details = utils.get_asset_tracking_details(fledge_url, "Egress")
+    assert len(egress_tracking_details["track"]), "Failed to track Egress event"
+    tracked_item = egress_tracking_details["track"][0]
+    assert north_service_name == tracked_item["service"]
+    assert south_asset_name == tracked_item["asset"]
+    assert north_plugin == tracked_item["plugin"]
+
+
+class TestOMFNorthService:
+    def test_omf_service_with_restart(self, reset_fledge, start_south_north, skip_verify_north_interface, fledge_url, wait_time, retries):
+        """ Test OMF as a North service before and after restarting fledge.
+            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
+            reset_fledge: Fixture to reset fledge
+            start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            Assertions:
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/ping
+                on endpoint GET /fledge/asset"""        
+        
+        # Wait until south and north services are created
+        time.sleep(wait_time)
+        
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+        verify_asset(fledge_url)
+        verify_service_added(fledge_url)        
+        verify_statistics_map(fledge_url, skip_verify_north_interface)
+
+        put_url = "/fledge/restart"
+        utils.put_request(fledge_url, urllib.parse.quote(put_url))
+        
+        # Wait for fledge to restart
+        time.sleep(wait_time * 2)
+
+        old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        
+        # Wait for read and sent readings to increase
+        time.sleep(wait_time)
+        
+        new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        # Verifies whether Read and Sent readings are increasing after restart
+        assert old_ping_result['dataRead'] < new_ping_result['dataRead']
+        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+
+    def test_omf_service_with_enable_disable(self, reset_fledge, start_south_north, skip_verify_north_interface, fledge_url, wait_time, retries):
+        """ Test OMF as a North service by enabling and disabling it.
+            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
+            reset_fledge: Fixture to reset fledge
+            start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            Assertions:
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/ping
+                on endpoint GET /fledge/asset"""                
+        
+        # Wait until south and north services are created
+        time.sleep(wait_time)
+        
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+        verify_asset(fledge_url)
+        verify_service_added(fledge_url)        
+        verify_statistics_map(fledge_url, skip_verify_north_interface)
+        
+        data = {"enabled": "false"}
+        put_url = "/fledge/schedule/{}".format(north_schedule_id)
+        resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
+        assert False == resp['schedule']['enabled']
+        
+        # Wait for service to disable
+        time.sleep(wait_time)        
+        
+        data = {"enabled": "true"}
+        put_url = "/fledge/schedule/{}".format(north_schedule_id)
+        resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
+        assert True == resp['schedule']['enabled']
+        
+        old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        
+        # Wait for read and sent readings to increase
+        time.sleep(wait_time)
+        
+        new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        # Verifies whether Read and Sent readings are increasing after disable/enable
+        assert old_ping_result['dataRead'] < new_ping_result['dataRead']
+        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+
+
+    def test_omf_service_with_delete_add(self, reset_fledge, start_south_north, start_north_pi_server_c_web_api_service, skip_verify_north_interface, fledge_url, wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd):
+        """ Test OMF as a North service by deleting and adding north service.
+            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
+            reset_fledge: Fixture to reset fledge
+            start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            Assertions:
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/ping
+                on endpoint GET /fledge/asset"""               
+        
+        global north_schedule_id
+        
+        # Wait until south and north services are created
+        time.sleep(wait_time)
+        
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+        verify_asset(fledge_url)
+        verify_service_added(fledge_url)        
+        verify_statistics_map(fledge_url, skip_verify_north_interface)
+        
+        delete_url = "/fledge/service/{}".format(north_service_name)
+        resp = utils.delete_request(fledge_url, delete_url)
+        assert "Service {} deleted successfully.".format(north_service_name) == resp['result']
+        
+        # Wait for service to get deleted
+        time.sleep(wait_time)
+    
+        response = start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_user=pi_admin, pi_pwd=pi_passwd)
+        north_schedule_id = response["id"]
+        
+        old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        
+        # Wait for read and sent readings to increase
+        time.sleep(wait_time)
+        
+        new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        # Verifies whether Read and Sent readings are increasing after delete/add of north service
+        assert old_ping_result['dataRead'] < new_ping_result['dataRead']
+        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+
+    def test_omf_service_with_reconfig(self, reset_fledge, start_south_north, skip_verify_north_interface, fledge_url, wait_time, retries):
+        """ Test OMF as a North service by reconfiguring it.
+            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
+            reset_fledge: Fixture to reset fledge
+            start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            Assertions:
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/ping
+                on endpoint GET /fledge/asset"""                
+        
+        # Wait until south and north services are created
+        time.sleep(wait_time)
+        
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+        verify_asset(fledge_url)
+        verify_service_added(fledge_url)        
+        verify_statistics_map(fledge_url, skip_verify_north_interface)
+        
+        # Good reconfiguration to check data is not sent
+        data = {"SendFullStructure": "false"}
+        put_url = "/fledge/category/{}".format(north_service_name)
+        resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
+        assert "false" == resp["SendFullStructure"]["value"]
+        
+        # Wait for service reconfiguration
+        time.sleep(wait_time)        
+        
+        old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        
+        # Wait for read and sent readings to increase
+        time.sleep(wait_time)
+        
+        new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        # Verifies whether Read and Sent readings are increasing after delete/add of north service
+        assert old_ping_result['dataRead'] < new_ping_result['dataRead']
+        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+        
+        # Bad reconfiguration to check data is not sent
+        data = {"PIWebAPIUserId": "Admin"}
+        put_url = "/fledge/category/{}".format(north_service_name)
+        resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
+        assert "Admin" == resp["PIWebAPIUserId"]["value"]
+        
+        # Wait for service reconfiguration
+        time.sleep(wait_time)        
+        
+        old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        
+        # Wait for read and sent readings to increase
+        time.sleep(wait_time)
+        
+        new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        # Verifies whether Read and Sent readings are increasing after delete/add of north service
+        assert old_ping_result['dataRead'] < new_ping_result['dataRead']
+        assert old_ping_result['dataSent'] == new_ping_result['dataSent']        
+        

--- a/tests/system/python/packages/test_omf_north_service.py
+++ b/tests/system/python/packages/test_omf_north_service.py
@@ -372,7 +372,8 @@ class TestOMFNorthService:
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after delete/add of north service
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
-        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+        if not skip_verify_north_interface:
+            assert old_ping_result['dataSent'] == new_ping_result['dataSent']
 
         # Bad reconfiguration to check data is not sent
         data = {"PIWebAPIUserId": "Admin"}

--- a/tests/system/python/packages/test_omf_north_service.py
+++ b/tests/system/python/packages/test_omf_north_service.py
@@ -373,7 +373,7 @@ class TestOMFNorthService:
         # Verifies whether Read and Sent readings are increasing after delete/add of north service
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
         if not skip_verify_north_interface:
-            assert old_ping_result['dataSent'] == new_ping_result['dataSent']
+            assert old_ping_result['dataSent'] < new_ping_result['dataSent']
 
         # Bad reconfiguration to check data is not sent
         data = {"PIWebAPIUserId": "Admin"}

--- a/tests/system/python/packages/test_omf_north_service.py
+++ b/tests/system/python/packages/test_omf_north_service.py
@@ -42,13 +42,13 @@ def reset_fledge(wait_time):
 
 
 @pytest.fixture
-def start_south_north(add_south, start_north_pi_server_c_web_api_service, fledge_url,
+def start_south_north(add_south, start_north_omf_as_a_service, fledge_url,
                       pi_host, pi_port, pi_admin, pi_passwd):
     global north_schedule_id
 
     add_south(south_plugin, None, fledge_url, service_name="{}".format(south_service_name), installation_type='package')
 
-    response = start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_user=pi_admin, pi_pwd=pi_passwd)
+    response = start_north_omf_as_a_service(fledge_url, pi_host, pi_port, pi_user=pi_admin, pi_pwd=pi_passwd)
     north_schedule_id = response["id"]
 
     yield start_south_north
@@ -274,7 +274,7 @@ class TestOMFNorthService:
                            south_asset_name)
 
     def test_omf_service_with_delete_add(self, reset_fledge, start_south_north, read_data_from_pi_web_api,
-                                         start_north_pi_server_c_web_api_service,
+                                         start_north_omf_as_a_service,
                                          skip_verify_north_interface, fledge_url, wait_time, retries, pi_host, pi_port,
                                          pi_admin, pi_passwd, pi_db):
         """ Test OMF as a North service by deleting and adding north service.
@@ -310,7 +310,7 @@ class TestOMFNorthService:
         # Wait for service to get deleted
         time.sleep(wait_time)
 
-        response = start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_user=pi_admin,
+        response = start_north_omf_as_a_service(fledge_url, pi_host, pi_port, pi_user=pi_admin,
                                                            pi_pwd=pi_passwd)
         north_schedule_id = response["id"]
 
@@ -551,7 +551,7 @@ class TestOMFNorthServicewithFilters:
     @pytest.mark.skip(reason="FOGL-5215: Deleting a service doesn't delete its filter categories")
     def test_omf_service_with_delete_add(self, reset_fledge, start_south_north, add_configure_filter, add_filter,
                                          read_data_from_pi_web_api,
-                                         start_north_pi_server_c_web_api_service, skip_verify_north_interface,
+                                         start_north_omf_as_a_service, skip_verify_north_interface,
                                          fledge_url, wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd, pi_db):
         """ Test OMF as a North service by deleting and adding north service.
             reset_fledge: Fixture to reset fledge
@@ -587,7 +587,7 @@ class TestOMFNorthServicewithFilters:
         # Wait for service to get deleted
         time.sleep(wait_time)
 
-        response = start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_user=pi_admin,
+        response = start_north_omf_as_a_service(fledge_url, pi_host, pi_port, pi_user=pi_admin,
                                                            pi_pwd=pi_passwd)
         north_schedule_id = response["id"]
 

--- a/tests/system/python/packages/test_omf_north_service.py
+++ b/tests/system/python/packages/test_omf_north_service.py
@@ -26,6 +26,7 @@ south_service_name="Sine #1"
 north_plugin = "OMF"
 north_service_name="NorthReadingsToPI_WebAPI"
 north_schedule_id=""
+filter1_name="SF1"
 # This  gives the path of directory where fledge is cloned. test_file < packages < python < system < tests < ROOT
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.parent
 SCRIPTS_DIR_ROOT = "{}/tests/system/python/scripts/package/".format(PROJECT_ROOT)
@@ -56,6 +57,14 @@ def start_south_north(add_south, start_north_pi_server_c_web_api_service, fledge
     north_schedule_id = response["id"]
 
     yield start_south_north
+
+
+@pytest.fixture
+def add_configure_filter(add_filter, fledge_url):    
+    filter_cfg_scale = {"enable": "true"}
+    add_filter("scale", None, filter1_name, filter_cfg_scale, fledge_url, north_service_name, installation_type='package')
+
+    yield add_configure_filter
 
 
 def verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries):
@@ -99,11 +108,23 @@ def verify_service_added(fledge_url):
     assert len(result["services"])
     assert south_service_name in [s["name"] for s in result["services"]]
     
+    get_url = "/fledge/north"
+    result = utils.get_request(fledge_url, get_url)
+    assert len(result)
+    assert north_service_name in [s["name"] for s in result]
+    
     get_url = "/fledge/service"
     result = utils.get_request(fledge_url, get_url)
     assert len(result["services"])
     assert south_service_name in [s["name"] for s in result["services"]]
     assert north_service_name in [s["name"] for s in result["services"]]
+
+
+def verify_filter_added(fledge_url):
+    get_url = "/fledge/filter"
+    result = utils.get_request(fledge_url, get_url)
+    assert len(result["filters"])
+    assert filter1_name in [s["name"] for s in result["filters"]]
 
 
 def verify_asset(fledge_url):
@@ -300,5 +321,214 @@ class TestOMFNorthService:
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after delete/add of north service
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
-        assert old_ping_result['dataSent'] == new_ping_result['dataSent']        
+        assert old_ping_result['dataSent'] == new_ping_result['dataSent']
+
+
+class TestOMFNorthServicewithFilters:
+    def test_omf_service_with_filter(self, reset_fledge, start_south_north, add_configure_filter, skip_verify_north_interface, fledge_url, wait_time, retries):
+        """ Test OMF as a North service with filters.
+            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
+            reset_fledge: Fixture to reset fledge
+            start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            Assertions:
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/ping
+                on endpoint GET /fledge/asset"""        
         
+        # Wait until south and north services are created
+        time.sleep(wait_time)
+        
+        old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+        verify_asset(fledge_url)
+        verify_service_added(fledge_url)
+        verify_filter_added(fledge_url)        
+        verify_statistics_map(fledge_url, skip_verify_north_interface)
+        
+        # Wait for read and sent readings to increase
+        time.sleep(wait_time)
+        
+        new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        # Verifies whether Read and Sent readings are increasing after delete/add of north service
+        assert old_ping_result['dataRead'] < new_ping_result['dataRead']
+        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+        
+    def test_omf_service_with_disable_enable_filter(self, reset_fledge, start_south_north, add_configure_filter, skip_verify_north_interface, fledge_url, wait_time, retries):
+        """ Test OMF as a North service with enable/diable of filters.
+            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
+            reset_fledge: Fixture to reset fledge
+            start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            Assertions:
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/ping
+                on endpoint GET /fledge/asset"""        
+        
+        # Wait until south and north services are created
+        time.sleep(wait_time)
+        
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+        verify_asset(fledge_url)
+        verify_service_added(fledge_url)
+        verify_filter_added(fledge_url)    
+        verify_statistics_map(fledge_url, skip_verify_north_interface)
+        
+        data = {"enable": "false"}
+        put_url = "/fledge/category/{}_SF1".format(north_service_name)
+        resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
+        assert "false" == resp['enable']['value']
+        
+        # Wait for service to disable
+        time.sleep(wait_time)        
+        
+        data = {"enable": "true"}
+        put_url = "/fledge/category/{}_SF1".format(north_service_name)
+        resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
+        assert "true" == resp['enable']['value']
+        
+        old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        
+        # Wait for read and sent readings to increase
+        time.sleep(wait_time)
+        
+        new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        # Verifies whether Read and Sent readings are increasing after disable/enable
+        assert old_ping_result['dataRead'] < new_ping_result['dataRead']
+        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+        
+    def test_omf_service_with_filter_reconfig(self, reset_fledge, start_south_north, add_configure_filter, skip_verify_north_interface, fledge_url, wait_time, retries):
+        """ Test OMF as a North service with reconfiguration of filters.
+            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
+            reset_fledge: Fixture to reset fledge
+            start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            Assertions:
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/ping
+                on endpoint GET /fledge/asset"""        
+        
+        # Wait until south and north services are created
+        time.sleep(wait_time)
+        
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+        verify_asset(fledge_url)
+        verify_service_added(fledge_url)
+        verify_filter_added(fledge_url)      
+        verify_statistics_map(fledge_url, skip_verify_north_interface)
+        
+        data = {"factor": "50"}
+        put_url = "/fledge/category/{}_SF1".format(north_service_name)
+        resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
+        assert "50.0" == resp['factor']['value']
+        
+        # Wait for filter reconfiguration
+        time.sleep(wait_time)        
+        
+        old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        
+        # Wait for read and sent readings to increase
+        time.sleep(wait_time)
+        
+        new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        # Verifies whether Read and Sent readings are increasing after disable/enable
+        assert old_ping_result['dataRead'] < new_ping_result['dataRead']
+        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+        
+    @pytest.mark.skip(reason="FOGL-5215: Deleting a service doesn't delete its filter categories")
+    def test_omf_service_with_delete_add(self, reset_fledge, start_south_north, add_configure_filter, add_filter, start_north_pi_server_c_web_api_service, skip_verify_north_interface, fledge_url, wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd):
+        """ Test OMF as a North service by deleting and adding north service.
+            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
+            reset_fledge: Fixture to reset fledge
+            start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            Assertions:
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/ping
+                on endpoint GET /fledge/asset"""               
+        
+        global north_schedule_id
+        
+        # Wait until south and north services are created
+        time.sleep(wait_time)
+        
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+        verify_asset(fledge_url)
+        verify_service_added(fledge_url)      
+        verify_filter_added(fledge_url)  
+        verify_statistics_map(fledge_url, skip_verify_north_interface)
+        
+        delete_url = "/fledge/service/{}".format(north_service_name)
+        resp = utils.delete_request(fledge_url, delete_url)
+        assert "Service {} deleted successfully.".format(north_service_name) == resp['result']
+        
+        # Wait for service to get deleted
+        time.sleep(wait_time)
+    
+        response = start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_user=pi_admin, pi_pwd=pi_passwd)
+        north_schedule_id = response["id"]
+        
+        filter_cfg_scale = {"enable": "true"}
+        add_filter("scale", None, "SF2", filter_cfg_scale, fledge_url, north_service_name, installation_type='package')
+        
+        # Wait for service and filter to get added
+        time.sleep(wait_time)
+        
+        verify_service_added(fledge_url)      
+        verify_filter_added(fledge_url)
+        
+        old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        
+        # Wait for read and sent readings to increase
+        time.sleep(wait_time)
+        
+        new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        # Verifies whether Read and Sent readings are increasing after delete/add of north service
+        assert old_ping_result['dataRead'] < new_ping_result['dataRead']
+        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+        
+    
+    def test_omf_service_with_delete_add_filter(self, reset_fledge, start_south_north, add_configure_filter, add_filter, skip_verify_north_interface, fledge_url, wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd):
+        """ Test OMF as a North service by deleting and adding north service.
+            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
+            reset_fledge: Fixture to reset fledge
+            start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            Assertions:
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/ping
+                on endpoint GET /fledge/asset"""       
+        
+        # Wait until south and north services are created
+        time.sleep(wait_time)
+        
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+        verify_asset(fledge_url)
+        verify_service_added(fledge_url)      
+        verify_filter_added(fledge_url)  
+        verify_statistics_map(fledge_url, skip_verify_north_interface)
+        
+        data = {"pipeline": []}
+        put_url = "/fledge/filter/{}/pipeline?allow_duplicates=true&append_filter=false" \
+            .format(north_service_name)
+        resp = utils.put_request(fledge_url, urllib.parse.quote(put_url, safe='?,=,&,/'), data)
+        
+        delete_url = "/fledge/filter/{}".format(filter1_name)
+        resp = utils.delete_request(fledge_url, delete_url)
+        print (resp)
+        assert "Filter {} deleted successfully".format(filter1_name) == resp['result']
+        
+        # Wait for service to get deleted
+        time.sleep(wait_time)
+        
+        filter_cfg_scale = {"enable": "true"}
+        add_filter("scale", None, filter1_name, filter_cfg_scale, fledge_url, north_service_name, installation_type='package')
+        
+        # Wait for filter to get added
+        time.sleep(wait_time)
+      
+        verify_filter_added(fledge_url)
+        
+        old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        
+        # Wait for read and sent readings to increase
+        time.sleep(wait_time)
+        
+        new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
+        # Verifies whether Read and Sent readings are increasing after delete/add of north service
+        assert old_ping_result['dataRead'] < new_ping_result['dataRead']
+        assert old_ping_result['dataSent'] < new_ping_result['dataSent']

--- a/tests/system/python/packages/test_omf_north_service.py
+++ b/tests/system/python/packages/test_omf_north_service.py
@@ -617,7 +617,7 @@ class TestOMFNorthServicewithFilters:
                                                 read_data_from_pi_web_api,
                                                 skip_verify_north_interface, fledge_url, wait_time, retries, pi_host,
                                                 pi_port, pi_admin, pi_passwd, pi_db):
-        """ Test OMF as a North service by deleting and adding north service.
+        """ Test OMF as a North service by deleting filter attached to north service.
             reset_fledge: Fixture to reset fledge
             start_south_north: Adds and configures south(sinusoid) and north(OMF) service
             read_data_from_pi_web_api: Fixture to read data from PI web API
@@ -681,7 +681,7 @@ class TestOMFNorthServicewithFilters:
                                              read_data_from_pi_web_api,
                                              skip_verify_north_interface, fledge_url, wait_time, retries, pi_host,
                                              pi_port, pi_admin, pi_passwd, pi_db):
-        """ Test OMF as a North service by deleting and adding north service.
+        """ Test OMF as a North service by reordering filters attached to north service.
             reset_fledge: Fixture to reset fledge
             start_south_north: Adds and configures south(sinusoid) and north(OMF) service
             read_data_from_pi_web_api: Fixture to read data from PI web API

--- a/tests/system/python/packages/test_omf_north_service.py
+++ b/tests/system/python/packages/test_omf_north_service.py
@@ -10,24 +10,20 @@ __author__ = "Yash Tatkondawar"
 __copyright__ = "Copyright (c) 2021 Dianomic Systems, Inc."
 
 import subprocess
-import http.client
-import json
-import os
 import time
 import urllib.parse
 from pathlib import Path
 import pytest
 import utils
 
-
 south_plugin = "sinusoid"
 south_asset_name = "sinusoid"
-south_service_name="Sine #1"
+south_service_name = "Sine #1"
 north_plugin = "OMF"
-north_service_name="NorthReadingsToPI_WebAPI"
-north_schedule_id=""
-filter1_name="SF1"
-filter2_name="MD1"
+north_service_name = "NorthReadingsToPI_WebAPI"
+north_schedule_id = ""
+filter1_name = "SF1"
+filter2_name = "MD1"
 # This  gives the path of directory where fledge is cloned. test_file < packages < python < system < tests < ROOT
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.parent
 SCRIPTS_DIR_ROOT = "{}/tests/system/python/scripts/package/".format(PROJECT_ROOT)
@@ -46,12 +42,12 @@ def reset_fledge(wait_time):
 
 
 @pytest.fixture
-def start_south_north(clean_setup_fledge_packages, add_south, start_north_pi_server_c_web_api_service, fledge_url, 
-                        pi_host, pi_port, pi_admin, pi_passwd):
+def start_south_north(add_south, start_north_pi_server_c_web_api_service, fledge_url,
+                      pi_host, pi_port, pi_admin, pi_passwd):
     global north_schedule_id
-    
+
     add_south(south_plugin, None, fledge_url, service_name="{}".format(south_service_name), installation_type='package')
-    
+
     response = start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_user=pi_admin, pi_pwd=pi_passwd)
     north_schedule_id = response["id"]
 
@@ -59,9 +55,10 @@ def start_south_north(clean_setup_fledge_packages, add_south, start_north_pi_ser
 
 
 @pytest.fixture
-def add_configure_filter(add_filter, fledge_url):    
+def add_configure_filter(add_filter, fledge_url):
     filter_cfg_scale = {"enable": "true"}
-    add_filter("scale", None, filter1_name, filter_cfg_scale, fledge_url, north_service_name, installation_type='package')
+    add_filter("scale", None, filter1_name, filter_cfg_scale, fledge_url, north_service_name,
+               installation_type='package')
 
     yield add_configure_filter
 
@@ -72,7 +69,7 @@ def verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries):
     assert "dataRead" in ping_result
     assert "dataSent" in ping_result
     assert 0 < ping_result['dataRead'], "South data NOT seen in ping header"
-        
+
     retry_count = 1
     sent = 0
     if not skip_verify_north_interface:
@@ -106,12 +103,12 @@ def verify_service_added(fledge_url):
     result = utils.get_request(fledge_url, get_url)
     assert len(result["services"])
     assert south_service_name in [s["name"] for s in result["services"]]
-    
+
     get_url = "/fledge/north"
     result = utils.get_request(fledge_url, get_url)
     assert len(result)
     assert north_service_name in [s["name"] for s in result]
-    
+
     get_url = "/fledge/service"
     result = utils.get_request(fledge_url, get_url)
     assert len(result["services"])
@@ -134,7 +131,7 @@ def verify_asset(fledge_url):
     assert south_asset_name in [s["assetCode"] for s in result]
 
 
-def verify_asset_tracking_details(fledge_url):
+def verify_asset_tracking_details(fledge_url, skip_verify_north_interface):
     tracking_details = utils.get_asset_tracking_details(fledge_url, "Ingest")
     assert len(tracking_details["track"]), "Failed to track Ingest event"
     tracked_item = tracking_details["track"][0]
@@ -142,448 +139,611 @@ def verify_asset_tracking_details(fledge_url):
     assert south_asset_name == tracked_item["asset"]
     assert south_asset_name == tracked_item["plugin"]
 
-    egress_tracking_details = utils.get_asset_tracking_details(fledge_url, "Egress")
-    assert len(egress_tracking_details["track"]), "Failed to track Egress event"
-    tracked_item = egress_tracking_details["track"][0]
-    assert north_service_name == tracked_item["service"]
-    assert south_asset_name == tracked_item["asset"]
-    assert north_plugin == tracked_item["plugin"]
+    if not skip_verify_north_interface:
+        egress_tracking_details = utils.get_asset_tracking_details(fledge_url, "Egress")
+        assert len(egress_tracking_details["track"]), "Failed to track Egress event"
+        tracked_item = egress_tracking_details["track"][0]
+        assert north_service_name == tracked_item["service"]
+        assert south_asset_name == tracked_item["asset"]
+        assert north_plugin == tracked_item["plugin"]
+
+
+def _verify_egress(read_data_from_pi_web_api, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name):
+    retry_count = 0
+    data_from_pi = None
+
+    af_hierarchy_level = "fledge/room1/machine1"
+    af_hierarchy_level_list = af_hierarchy_level.split("/")
+    type_id = 1
+    recorded_datapoint = "{}measurement_{}".format(type_id, asset_name)
+    # Name of asset in the PI server
+    pi_asset_name = "{}-type{}".format(asset_name, type_id)
+
+    while (data_from_pi is None or data_from_pi == []) and retry_count < retries:
+        data_from_pi = read_data_from_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db, af_hierarchy_level_list,
+                                                 pi_asset_name, {recorded_datapoint})
+        retry_count += 1
+        time.sleep(wait_time * 2)
+
+    if data_from_pi is None or retry_count == retries:
+        assert False, "Failed to read data from PI"
 
 
 class TestOMFNorthService:
-    def test_omf_service_with_restart(self, reset_fledge, start_south_north, skip_verify_north_interface, fledge_url, wait_time, retries):
+    def test_omf_service_with_restart(self, clean_setup_fledge_packages, reset_fledge, start_south_north,
+                                      read_data_from_pi_web_api, skip_verify_north_interface, fledge_url,
+                                      wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd, pi_db):
         """ Test OMF as a North service before and after restarting fledge.
-            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
+            clean_setup_fledge_packages: Fixture to remove and install latest fledge packages
             reset_fledge: Fixture to reset fledge
             start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            read_data_from_pi_web_api: Fixture to read data from PI web API
+            skip_verify_north_interface: Flag for assertion of data using PI web API
             Assertions:
-                on endpoint GET /fledge/south
                 on endpoint GET /fledge/ping
-                on endpoint GET /fledge/asset"""        
-        
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/north
+                on endpoint GET /fledge/filter
+                on endpoint GET /fledge/service
+                on endpoint GET /fledge/statistics
+                on endpoint GET /fledge/asset
+                on endpoint GET /fledge/track"""
+
         # Wait until south and north services are created
         time.sleep(wait_time)
-        
-        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         verify_asset(fledge_url)
-        verify_service_added(fledge_url)        
+        verify_service_added(fledge_url)
         verify_statistics_map(fledge_url, skip_verify_north_interface)
+        verify_asset_tracking_details(fledge_url, verify_asset_tracking_details)
 
         put_url = "/fledge/restart"
         utils.put_request(fledge_url, urllib.parse.quote(put_url))
-        
+
         # Wait for fledge to restart
         time.sleep(wait_time * 2)
 
         old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
-        
+
         # Wait for read and sent readings to increase
         time.sleep(wait_time)
-        
+
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after restart
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
-        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
 
-    def test_omf_service_with_enable_disable(self, reset_fledge, start_south_north, skip_verify_north_interface, fledge_url, wait_time, retries):
+        if not skip_verify_north_interface:
+            assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+            _verify_egress(read_data_from_pi_web_api, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
+                           south_asset_name)
+
+    def test_omf_service_with_enable_disable(self, reset_fledge, start_south_north, read_data_from_pi_web_api,
+                                             skip_verify_north_interface,
+                                             fledge_url, wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd,
+                                             pi_db):
         """ Test OMF as a North service by enabling and disabling it.
-            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
             reset_fledge: Fixture to reset fledge
             start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            read_data_from_pi_web_api: Fixture to read data from PI web API
+            skip_verify_north_interface: Flag for assertion of data using PI web API
             Assertions:
-                on endpoint GET /fledge/south
                 on endpoint GET /fledge/ping
-                on endpoint GET /fledge/asset"""                
-        
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/north
+                on endpoint GET /fledge/filter
+                on endpoint GET /fledge/service
+                on endpoint GET /fledge/statistics
+                on endpoint GET /fledge/asset
+                on endpoint GET /fledge/track"""
+
         # Wait until south and north services are created
         time.sleep(wait_time)
-        
-        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         verify_asset(fledge_url)
-        verify_service_added(fledge_url)        
+        verify_service_added(fledge_url)
         verify_statistics_map(fledge_url, skip_verify_north_interface)
-        
+        verify_asset_tracking_details(fledge_url, skip_verify_north_interface)
+
         data = {"enabled": "false"}
         put_url = "/fledge/schedule/{}".format(north_schedule_id)
         resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
         assert False == resp['schedule']['enabled']
-        
+
         # Wait for service to disable
-        time.sleep(wait_time)        
-        
+        time.sleep(wait_time)
+
         data = {"enabled": "true"}
         put_url = "/fledge/schedule/{}".format(north_schedule_id)
         resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
         assert True == resp['schedule']['enabled']
-        
+
         old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
-        
+
         # Wait for read and sent readings to increase
         time.sleep(wait_time)
-        
+
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after disable/enable
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
-        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
 
+        if not skip_verify_north_interface:
+            assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+            _verify_egress(read_data_from_pi_web_api, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
+                           south_asset_name)
 
-    def test_omf_service_with_delete_add(self, reset_fledge, start_south_north, start_north_pi_server_c_web_api_service, skip_verify_north_interface, fledge_url, wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd):
+    def test_omf_service_with_delete_add(self, reset_fledge, start_south_north, read_data_from_pi_web_api,
+                                         start_north_pi_server_c_web_api_service,
+                                         skip_verify_north_interface, fledge_url, wait_time, retries, pi_host, pi_port,
+                                         pi_admin, pi_passwd, pi_db):
         """ Test OMF as a North service by deleting and adding north service.
-            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
             reset_fledge: Fixture to reset fledge
             start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            read_data_from_pi_web_api: Fixture to read data from PI web API
+            skip_verify_north_interface: Flag for assertion of data using PI web API
             Assertions:
-                on endpoint GET /fledge/south
                 on endpoint GET /fledge/ping
-                on endpoint GET /fledge/asset"""               
-        
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/north
+                on endpoint GET /fledge/filter
+                on endpoint GET /fledge/service
+                on endpoint GET /fledge/statistics
+                on endpoint GET /fledge/asset
+                on endpoint GET /fledge/track"""
+
         global north_schedule_id
-        
+
         # Wait until south and north services are created
         time.sleep(wait_time)
-        
-        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         verify_asset(fledge_url)
-        verify_service_added(fledge_url)        
+        verify_service_added(fledge_url)
         verify_statistics_map(fledge_url, skip_verify_north_interface)
-        
+        verify_asset_tracking_details(fledge_url, skip_verify_north_interface)
+
         delete_url = "/fledge/service/{}".format(north_service_name)
         resp = utils.delete_request(fledge_url, delete_url)
         assert "Service {} deleted successfully.".format(north_service_name) == resp['result']
-        
+
         # Wait for service to get deleted
         time.sleep(wait_time)
-    
-        response = start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_user=pi_admin, pi_pwd=pi_passwd)
+
+        response = start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_user=pi_admin,
+                                                           pi_pwd=pi_passwd)
         north_schedule_id = response["id"]
-        
+
         old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
-        
+
         # Wait for read and sent readings to increase
         time.sleep(wait_time)
-        
+
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after delete/add of north service
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
-        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
 
-    def test_omf_service_with_reconfig(self, reset_fledge, start_south_north, skip_verify_north_interface, fledge_url, wait_time, retries):
+        if not skip_verify_north_interface:
+            assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+            _verify_egress(read_data_from_pi_web_api, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
+                           south_asset_name)
+
+    def test_omf_service_with_reconfig(self, reset_fledge, start_south_north, read_data_from_pi_web_api,
+                                       skip_verify_north_interface, fledge_url,
+                                       wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd, pi_db):
         """ Test OMF as a North service by reconfiguring it.
-            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
             reset_fledge: Fixture to reset fledge
             start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            read_data_from_pi_web_api: Fixture to read data from PI web API
+            skip_verify_north_interface: Flag for assertion of data using PI web API
             Assertions:
-                on endpoint GET /fledge/south
                 on endpoint GET /fledge/ping
-                on endpoint GET /fledge/asset"""                
-        
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/north
+                on endpoint GET /fledge/filter
+                on endpoint GET /fledge/service
+                on endpoint GET /fledge/statistics
+                on endpoint GET /fledge/asset
+                on endpoint GET /fledge/track"""
+
         # Wait until south and north services are created
         time.sleep(wait_time)
-        
-        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         verify_asset(fledge_url)
-        verify_service_added(fledge_url)        
+        verify_service_added(fledge_url)
         verify_statistics_map(fledge_url, skip_verify_north_interface)
-        
-        # Good reconfiguration to check data is not sent
+        verify_asset_tracking_details(fledge_url, skip_verify_north_interface)
+
+        # Good reconfiguration to check data is sent
         data = {"SendFullStructure": "false"}
         put_url = "/fledge/category/{}".format(north_service_name)
         resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
         assert "false" == resp["SendFullStructure"]["value"]
-        
+
         # Wait for service reconfiguration
-        time.sleep(wait_time)        
-        
+        time.sleep(wait_time)
+
         old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
-        
+
         # Wait for read and sent readings to increase
         time.sleep(wait_time)
-        
+
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after delete/add of north service
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
         assert old_ping_result['dataSent'] < new_ping_result['dataSent']
-        
+
         # Bad reconfiguration to check data is not sent
         data = {"PIWebAPIUserId": "Admin"}
         put_url = "/fledge/category/{}".format(north_service_name)
         resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
         assert "Admin" == resp["PIWebAPIUserId"]["value"]
-        
+
         # Wait for service reconfiguration
-        time.sleep(wait_time)        
-        
+        time.sleep(wait_time)
+
         old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
-        
+
         # Wait for read and sent readings to increase
         time.sleep(wait_time)
-        
+
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after delete/add of north service
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
-        assert old_ping_result['dataSent'] == new_ping_result['dataSent']
+
+        if not skip_verify_north_interface:
+            assert old_ping_result['dataSent'] == new_ping_result['dataSent']
+            _verify_egress(read_data_from_pi_web_api, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
+                           south_asset_name)
 
 
 class TestOMFNorthServicewithFilters:
-    def test_omf_service_with_filter(self, reset_fledge, start_south_north, add_configure_filter, skip_verify_north_interface, fledge_url, wait_time, retries):
+    def test_omf_service_with_filter(self, reset_fledge, start_south_north, add_configure_filter,
+                                     read_data_from_pi_web_api,
+                                     skip_verify_north_interface, fledge_url, wait_time, retries, pi_host, pi_port,
+                                     pi_admin, pi_passwd, pi_db):
         """ Test OMF as a North service with filters.
-            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
             reset_fledge: Fixture to reset fledge
             start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            read_data_from_pi_web_api: Fixture to read data from PI web API
+            skip_verify_north_interface: Flag for assertion of data using PI web API
             Assertions:
-                on endpoint GET /fledge/south
                 on endpoint GET /fledge/ping
-                on endpoint GET /fledge/asset"""        
-        
-        # Wait until south and north services are created
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/north
+                on endpoint GET /fledge/filter
+                on endpoint GET /fledge/service
+                on endpoint GET /fledge/statistics
+                on endpoint GET /fledge/asset
+                on endpoint GET /fledge/track"""
+
+        # Wait until south, north services and filters are created
         time.sleep(wait_time)
-        
-        old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+
+        old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         verify_asset(fledge_url)
         verify_service_added(fledge_url)
-        verify_filter_added(fledge_url)        
+        verify_filter_added(fledge_url)
         verify_statistics_map(fledge_url, skip_verify_north_interface)
-        
+        verify_asset_tracking_details(fledge_url, skip_verify_north_interface)
+
         # Wait for read and sent readings to increase
         time.sleep(wait_time)
-        
+
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after delete/add of north service
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
-        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
-        
-    def test_omf_service_with_disable_enable_filter(self, reset_fledge, start_south_north, add_configure_filter, skip_verify_north_interface, fledge_url, wait_time, retries):
-        """ Test OMF as a North service with enable/diable of filters.
-            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
+
+        if not skip_verify_north_interface:
+            assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+            _verify_egress(read_data_from_pi_web_api, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
+                           south_asset_name)
+
+    def test_omf_service_with_disable_enable_filter(self, reset_fledge, start_south_north, add_configure_filter,
+                                                    read_data_from_pi_web_api,
+                                                    skip_verify_north_interface, fledge_url, wait_time, retries,
+                                                    pi_host, pi_port, pi_admin, pi_passwd, pi_db):
+        """ Test OMF as a North service with enable/disable of filters.
             reset_fledge: Fixture to reset fledge
             start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            read_data_from_pi_web_api: Fixture to read data from PI web API
+            skip_verify_north_interface: Flag for assertion of data using PI web API
             Assertions:
-                on endpoint GET /fledge/south
                 on endpoint GET /fledge/ping
-                on endpoint GET /fledge/asset"""        
-        
-        # Wait until south and north services are created
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/north
+                on endpoint GET /fledge/filter
+                on endpoint GET /fledge/service
+                on endpoint GET /fledge/statistics
+                on endpoint GET /fledge/asset
+                on endpoint GET /fledge/track"""
+
+        # Wait until south, north services and filters are created
         time.sleep(wait_time)
-        
-        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         verify_asset(fledge_url)
         verify_service_added(fledge_url)
-        verify_filter_added(fledge_url)    
+        verify_filter_added(fledge_url)
         verify_statistics_map(fledge_url, skip_verify_north_interface)
-        
+        verify_asset_tracking_details(fledge_url, skip_verify_north_interface)
+
         data = {"enable": "false"}
         put_url = "/fledge/category/{}_SF1".format(north_service_name)
         resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
         assert "false" == resp['enable']['value']
-        
+
         # Wait for service to disable
-        time.sleep(wait_time)        
-        
+        time.sleep(wait_time)
+
         data = {"enable": "true"}
         put_url = "/fledge/category/{}_SF1".format(north_service_name)
         resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
         assert "true" == resp['enable']['value']
-        
+
         old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
-        
+
         # Wait for read and sent readings to increase
         time.sleep(wait_time)
-        
+
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after disable/enable
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
-        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
-        
-    def test_omf_service_with_filter_reconfig(self, reset_fledge, start_south_north, add_configure_filter, skip_verify_north_interface, fledge_url, wait_time, retries):
+
+        if not skip_verify_north_interface:
+            assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+            _verify_egress(read_data_from_pi_web_api, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
+                           south_asset_name)
+
+    def test_omf_service_with_filter_reconfig(self, reset_fledge, start_south_north, add_configure_filter,
+                                              read_data_from_pi_web_api,
+                                              skip_verify_north_interface, fledge_url, wait_time, retries, pi_host,
+                                              pi_port, pi_admin, pi_passwd, pi_db):
         """ Test OMF as a North service with reconfiguration of filters.
-            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
             reset_fledge: Fixture to reset fledge
             start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            read_data_from_pi_web_api: Fixture to read data from PI web API
+            skip_verify_north_interface: Flag for assertion of data using PI web API
             Assertions:
-                on endpoint GET /fledge/south
                 on endpoint GET /fledge/ping
-                on endpoint GET /fledge/asset"""        
-        
-        # Wait until south and north services are created
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/north
+                on endpoint GET /fledge/filter
+                on endpoint GET /fledge/service
+                on endpoint GET /fledge/statistics
+                on endpoint GET /fledge/asset
+                on endpoint GET /fledge/track"""
+
+        # Wait until south, north services and filters are created
         time.sleep(wait_time)
-        
-        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         verify_asset(fledge_url)
         verify_service_added(fledge_url)
-        verify_filter_added(fledge_url)      
+        verify_filter_added(fledge_url)
         verify_statistics_map(fledge_url, skip_verify_north_interface)
-        
+        verify_asset_tracking_details(fledge_url, skip_verify_north_interface)
+
         data = {"factor": "50"}
         put_url = "/fledge/category/{}_SF1".format(north_service_name)
         resp = utils.put_request(fledge_url, urllib.parse.quote(put_url), data)
         assert "50.0" == resp['factor']['value']
-        
+
         # Wait for filter reconfiguration
-        time.sleep(wait_time)        
-        
+        time.sleep(wait_time)
+
         old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
-        
+
         # Wait for read and sent readings to increase
         time.sleep(wait_time)
-        
+
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after disable/enable
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
-        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
-        
+
+        if not skip_verify_north_interface:
+            assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+            _verify_egress(read_data_from_pi_web_api, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
+                           south_asset_name)
+
     @pytest.mark.skip(reason="FOGL-5215: Deleting a service doesn't delete its filter categories")
-    def test_omf_service_with_delete_add(self, reset_fledge, start_south_north, add_configure_filter, add_filter, start_north_pi_server_c_web_api_service, skip_verify_north_interface, fledge_url, wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd):
+    def test_omf_service_with_delete_add(self, reset_fledge, start_south_north, add_configure_filter, add_filter,
+                                         read_data_from_pi_web_api,
+                                         start_north_pi_server_c_web_api_service, skip_verify_north_interface,
+                                         fledge_url, wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd, pi_db):
         """ Test OMF as a North service by deleting and adding north service.
-            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
             reset_fledge: Fixture to reset fledge
             start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            read_data_from_pi_web_api: Fixture to read data from PI web API
+            skip_verify_north_interface: Flag for assertion of data using PI web API
             Assertions:
-                on endpoint GET /fledge/south
                 on endpoint GET /fledge/ping
-                on endpoint GET /fledge/asset"""               
-        
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/north
+                on endpoint GET /fledge/filter
+                on endpoint GET /fledge/service
+                on endpoint GET /fledge/statistics
+                on endpoint GET /fledge/asset
+                on endpoint GET /fledge/track"""
+
         global north_schedule_id
-        
-        # Wait until south and north services are created
+
+        # Wait until south, north services and filters are created
         time.sleep(wait_time)
-        
-        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         verify_asset(fledge_url)
-        verify_service_added(fledge_url)      
-        verify_filter_added(fledge_url)  
+        verify_service_added(fledge_url)
+        verify_filter_added(fledge_url)
         verify_statistics_map(fledge_url, skip_verify_north_interface)
-        
+        verify_asset_tracking_details(fledge_url, skip_verify_north_interface)
+
         delete_url = "/fledge/service/{}".format(north_service_name)
         resp = utils.delete_request(fledge_url, delete_url)
         assert "Service {} deleted successfully.".format(north_service_name) == resp['result']
-        
+
         # Wait for service to get deleted
         time.sleep(wait_time)
-    
-        response = start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_user=pi_admin, pi_pwd=pi_passwd)
+
+        response = start_north_pi_server_c_web_api_service(fledge_url, pi_host, pi_port, pi_user=pi_admin,
+                                                           pi_pwd=pi_passwd)
         north_schedule_id = response["id"]
-        
+
         filter_cfg_scale = {"enable": "true"}
         add_filter("scale", None, "SF2", filter_cfg_scale, fledge_url, north_service_name, installation_type='package')
-        
+
         # Wait for service and filter to get added
         time.sleep(wait_time)
-        
-        verify_service_added(fledge_url)      
+
+        verify_service_added(fledge_url)
         verify_filter_added(fledge_url)
-        
+
         old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
-        
+
         # Wait for read and sent readings to increase
         time.sleep(wait_time)
-        
+
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after delete/add of north service
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
-        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
-        
-    
-    def test_omf_service_with_delete_add_filter(self, reset_fledge, start_south_north, add_configure_filter, add_filter, skip_verify_north_interface, fledge_url, wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd):
+
+        if not skip_verify_north_interface:
+            assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+            _verify_egress(read_data_from_pi_web_api, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
+                           south_asset_name)
+
+    def test_omf_service_with_delete_add_filter(self, reset_fledge, start_south_north, add_configure_filter, add_filter,
+                                                read_data_from_pi_web_api,
+                                                skip_verify_north_interface, fledge_url, wait_time, retries, pi_host,
+                                                pi_port, pi_admin, pi_passwd, pi_db):
         """ Test OMF as a North service by deleting and adding north service.
-            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
             reset_fledge: Fixture to reset fledge
             start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            read_data_from_pi_web_api: Fixture to read data from PI web API
+            skip_verify_north_interface: Flag for assertion of data using PI web API
             Assertions:
-                on endpoint GET /fledge/south
                 on endpoint GET /fledge/ping
-                on endpoint GET /fledge/asset"""       
-        
-        # Wait until south and north services are created
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/north
+                on endpoint GET /fledge/filter
+                on endpoint GET /fledge/service
+                on endpoint GET /fledge/statistics
+                on endpoint GET /fledge/asset
+                on endpoint GET /fledge/track"""
+
+        # Wait until south, north services and filters are created
         time.sleep(wait_time)
-        
-        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         verify_asset(fledge_url)
-        verify_service_added(fledge_url)      
-        verify_filter_added(fledge_url)  
+        verify_service_added(fledge_url)
+        verify_filter_added(fledge_url)
         verify_statistics_map(fledge_url, skip_verify_north_interface)
-        
+        verify_asset_tracking_details(fledge_url, skip_verify_north_interface)
+
         data = {"pipeline": []}
         put_url = "/fledge/filter/{}/pipeline?allow_duplicates=true&append_filter=false" \
             .format(north_service_name)
-        resp = utils.put_request(fledge_url, urllib.parse.quote(put_url, safe='?,=,&,/'), data)
-        
+        utils.put_request(fledge_url, urllib.parse.quote(put_url, safe='?,=,&,/'), data)
+
         delete_url = "/fledge/filter/{}".format(filter1_name)
         resp = utils.delete_request(fledge_url, delete_url)
         assert "Filter {} deleted successfully".format(filter1_name) == resp['result']
-        
-        # Wait for service to get deleted
+
+        # Wait for filter to get deleted
         time.sleep(wait_time)
-        
+
         filter_cfg_scale = {"enable": "true"}
-        add_filter("scale", None, filter1_name, filter_cfg_scale, fledge_url, north_service_name, installation_type='package')
-        
+        add_filter("scale", None, filter1_name, filter_cfg_scale, fledge_url, north_service_name,
+                   installation_type='package')
+
         # Wait for filter to get added
         time.sleep(wait_time)
-      
+
         verify_filter_added(fledge_url)
-        
+
         old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
-        
+
         # Wait for read and sent readings to increase
         time.sleep(wait_time)
-        
+
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after delete/add of north service
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
-        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
-        
-    def test_omf_service_with_filter_reorder(self, reset_fledge, start_south_north, add_configure_filter, add_filter, skip_verify_north_interface, fledge_url, wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd):
+
+        if not skip_verify_north_interface:
+            assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+            _verify_egress(read_data_from_pi_web_api, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
+                           south_asset_name)
+
+    def test_omf_service_with_filter_reorder(self, reset_fledge, start_south_north, add_configure_filter, add_filter,
+                                             read_data_from_pi_web_api,
+                                             skip_verify_north_interface, fledge_url, wait_time, retries, pi_host,
+                                             pi_port, pi_admin, pi_passwd, pi_db):
         """ Test OMF as a North service by deleting and adding north service.
-            remove_and_add_pkgs: Fixture to remove and install latest fledge packages
             reset_fledge: Fixture to reset fledge
             start_south_north: Adds and configures south(sinusoid) and north(OMF) service
+            read_data_from_pi_web_api: Fixture to read data from PI web API
+            skip_verify_north_interface: Flag for assertion of data using PI web API
             Assertions:
-                on endpoint GET /fledge/south
                 on endpoint GET /fledge/ping
-                on endpoint GET /fledge/asset"""       
-        
-        # Wait until south and north services are created
+                on endpoint GET /fledge/south
+                on endpoint GET /fledge/north
+                on endpoint GET /fledge/filter
+                on endpoint GET /fledge/service
+                on endpoint GET /fledge/statistics
+                on endpoint GET /fledge/asset
+                on endpoint GET /fledge/track"""
+
+        # Wait until south, north services and filters are created
         time.sleep(wait_time)
-        
-        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)        
+
+        verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         verify_asset(fledge_url)
-        verify_service_added(fledge_url)      
-        verify_filter_added(fledge_url)  
-        verify_statistics_map(fledge_url, skip_verify_north_interface)  
+        verify_service_added(fledge_url)
+        verify_filter_added(fledge_url)
+        verify_statistics_map(fledge_url, skip_verify_north_interface)
+        verify_asset_tracking_details(fledge_url, skip_verify_north_interface)
 
         # Adding second filter
         filter_cfg_meta = {"enable": "true"}
-        resp = add_filter("metadata", None, filter2_name, filter_cfg_meta, fledge_url, north_service_name, installation_type='package')
-        
+        add_filter("metadata", None, filter2_name, filter_cfg_meta, fledge_url, north_service_name,
+                   installation_type='package')
+
         # Wait for filter to get added
         time.sleep(wait_time)
-      
+
         result = verify_filter_added(fledge_url)
         assert filter2_name in [s["name"] for s in result["filters"]]
-        
+
         # Verify the filter pipeline order
         get_url = "/fledge/filter/{}/pipeline".format(north_service_name)
         resp = utils.get_request(fledge_url, get_url)
         assert filter1_name == resp['result']['pipeline'][0]
         assert filter2_name == resp['result']['pipeline'][1]
-        
+
         data = {"pipeline": ["{}".format(filter2_name), "{}".format(filter1_name)]}
         put_url = "/fledge/filter/{}/pipeline?allow_duplicates=true&append_filter=false" \
             .format(north_service_name)
-        resp = utils.put_request(fledge_url, urllib.parse.quote(put_url, safe='?,=,&,/'), data)
-        
-        # Verify the filter pipeline order
+        utils.put_request(fledge_url, urllib.parse.quote(put_url, safe='?,=,&,/'), data)
+
+        # Verify the filter pipeline order after reordering
         get_url = "/fledge/filter/{}/pipeline".format(north_service_name)
         resp = utils.get_request(fledge_url, get_url)
         assert filter2_name == resp['result']['pipeline'][0]
         assert filter1_name == resp['result']['pipeline'][1]
-        
+
         old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
-        
+
         # Wait for read and sent readings to increase
         time.sleep(wait_time)
-        
+
         new_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         # Verifies whether Read and Sent readings are increasing after reordering of filters
         assert old_ping_result['dataRead'] < new_ping_result['dataRead']
-        assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+
+        if not skip_verify_north_interface:
+            assert old_ping_result['dataSent'] < new_ping_result['dataSent']
+            _verify_egress(read_data_from_pi_web_api, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
+                           south_asset_name)


### PR DESCRIPTION
Signed-off-by: YashTatkondawar <yashtatkondawar@gmail.com>

Tests with different scenarios related to north service are complete.

Pending Items related to filters with North service:
- [x] Add filter to the North service.
- [x] Disable/Enable the filter.
- [x] Reconfiguration of the attached filter North service.
- [x] Delete/re-add the North service (with filter now). - Skipped because of FOGL-5215
- [x] Change the order of the filters.
- [x] Delete and re-add the filter.