### PR TITLE
FOGL-5573: Change default behavior of OMF North plugin to have concise naming

### DIFF
--- a/C/plugins/north/OMF/include/omf.h
+++ b/C/plugins/north/OMF/include/omf.h
@@ -33,6 +33,14 @@ enum OMF_ENDPOINT {
 	ENDPOINT_EDS
 };
 
+enum NAMINGSCHEME_ENDPOINT {
+	NAMINGSCHEME_CONCISE,
+	NAMINGSCHEME_SUFFIX,
+	NAMINGSCHEME_HASH,
+	NAMINGSCHEME_COMPATIBILITY
+};
+
+
 using namespace std;
 using namespace rapidjson;
 
@@ -113,6 +121,12 @@ class OMF
 
 		// Set which PIServer component should be used for the communication
 		void setPIServerEndpoint(const OMF_ENDPOINT PIServerEndpoint);
+
+		// Set the naming sche of the objects in the endpoint
+		void setNamingScheme(const NAMINGSCHEME_ENDPOINT namingScheme) {m_NamingScheme = namingScheme;};
+
+		// FIXME_I:
+		std::string suffixType(long typeId);
 
 		// Set the first level of hierarchy in Asset Framework in which the assets will be created, PI Web API only.
 		void setDefaultAFLocation(const std::string &DefaultAFLocation);
@@ -281,12 +295,13 @@ private:
 			unsigned long valueLong = 0;
 		};
 
-		std::string	        m_assetName;
-		const std::string	m_path;
-		long			    m_typeId;
-		const std::string	m_producerToken;
-		OMF_ENDPOINT		m_PIServerEndpoint;
-		std::string		    m_DefaultAFLocation;
+		std::string	          m_assetName;
+		const std::string	  m_path;
+		long			      m_typeId;
+		const std::string	  m_producerToken;
+		OMF_ENDPOINT		  m_PIServerEndpoint;
+		NAMINGSCHEME_ENDPOINT m_NamingScheme;
+		std::string		      m_DefaultAFLocation;
 
 		bool            m_sendFullStructure;
 		// AF hierarchies handling - Metadata MAP

--- a/C/plugins/north/OMF/include/omf.h
+++ b/C/plugins/north/OMF/include/omf.h
@@ -124,16 +124,16 @@ class OMF
 		// Set which PIServer component should be used for the communication
 		void setPIServerEndpoint(const OMF_ENDPOINT PIServerEndpoint);
 
-		// Set the naming sche of the objects in the endpoint
+		// Set the naming scheme of the objects in the endpoint
 		void setNamingScheme(const NAMINGSCHEME_ENDPOINT namingScheme) {m_NamingScheme = namingScheme;};
 
-		// FIXME_I:
-		std::string generateSuffixType(string &assetName, long typeId);
-
-		// FIXME_I:
+		// Generate the container id for the given asset
 		std::string generateMeasurementId(const string& assetName);
 
-		// FIXME_I:
+		// Generate a suffix for the given asset in relation to the selected naming schema and the value of the type id
+		std::string generateSuffixType(string &assetName, long typeId);
+
+		// Generate a suffix for the given asset in relation to the selected naming schema and the value of the type id
 		long getNamingScheme(const string& assetName);
 
 		// Set the first level of hierarchy in Asset Framework in which the assets will be created, PI Web API only.

--- a/C/plugins/north/OMF/include/omf.h
+++ b/C/plugins/north/OMF/include/omf.h
@@ -126,7 +126,10 @@ class OMF
 		void setNamingScheme(const NAMINGSCHEME_ENDPOINT namingScheme) {m_NamingScheme = namingScheme;};
 
 		// FIXME_I:
-		std::string suffixType(long typeId);
+		std::string generateSuffixType(long typeId);
+
+		// FIXME_I:
+		std::string generateMeasurementId(string& assetName);
 
 		// Set the first level of hierarchy in Asset Framework in which the assets will be created, PI Web API only.
 		void setDefaultAFLocation(const std::string &DefaultAFLocation);
@@ -396,7 +399,7 @@ class OMFData
 {
 	public:
 		OMFData(const Reading& reading,
-			const long typeId,
+			string measurementId,
 			const OMF_ENDPOINT PIServerEndpoint = ENDPOINT_CR,
 			const std::string& DefaultAFLocation = std::string(),
 			OMFHints *hints = NULL);

--- a/C/plugins/north/OMF/include/omf.h
+++ b/C/plugins/north/OMF/include/omf.h
@@ -59,6 +59,8 @@ class OMFDataTypes
                 long           typeId;
                 std::string    types;
                 unsigned long  typesShort;
+				long           namingScheme;
+
 		unsigned short hintChkSum;
 };
 
@@ -126,10 +128,13 @@ class OMF
 		void setNamingScheme(const NAMINGSCHEME_ENDPOINT namingScheme) {m_NamingScheme = namingScheme;};
 
 		// FIXME_I:
-		std::string generateSuffixType(long typeId);
+		std::string generateSuffixType(string &assetName, long typeId);
 
 		// FIXME_I:
 		std::string generateMeasurementId(const string& assetName);
+
+		// FIXME_I:
+		long getNamingScheme(const string& assetName);
 
 		// Set the first level of hierarchy in Asset Framework in which the assets will be created, PI Web API only.
 		void setDefaultAFLocation(const std::string &DefaultAFLocation);

--- a/C/plugins/north/OMF/include/omf.h
+++ b/C/plugins/north/OMF/include/omf.h
@@ -129,7 +129,7 @@ class OMF
 		std::string generateSuffixType(long typeId);
 
 		// FIXME_I:
-		std::string generateMeasurementId(string& assetName);
+		std::string generateMeasurementId(const string& assetName);
 
 		// Set the first level of hierarchy in Asset Framework in which the assets will be created, PI Web API only.
 		void setDefaultAFLocation(const std::string &DefaultAFLocation);

--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -1939,6 +1939,13 @@ const std::string OMF::createContainerData(const Reading& reading, OMFHints *hin
  */
 const std::string OMF::createStaticData(const Reading& reading)
 {
+
+	//# FIXME_I
+	Logger::getLogger()->setMinLevel("debug");
+	Logger::getLogger()->debug("xxx3 %s - ", __FUNCTION__);
+	Logger::getLogger()->setMinLevel("warning");
+
+
 	string assetName;
 	// Build the Static data (JSON Array)
 	string sData = "[";
@@ -1985,15 +1992,41 @@ const std::string OMF::createStaticData(const Reading& reading)
 
 		retrieveAFHierarchyPrefixAssetName(assetName, AFHierarchyPrefix, AFHierarchyLevel);
 
-		sData.append(assetName + AF_TYPES_SUFFIX + to_string(typeId));
+		sData.append(assetName + suffixType(typeId));
 		sData.append("\", \"AssetId\": \"");
-		sData.append("A_" + AFHierarchyPrefix + "_" + assetName + AF_TYPES_SUFFIX + to_string(typeId));
+		sData.append("A_" + AFHierarchyPrefix + "_" + assetName + suffixType(typeId) );
 	}
 
 	sData.append("\"}]}]");
 
 	// Return JSON string
 	return sData;
+}
+
+// FIXME_I:
+std::string OMF::suffixType(long typeId)
+{
+	std::string suffix;
+
+	if (m_NamingScheme == NAMINGSCHEME_COMPATIBILITY ||
+		m_NamingScheme == NAMINGSCHEME_SUFFIX)
+	{
+		suffix = AF_TYPES_SUFFIX + to_string(typeId);
+
+	} else {
+		if (typeId > 1)
+		{
+			suffix = AF_TYPES_SUFFIX + to_string(typeId);
+		}
+
+	}
+
+	//# FIXME_I
+	Logger::getLogger()->setMinLevel("debug");
+	Logger::getLogger()->debug("xxx4 %s - NamingScheme :%d: typeId :%ld: suffix :%s:", __FUNCTION__, m_NamingScheme, typeId, suffix.c_str());
+	Logger::getLogger()->setMinLevel("warning");
+
+	return(suffix);
 }
 
 /**
@@ -2059,7 +2092,7 @@ std::string OMF::createLinkData(const Reading& reading,  std::string& AFHierarch
 		StringReplace(tmpStr, "_placeholder_src_type_", AFHierarchyPrefix + "_" + AFHierarchyLevel + "_typeid");
 		StringReplace(tmpStr, "_placeholder_src_idx_",  AFHierarchyPrefix + "_" + AFHierarchyLevel );
 		StringReplace(tmpStr, "_placeholder_tgt_type_", targetTypeId);
-		StringReplace(tmpStr, "_placeholder_tgt_idx_",  "A_" + objectPrefix + "_" + assetName + AF_TYPES_SUFFIX +  to_string(typeId));
+		StringReplace(tmpStr, "_placeholder_tgt_idx_",  "A_" + objectPrefix + "_" + assetName + suffixType(typeId) );
 
 		lData.append(tmpStr);
 		lData.append(",");
@@ -2087,7 +2120,7 @@ std::string OMF::createLinkData(const Reading& reading,  std::string& AFHierarch
 	}
 	else if (m_PIServerEndpoint == ENDPOINT_PIWEB_API)
 	{
-		lData.append("A_" + objectPrefix + "_" + assetName + AF_TYPES_SUFFIX + to_string(typeId));
+		lData.append("A_" + objectPrefix + "_" + assetName + suffixType(typeId) );
 	}
 
 	measurementId = to_string(OMF::getAssetTypeId(assetName)) + "measurement_" + assetName;

--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -1942,18 +1942,6 @@ std::string OMF::generateMeasurementId(const string& assetName)
 
 	typeId = OMF::getAssetTypeId(assetName);
 
-	//###   #########################################################################################:
-//	measurementId = to_string(typeId) + "measurement_" + assetName;
-//
-//	// Add the 1st level of AFHierarchy as a prefix to the name in case of PI Web API
-//	if (m_PIServerEndpoint == ENDPOINT_PIWEB_API)
-//	{
-//		retrieveAFHierarchyPrefixAssetName(assetName, AFHierarchyPrefix, AFHierarchyLevel);
-//
-//		measurementId = AFHierarchyPrefix + "_" + measurementId;
-//	}
-	//###   #########################################################################################:
-
 	if (m_NamingScheme == NAMINGSCHEME_COMPATIBILITY ||
 		m_NamingScheme == NAMINGSCHEME_HASH)
 	{

--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -1931,7 +1931,7 @@ const std::string OMF::createContainerData(const Reading& reading, OMFHints *hin
 }
 
 // FIXME_I:
-std::string OMF::generateMeasurementId(string& assetName)
+std::string OMF::generateMeasurementId(const string& assetName)
 {
 	std::string measurementId;
 

--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -124,6 +124,12 @@ OMFData::OMFData(const Reading& reading, string measurementId, const OMF_ENDPOIN
 	string outData;
 	bool changed;
 
+	// FIXME_I:
+	Logger::getLogger()->setMinLevel("debug");
+	Logger::getLogger()->debug("xxx2 %s - measurementId :%s: ", __FUNCTION__, measurementId.c_str());
+	Logger::getLogger()->setMinLevel("warning");
+
+
 	// Apply any TagName hints to modify the containerid
 	if (hints)
 	{
@@ -1157,9 +1163,6 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 			keyComplete = AFHierarchyPrefix + "_" + m_assetName;
 		}
 
-		// FIXME_I:
-		measurementId = generateMeasurementId(m_assetName);
-
 		if (! usingTagHint)
 		{
 			/*
@@ -1258,6 +1261,9 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 			// Create the key for dataTypes sending once
 			typeId = OMF::getAssetTypeId(m_assetName);
 		}
+
+		// FIXME_I:
+		measurementId = generateMeasurementId(m_assetName);
 
 		string outData = OMFData(*reading, measurementId, m_PIServerEndpoint, AFHierarchyPrefix, hints ).OMFdataVal();
 		if (!outData.empty())

--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -124,11 +124,7 @@ OMFData::OMFData(const Reading& reading, string measurementId, const OMF_ENDPOIN
 	string outData;
 	bool changed;
 
-	// FIXME_I:
-	Logger::getLogger()->setMinLevel("debug");
-	Logger::getLogger()->debug("xxx2 %s - measurementId :%s: ", __FUNCTION__, measurementId.c_str());
-	Logger::getLogger()->setMinLevel("warning");
-
+	Logger::getLogger()->debug("%s - measurementId :%s: ", __FUNCTION__, measurementId.c_str());
 
 	// Apply any TagName hints to modify the containerid
 	if (hints)
@@ -1262,7 +1258,6 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 			typeId = OMF::getAssetTypeId(m_assetName);
 		}
 
-		// FIXME_I:
 		measurementId = generateMeasurementId(m_assetName);
 
 		string outData = OMFData(*reading, measurementId, m_PIServerEndpoint, AFHierarchyPrefix, hints ).OMFdataVal();
@@ -1807,10 +1802,8 @@ const std::string OMF::createTypeData(const Reading& reading, OMFHints *hints)
 		// Add datapoint Type
 		tData.append(omfType);
 
-		// FIXME_I:
 		tData.append("\", \"name\": \"");
 		tData.append(ApplyPIServerNamingRulesObj(dpName, nullptr) );
-		tData.append("_v2");
 
 		// Applies a format if it is defined
 		if (! format.empty() ) {
@@ -1905,7 +1898,6 @@ const std::string OMF::createContainerData(const Reading& reading, OMFHints *hin
 				     cData);
 	}
 
-	// FIXME_I:
 	measurementId = generateMeasurementId(assetName);
 
 	// Apply any TagName hints to modify the containerid
@@ -1930,7 +1922,12 @@ const std::string OMF::createContainerData(const Reading& reading, OMFHints *hin
 	return cData;
 }
 
-// FIXME_I:
+/**
+ * Generate the container id for the given asset
+ *
+ * @param assetName  Asset for quick the container id should be generated
+ * @return           Container it for the requested asset
+ */
 std::string OMF::generateMeasurementId(const string& assetName)
 {
 	std::string measurementId;
@@ -1959,7 +1956,6 @@ std::string OMF::generateMeasurementId(const string& assetName)
 	} else {
 		if (typeId > 1)
 		{
-			// FIXME_I:
 			measurementId = to_string(typeId) + "measurement_" + assetName;
 		} else {
 
@@ -1968,21 +1964,25 @@ std::string OMF::generateMeasurementId(const string& assetName)
 
 	}
 
-	//# FIXME_I
-	Logger::getLogger()->setMinLevel("debug");
-	Logger::getLogger()->debug("xxx2 %s - mamingScheme default :%ld: namingScheme applied :%ld:  assetName :%s: typeId :%ld: measurementId :%s:",
+	Logger::getLogger()->debug("%s - mamingScheme default :%ld: namingScheme applied :%ld:  assetName :%s: typeId :%ld: measurementId :%s:",
 							   __FUNCTION__,
 							   m_NamingScheme,
 							   namingScheme,
 							   assetName.c_str(), 
 							   typeId, 
 							   measurementId.c_str() );
-	Logger::getLogger()->setMinLevel("warning");
 
 	return(measurementId);
 }
 
-// FIXME_I:
+
+/**
+ * Generate a suffix for the given asset in relation to the selected naming schema and the value of the type id
+ *
+ * @param assetName  Asset for quick the suffix should be generated
+ * @param typeId     TYpe id of the asset
+ * @return           Suffix to be used for the given asset
+ */
 std::string OMF::generateSuffixType(string &assetName, long typeId)
 {
 	std::string suffix;
@@ -2003,15 +2003,12 @@ std::string OMF::generateSuffixType(string &assetName, long typeId)
 
 	}
 
-	//# FIXME_I
-	Logger::getLogger()->setMinLevel("debug");
-	Logger::getLogger()->debug("xxx2 %s - mamingScheme default :%ld: namingScheme applied :%ld: typeId :%ld: suffix :%s:",
+	Logger::getLogger()->debug("%s - mamingScheme default :%ld: namingScheme applied :%ld: typeId :%ld: suffix :%s:",
 		__FUNCTION__, 
 		m_NamingScheme,
 		namingScheme,
 		typeId, 
 		suffix.c_str());
-	Logger::getLogger()->setMinLevel("warning");
 
 	return(suffix);
 }
@@ -2027,13 +2024,6 @@ std::string OMF::generateSuffixType(string &assetName, long typeId)
  */
 const std::string OMF::createStaticData(const Reading& reading)
 {
-
-	//# FIXME_I
-	Logger::getLogger()->setMinLevel("debug");
-	Logger::getLogger()->debug(" %s - ", __FUNCTION__);
-	Logger::getLogger()->setMinLevel("warning");
-
-
 	string assetName;
 	// Build the Static data (JSON Array)
 	string sData = "[";
@@ -2187,15 +2177,7 @@ std::string OMF::createLinkData(const Reading& reading,  std::string& AFHierarch
 		lData.append("A_" + objectPrefix + "_" + assetName + generateSuffixType(assetName, typeId) );
 	}
 
-	// FIXME_I:
 	measurementId = generateMeasurementId(assetName);
-	//measurementId = to_string(OMF::getAssetTypeId(assetName)) + "measurement_" + assetName;
-
-//	// Add the 1st level of AFHierarchy as a prefix to the name in case of PI Web API
-//	if (m_PIServerEndpoint == ENDPOINT_PIWEB_API)
-//	{
-//		measurementId = objectPrefix + "_" + measurementId;
-//	}
 
 	// Apply any TagName hints to modify the containerid
 	if (hints)
@@ -3239,7 +3221,13 @@ long OMF::getAssetTypeId(const string& assetName)
 	return typeId;
 }
 
-// FIXME_I:
+/**
+ * Retrieve the naming scheme for the given asset in relation to the end point selected the default naming scheme selected
+ * and the naming scheme of the asset itself
+ *
+ * @param assetName  Asset for quick the naming schema should be retrieved
+ * @return           Naming schema of the given asset
+ */
 long OMF::getNamingScheme(const string& assetName)
 {
 	long namingScheme;
@@ -3538,11 +3526,7 @@ bool OMF::setCreatedTypes(const Reading& row, OMFHints *hints)
 
 	(*m_OMFDataTypes)[keyComplete].namingScheme = m_NamingScheme;
 
-	//# FIXME_I
-	Logger::getLogger()->setMinLevel("debug");
-	Logger::getLogger()->debug("xxx3 %s - keyComplete :%s: m_NamingScheme :%ld: ", __FUNCTION__, keyComplete.c_str(), m_NamingScheme);
-	Logger::getLogger()->setMinLevel("warning");
-
+	Logger::getLogger()->debug("%s - keyComplete :%s: m_NamingScheme :%ld: ", __FUNCTION__, keyComplete.c_str(), m_NamingScheme);
 
 	return true;
 }

--- a/C/plugins/north/OMF/plugin.cpp
+++ b/C/plugins/north/OMF/plugin.cpp
@@ -118,11 +118,19 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"displayName": "Send full structure",
 			"validity" : "PIServerEndpoint == \"PI Web API\""
 		},
+		"NamingScheme": {
+			"description": "Define the naming scheme of the objects in the endpoint",
+			"type": "enumeration",
+			"options":["Concise", "Use Type Suffix", "Use Attribute Hash", "Backward compatibility"],
+			"default": "Concise",
+			"order": "3",
+			"displayName": "Naming Scheme"
+		},
 		"ServerHostname": {
 			"description": "Hostname of the server running the endpoint either PI Web API or Connector Relay",
 			"type": "string",
 			"default": "localhost",
-			"order": "3",
+			"order": "4",
 			"displayName": "Server hostname",
 			"validity" : "PIServerEndpoint != \"Edge Data Store\" && PIServerEndpoint != \"OSIsoft Cloud Services\""
 		},
@@ -130,7 +138,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"description": "Port on which the endpoint either PI Web API or Connector Relay or Edge Data Store is listening, 0 will use the default one",
 			"type": "integer",
 			"default": "0",
-			"order": "4",
+			"order": "5",
 			"displayName": "Server port, 0=use the default",
 			"validity" : "PIServerEndpoint != \"OSIsoft Cloud Services\""
 		},
@@ -138,7 +146,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"description": "The producer token that represents this Fledge stream",
 			"type": "string",
 			"default": "omf_north_0001",
-			"order": "5",
+			"order": "6",
 			"displayName": "Producer Token",
 			"validity" : "PIServerEndpoint == \"Connector Relay\""
 		},
@@ -147,63 +155,63 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"type": "enumeration",
 			"options":["readings", "statistics"],
 			"default": "readings",
-			"order": "6",
+			"order": "7",
 			"displayName": "Data Source"
 		},
 		"StaticData": {
 			"description": "Static data to include in each sensor reading sent to the PI Server.",
 			"type": "string",
 			"default": "Location: Palo Alto, Company: Dianomic",
-			"order": "7",
+			"order": "8",
 			"displayName": "Static Data"
 		},
 		"OMFRetrySleepTime": {
 			"description": "Seconds between each retry for the communication with the OMF PI Connector Relay, NOTE : the time is doubled at each attempt.",
 			"type": "integer",
 			"default": "1",
-			"order": "8",
+			"order": "9",
 			"displayName": "Sleep Time Retry"
 		},
 		"OMFMaxRetry": {
 			"description": "Max number of retries for the communication with the OMF PI Connector Relay",
 			"type": "integer",
 			"default": "3",
-			"order": "9",
+			"order": "10",
 			"displayName": "Maximum Retry"
 		},
 		"OMFHttpTimeout": {
 			"description": "Timeout in seconds for the HTTP operations with the OMF PI Connector Relay",
 			"type": "integer",
 			"default": "10",
-			"order": "10",
+			"order": "11",
 			"displayName": "HTTP Timeout"
 		},
 		"formatInteger": {
 			"description": "OMF format property to apply to the type Integer",
 			"type": "string",
 			"default": "int64",
-			"order": "11",
+			"order": "12",
 			"displayName": "Integer Format"
 		},
 		"formatNumber": {
 			"description": "OMF format property to apply to the type Number",
 			"type": "string",
 			"default": "float64",
-			"order": "12",
+			"order": "13",
 			"displayName": "Number Format"
 		},
 		"compression": {
 			"description": "Compress readings data before sending to PI server",
 			"type": "boolean",
 			"default": "true",
-			"order": "13",
+			"order": "14",
 			"displayName": "Compression"
 		},
 		"DefaultAFLocation": {
 			"description": "Defines the hierarchies tree in Asset Framework in which the assets will be created, each level is separated by /, PI Web API only.",
 			"type": "string",
 			"default": "/fledge/data_piwebapi/default",
-			"order": "14",
+			"order": "15",
 			"displayName": "Asset Framework hierarchies tree",
 			"validity" : "PIServerEndpoint == \"PI Web API\""
 		},
@@ -211,7 +219,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"description": "Defines a set of rules to address where assets should be placed in the AF hierarchy.",
 			"type": "JSON",
 			"default": AF_HIERARCHY_RULES,
-			"order": "15",
+			"order": "16",
 			"displayName": "Asset Framework hierarchies rules",
 			"validity" : "PIServerEndpoint == \"PI Web API\""
 		},
@@ -219,14 +227,14 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"description": "These errors are considered not blocking in the communication with the PI Server, the sending operation will proceed with the next block of data if one of these is encountered",
 			"type": "JSON",
 			"default": NOT_BLOCKING_ERRORS_DEFAULT,
-			"order": "16" ,
+			"order": "17" ,
 			"readonly": "true"
 		},
 		"streamId": {
 			"description": "Identifies the specific stream to handle and the related information, among them the ID of the last object streamed.",
 			"type": "integer",
 			"default": "0",
-			"order": "17" ,
+			"order": "18" ,
 			"readonly": "true"
 		},
 		"PIWebAPIAuthenticationMethod": {
@@ -234,7 +242,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"type": "enumeration",
 			"options":["anonymous", "basic", "kerberos"],
 			"default": "anonymous",
-			"order": "18",
+			"order": "19",
 			"displayName": "PI Web API Authentication Method",
 			"validity" : "PIServerEndpoint == \"PI Web API\""
 		},
@@ -242,7 +250,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"description": "User id of PI Web API to be used with the basic access authentication.",
 			"type": "string",
 			"default": "user_id",
-			"order": "19",
+			"order": "20",
 			"displayName": "PI Web API User Id",
 			"validity" : "PIServerEndpoint == \"PI Web API\" && PIWebAPIAuthenticationMethod == \"basic\""
 		},
@@ -250,7 +258,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"description": "Password of the user of PI Web API to be used with the basic access authentication.",
 			"type": "password",
 			"default": "password",
-			"order": "20" ,
+			"order": "21" ,
 			"displayName": "PI Web API Password",
 			"validity" : "PIServerEndpoint == \"PI Web API\" && PIWebAPIAuthenticationMethod == \"basic\""
 		},
@@ -258,7 +266,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"description": "Keytab file name used for Kerberos authentication in PI Web API.",
 			"type": "string",
 			"default": "piwebapi_kerberos_https.keytab",
-			"order": "21" ,
+			"order": "22" ,
 			"displayName": "PI Web API Kerberos keytab file",
 			"validity" : "PIServerEndpoint == \"PI Web API\" && PIWebAPIAuthenticationMethod == \"kerberos\""
 		},
@@ -266,7 +274,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"description" : "Specifies the OCS namespace where the information are stored and it is used for the interaction with the OCS API",
 			"type" : "string",
 			"default": "name_space",
-			"order": "22",
+			"order": "23",
 			"displayName" : "OCS Namespace",
 			"validity" : "PIServerEndpoint == \"OSIsoft Cloud Services\""
 		},
@@ -274,7 +282,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"description" : "Tenant id associated to the specific OCS account",
 			"type" : "string",
 			"default": "ocs_tenant_id",
-			"order": "23",
+			"order": "24",
 			"displayName" : "OCS Tenant ID",
 			"validity" : "PIServerEndpoint == \"OSIsoft Cloud Services\""
 		},
@@ -282,7 +290,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"description" : "Client id associated to the specific OCS account, it is used to authenticate the source for using the OCS API",
 			"type" : "string",
 			"default": "ocs_client_id",
-			"order": "24",
+			"order": "25",
 			"displayName" : "OCS Client ID",
 			"validity" : "PIServerEndpoint == \"OSIsoft Cloud Services\""
 		},
@@ -290,7 +298,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"description" : "Client secret associated to the specific OCS account, it is used to authenticate the source for using the OCS API",
 			"type" : "password",
 			"default": "ocs_client_secret",
-			"order": "25",
+			"order": "26",
 			"displayName" : "OCS Client Secret",
 			"validity" : "PIServerEndpoint == \"OSIsoft Cloud Services\""
 		},
@@ -298,7 +306,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"description": "These errors are considered not blocking in the communication with the PI Web API, the sending operation will proceed with the next block of data if one of these is encountered",
 			"type": "JSON",
 			"default": NOT_BLOCKING_ERRORS_DEFAULT_PI_WEB_API,
-			"order": "26" ,
+			"order": "27" ,
 			"readonly": "true"
 		}
 	}
@@ -326,6 +334,7 @@ typedef struct
 	string		formatNumber;	        // OMF protocol Number format
 	string		formatInteger;	        // OMF protocol Integer format
 	OMF_ENDPOINT PIServerEndpoint;      // Defines which End point should be used for the communication
+	NAMINGSCHEME_ENDPOINT NamingScheme; // Define how the object names should generated
 	string		DefaultAFLocation;      // 1st hierarchy in Asset Framework, PI Web API only.
 	string		AFMap;                  // Defines a set of rules to address where assets should be placed in the AF hierarchy.
 
@@ -417,6 +426,7 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* configData)
 	string ServerHostname = configData->getValue("ServerHostname");
 	string ServerPort = configData->getValue("ServerPort");
 	string url;
+	string NamingScheme = configData->getValue("NamingScheme");
 	{
 		// Translate the PIServerEndpoint configuration
 		if(PIServerEndpoint.compare("PI Web API") == 0)
@@ -597,6 +607,31 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* configData)
 		}
 	} while (pos != string::npos);
 
+	{
+		// NamingScheme handling
+		if(NamingScheme.compare("Concise") == 0)
+		{
+			connInfo->NamingScheme = NAMINGSCHEME_CONCISE;
+		}
+		else if(NamingScheme.compare("Use Type Suffix") == 0)
+		{
+			connInfo->NamingScheme = NAMINGSCHEME_SUFFIX;
+		}
+		else if(NamingScheme.compare("Use Attribute Hash") == 0)
+		{
+			connInfo->NamingScheme = NAMINGSCHEME_HASH;
+		}
+		else if(NamingScheme.compare("Backward compatibility") == 0)
+		{
+			connInfo->NamingScheme = NAMINGSCHEME_COMPATIBILITY;
+		}
+		//# FIXME_I
+		Logger::getLogger()->setMinLevel("debug");
+		Logger::getLogger()->debug("xxx4 End point naming scheme :%s: ", NamingScheme.c_str() );
+		Logger::getLogger()->setMinLevel("warning");
+
+	}
+
 	// retrieves the Pi Web Api Version
 	if (connInfo->PIServerEndpoint == ENDPOINT_PIWEB_API)
 	{
@@ -744,6 +779,7 @@ uint32_t plugin_send(const PLUGIN_HANDLE handle,
 	connInfo->omf->setSendFullStructure(connInfo->sendFullStructure);
 
 	// Set PIServerEndpoint configuration
+	connInfo->omf->setNamingScheme(connInfo->NamingScheme);
 	connInfo->omf->setPIServerEndpoint(connInfo->PIServerEndpoint);
 	connInfo->omf->setDefaultAFLocation(connInfo->DefaultAFLocation);
 	connInfo->omf->setAFMap(connInfo->AFMap);

--- a/C/plugins/north/OMF/plugin.cpp
+++ b/C/plugins/north/OMF/plugin.cpp
@@ -47,6 +47,8 @@ using namespace SimpleWeb;
 #define DATA_KEY "dataTypes"
 #define DATA_KEY_SHORT "dataTypesShort"
 #define DATA_KEY_HINT "hintChecksum"
+#define NAMING_SCHEME "namingScheme"
+
 
 #define PROPERTY_TYPE   "type"
 #define PROPERTY_NUMBER "number"
@@ -627,7 +629,7 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* configData)
 		}
 		//# FIXME_I
 		Logger::getLogger()->setMinLevel("debug");
-		Logger::getLogger()->debug("xxx4 End point naming scheme :%s: ", NamingScheme.c_str() );
+		Logger::getLogger()->debug("xxx3 End point naming scheme :%s: ", NamingScheme.c_str() );
 		Logger::getLogger()->setMinLevel("warning");
 
 	}
@@ -924,6 +926,17 @@ string saveSentDataTypes(CONNECTOR_INFO* connInfo)
 				std::string hintChecksum = hintStream.str();
 				newData << ", \"" << DATA_KEY_HINT << "\": \"0x" << hintChecksum << "\"";
 
+				// FIXME_I:
+				long NamingScheme;
+				NamingScheme = ((*it).second).namingScheme;
+				newData << ", \"" << NAMING_SCHEME << "\": " << to_string(NamingScheme) << "";
+
+				//# FIXME_I
+				Logger::getLogger()->setMinLevel("debug");
+				Logger::getLogger()->debug("xxx2 %s - NamingScheme :%ld: ", __FUNCTION__,NamingScheme );
+				Logger::getLogger()->setMinLevel("warning");
+
+
 				newData << ", \"" << DATA_KEY << "\": " <<
 					   (((*it).second).types.empty() ? "{}" : ((*it).second).types) <<
 					   "}}";
@@ -1035,8 +1048,8 @@ unsigned long calcTypeShort(const string& dataTypes)
  * all new created OMF dataTypes have type-id prefix set to the value of 1
  * while existing (loaded) OMF dataTypes will keep their type-id values.
  *
- * @param   connInfo	The CONNECTOR_INFO data scructure
- * @param   JSONData	The JSON document cotaining all saved data
+ * @param   connInfo	The CONNECTOR_INFO data structure
+ * @param   JSONData	The JSON document containing all saved data
  */
 void loadSentDataTypes(CONNECTOR_INFO* connInfo,
                         Document& JSONData)
@@ -1075,11 +1088,29 @@ void loadSentDataTypes(CONNECTOR_INFO* connInfo,
 				else
 				{
 					Logger::getLogger()->warn("%s plugin: current element '%s'" \
-								  "doesn't have '%s' property, ignoring it",
+								  " doesn't have '%s' property, ignoring it",
 								  PLUGIN_NAME,
 								  key.c_str(),
 								  TYPE_ID_KEY);
 					continue;
+				}
+
+				// FIXME_I:
+				long NamingScheme;
+				if (cachedValue.HasMember(NAMING_SCHEME) &&
+					cachedValue[NAMING_SCHEME].IsNumber())
+				{
+					NamingScheme = cachedValue[NAMING_SCHEME].GetInt();
+				}
+				else
+				{
+					// FIXME_I:
+					Logger::getLogger()->warn("xxx2 %s plugin: current element '%s'" \
+								  " doesn't have '%s' property, handling naming scheme in compatibility mode",
+											  PLUGIN_NAME,
+											  key.c_str(),
+											  NAMING_SCHEME);
+					NamingScheme = NAMINGSCHEME_COMPATIBILITY;
 				}
 
 				string dataTypes;
@@ -1095,7 +1126,7 @@ void loadSentDataTypes(CONNECTOR_INFO* connInfo,
 				else
 				{
 					Logger::getLogger()->warn("%s plugin: current element '%s'" \
-								  "doesn't have '%s' property, ignoring it",
+								  " doesn't have '%s' property, ignoring it",
 								  PLUGIN_NAME,
 								  key.c_str(),
 								  DATA_KEY);
@@ -1117,7 +1148,7 @@ void loadSentDataTypes(CONNECTOR_INFO* connInfo,
 					if (dataTypesShort == 0)
 					{
 						Logger::getLogger()->warn("%s plugin: current element '%s'" \
-                                      "doesn't have '%s' property",
+                                      " doesn't have '%s' property",
 												  PLUGIN_NAME,
 												  key.c_str(),
 												  DATA_KEY_SHORT);
@@ -1145,6 +1176,15 @@ void loadSentDataTypes(CONNECTOR_INFO* connInfo,
 				dataType.types = dataTypes;
 				dataType.typesShort = dataTypesShort;
 				dataType.hintChkSum = hintChecksum;
+				// FIXME_I:
+				dataType.namingScheme = NamingScheme;
+
+				//# FIXME_I
+				Logger::getLogger()->setMinLevel("debug");
+				Logger::getLogger()->debug("xxx2 %s - NamingScheme :%ld: ", __FUNCTION__,NamingScheme );
+				Logger::getLogger()->setMinLevel("warning");
+
+
 
 				// Add data into the map
 				connInfo->assetsDataTypes[key] = dataType;

--- a/C/plugins/north/OMF/plugin.cpp
+++ b/C/plugins/north/OMF/plugin.cpp
@@ -627,10 +627,7 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* configData)
 		{
 			connInfo->NamingScheme = NAMINGSCHEME_COMPATIBILITY;
 		}
-		//# FIXME_I
-		Logger::getLogger()->setMinLevel("debug");
-		Logger::getLogger()->debug("xxx3 End point naming scheme :%s: ", NamingScheme.c_str() );
-		Logger::getLogger()->setMinLevel("warning");
+		Logger::getLogger()->debug("End point naming scheme :%s: ", NamingScheme.c_str() );
 
 	}
 
@@ -926,16 +923,11 @@ string saveSentDataTypes(CONNECTOR_INFO* connInfo)
 				std::string hintChecksum = hintStream.str();
 				newData << ", \"" << DATA_KEY_HINT << "\": \"0x" << hintChecksum << "\"";
 
-				// FIXME_I:
 				long NamingScheme;
 				NamingScheme = ((*it).second).namingScheme;
 				newData << ", \"" << NAMING_SCHEME << "\": " << to_string(NamingScheme) << "";
 
-				//# FIXME_I
-				Logger::getLogger()->setMinLevel("debug");
-				Logger::getLogger()->debug("xxx2 %s - NamingScheme :%ld: ", __FUNCTION__,NamingScheme );
-				Logger::getLogger()->setMinLevel("warning");
-
+				Logger::getLogger()->debug("%s - NamingScheme :%ld: ", __FUNCTION__,NamingScheme );
 
 				newData << ", \"" << DATA_KEY << "\": " <<
 					   (((*it).second).types.empty() ? "{}" : ((*it).second).types) <<
@@ -1095,7 +1087,6 @@ void loadSentDataTypes(CONNECTOR_INFO* connInfo,
 					continue;
 				}
 
-				// FIXME_I:
 				long NamingScheme;
 				if (cachedValue.HasMember(NAMING_SCHEME) &&
 					cachedValue[NAMING_SCHEME].IsNumber())
@@ -1104,8 +1095,7 @@ void loadSentDataTypes(CONNECTOR_INFO* connInfo,
 				}
 				else
 				{
-					// FIXME_I:
-					Logger::getLogger()->warn("xxx2 %s plugin: current element '%s'" \
+					Logger::getLogger()->warn("%s plugin: current element '%s'" \
 								  " doesn't have '%s' property, handling naming scheme in compatibility mode",
 											  PLUGIN_NAME,
 											  key.c_str(),
@@ -1176,15 +1166,9 @@ void loadSentDataTypes(CONNECTOR_INFO* connInfo,
 				dataType.types = dataTypes;
 				dataType.typesShort = dataTypesShort;
 				dataType.hintChkSum = hintChecksum;
-				// FIXME_I:
 				dataType.namingScheme = NamingScheme;
 
-				//# FIXME_I
-				Logger::getLogger()->setMinLevel("debug");
-				Logger::getLogger()->debug("xxx2 %s - NamingScheme :%ld: ", __FUNCTION__,NamingScheme );
-				Logger::getLogger()->setMinLevel("warning");
-
-
+				Logger::getLogger()->debug("%s - NamingScheme :%ld: ", __FUNCTION__,NamingScheme );
 
 				// Add data into the map
 				connInfo->assetsDataTypes[key] = dataType;

--- a/tests/unit/C/plugins/common/test_omf_translation.cpp
+++ b/tests/unit/C/plugins/common/test_omf_translation.cpp
@@ -182,6 +182,8 @@ const string two_translated_readings = "[{\"containerid\": \"" + to_string(TYPE_
 // Compare translated readings with a provided JSON value
 TEST(OMF_transation, TwoTranslationsCompareResult)
 {
+	string measurementId;
+
 	// Build a ReadingSet from JSON
 	ReadingSet readingSet(two_readings);
 
@@ -193,8 +195,10 @@ TEST(OMF_transation, TwoTranslationsCompareResult)
 							elem != readingSet.getAllReadings().end();
 							++elem)
 	{
+		measurementId = to_string(TYPE_ID) + "measurement_luxometer";
+
 		// Add into JSON string the OMF transformed Reading data
-		jsonData << OMFData(**elem, TYPE_ID).OMFdataVal() << (elem < (readingSet.getAllReadings().end() - 1 ) ? ", " : "");
+		jsonData << OMFData(**elem, measurementId).OMFdataVal() << (elem < (readingSet.getAllReadings().end() - 1 ) ? ", " : "");
 	}
 
 	jsonData << "]";
@@ -206,6 +210,8 @@ TEST(OMF_transation, TwoTranslationsCompareResult)
 // Create ONE reading, convert it and run checks
 TEST(OMF_transation, OneReading)
 {
+	string measurementId;
+
 	ostringstream jsonData;
 	string strVal("printer");
         DatapointValue value(strVal);
@@ -216,12 +222,14 @@ TEST(OMF_transation, OneReading)
 	DatapointValue id((long) 3001);
 	lab.addDatapoint(new Datapoint("id", id));
 
+	measurementId = "dummy";
+
 	// Create the OMF Json data
 	jsonData << "[";
-	jsonData << OMFData(lab, TYPE_ID).OMFdataVal();
+	jsonData << OMFData(lab, measurementId).OMFdataVal();
 	jsonData << "]";
 
-	// "values" key is in the output 
+	// "values" key is in the output
 	ASSERT_NE(jsonData.str().find(string("\"values\" : { ")), 0);
 
 	// Parse JSON of translated data
@@ -283,6 +291,8 @@ TEST(OMF_transation, SuperSet)
 // Compare translated readings with a provided JSON value
 TEST(OMF_transation, AllReadingsWithUnsupportedTypes)
 {
+	string measurementId;
+
 	// Build a ReadingSet from JSON
 	ReadingSet readingSet(all_readings_with_unsupported_datapoints_types);
 
@@ -295,7 +305,9 @@ TEST(OMF_transation, AllReadingsWithUnsupportedTypes)
 	     elem != readingSet.getAllReadings().end();
 	     ++elem)
 	{
-		string rData =  OMFData(**elem, TYPE_ID).OMFdataVal();
+		measurementId = "dummy";
+
+		string rData =  OMFData(**elem, measurementId).OMFdataVal();
 		// Add into JSON string the OMF transformed Reading data
 		if (!rData.empty())
 		{
@@ -324,6 +336,8 @@ TEST(OMF_transation, AllReadingsWithUnsupportedTypes)
 // Compare translated readings with a provided JSON value
 TEST(OMF_transation, ReadingsWithUnsupportedTypes)
 {
+	string measurementId;
+
 	// Build a ReadingSet from JSON
 	ReadingSet readingSet(readings_with_unsupported_datapoints_types);
 
@@ -336,7 +350,9 @@ TEST(OMF_transation, ReadingsWithUnsupportedTypes)
 	     elem != readingSet.getAllReadings().end();
 	     ++elem)
 	{
-		string rData =  OMFData(**elem, TYPE_ID).OMFdataVal();
+		measurementId = "dummy";
+
+		string rData =  OMFData(**elem, measurementId).OMFdataVal();
 		// Add into JSON string the OMF transformed Reading data
 		if (!rData.empty())
 		{
@@ -406,7 +422,7 @@ TEST(OMF_AfHierarchy, HandleAFMapEmpty)
 	// Dummy initializations
 	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
 	OMF omf(sender, "/", 1, "ABC");
-	
+
 	// Test
 	omf.setAFMap(af_hierarchy_test02);
 
@@ -422,7 +438,7 @@ TEST(OMF_AfHierarchy, HandleAFMapNamesBad)
 	Document JSon;
 
 	map<std::string, std::string> MetadataRulesExist;
-	
+
 	// Dummy initializations
 	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
 	OMF omf(sender, "/", 1, "ABC");
@@ -471,4 +487,74 @@ TEST(PiServer_NamingRules, NamingRulesCheck)
 	ASSERT_EQ(omf.ApplyPIServerNamingRulesInvalidChars("asset_\b1", &changed), "asset__1");
 	ASSERT_EQ(omf.ApplyPIServerNamingRulesInvalidChars("asset_\r1", &changed), "asset__1");
 	ASSERT_EQ(omf.ApplyPIServerNamingRulesInvalidChars("asset_\\1", &changed), "asset__1");
+}
+
+TEST(PiServer_NamingRules, Suffix)
+{
+	// Dummy initializations
+	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
+	OMF omf(sender, "/", 1, "ABC");
+
+	omf.setNamingScheme(NAMINGSCHEME_CONCISE);
+	ASSERT_EQ(omf.generateSuffixType(1), "");
+	ASSERT_EQ(omf.generateSuffixType(2), "-type2");
+	ASSERT_EQ(omf.generateSuffixType(3), "-type3");
+
+	omf.setNamingScheme(NAMINGSCHEME_SUFFIX);
+	ASSERT_EQ(omf.generateSuffixType(1), "-type1");
+	ASSERT_EQ(omf.generateSuffixType(2), "-type2");
+	ASSERT_EQ(omf.generateSuffixType(3), "-type3");
+
+	omf.setNamingScheme(NAMINGSCHEME_HASH);
+	ASSERT_EQ(omf.generateSuffixType(1), "");
+	ASSERT_EQ(omf.generateSuffixType(2), "-type2");
+	ASSERT_EQ(omf.generateSuffixType(3), "-type3");
+
+	omf.setNamingScheme(NAMINGSCHEME_COMPATIBILITY);
+	ASSERT_EQ(omf.generateSuffixType(1), "-type1");
+	ASSERT_EQ(omf.generateSuffixType(2), "-type2");
+	ASSERT_EQ(omf.generateSuffixType(3), "-type3");
+}
+
+TEST(PiServer_NamingRules, Prefix)
+{
+	string asset;
+
+	// Dummy initializations
+	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
+	OMF omf(sender, "/", 1, "ABC");
+
+	asset="asset_1";
+
+	{ // ENDPOINT_PIWEB_API
+
+		omf.setPIServerEndpoint(ENDPOINT_PIWEB_API);
+		omf.setNamingScheme(NAMINGSCHEME_CONCISE);
+		ASSERT_EQ(omf.generateMeasurementId(asset), asset);
+
+		omf.setNamingScheme(NAMINGSCHEME_SUFFIX);
+		ASSERT_EQ(omf.generateMeasurementId(asset), asset);
+
+		omf.setNamingScheme(NAMINGSCHEME_HASH);
+		ASSERT_EQ(omf.generateMeasurementId(asset), "_1measurement_" + asset);
+
+		omf.setNamingScheme(NAMINGSCHEME_COMPATIBILITY);
+		ASSERT_EQ(omf.generateMeasurementId(asset), "_1measurement_" + asset);
+	}
+
+	{ // ENDPOINT_EDS
+
+		omf.setPIServerEndpoint(ENDPOINT_EDS);
+		omf.setNamingScheme(NAMINGSCHEME_CONCISE);
+		ASSERT_EQ(omf.generateMeasurementId(asset), asset);
+
+		omf.setNamingScheme(NAMINGSCHEME_SUFFIX);
+		ASSERT_EQ(omf.generateMeasurementId(asset), asset);
+
+		omf.setNamingScheme(NAMINGSCHEME_HASH);
+		ASSERT_EQ(omf.generateMeasurementId(asset), "1measurement_" + asset);
+
+		omf.setNamingScheme(NAMINGSCHEME_COMPATIBILITY);
+		ASSERT_EQ(omf.generateMeasurementId(asset), "1measurement_" + asset);
+	}
 }

--- a/tests/unit/C/plugins/common/test_omf_translation.cpp
+++ b/tests/unit/C/plugins/common/test_omf_translation.cpp
@@ -491,29 +491,32 @@ TEST(PiServer_NamingRules, NamingRulesCheck)
 
 TEST(PiServer_NamingRules, Suffix)
 {
+	string assetName;
 	// Dummy initializations
 	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
 	OMF omf(sender, "/", 1, "ABC");
 
+	assetName = "asset_1";
+
 	omf.setNamingScheme(NAMINGSCHEME_CONCISE);
-	ASSERT_EQ(omf.generateSuffixType(1), "");
-	ASSERT_EQ(omf.generateSuffixType(2), "-type2");
-	ASSERT_EQ(omf.generateSuffixType(3), "-type3");
+	ASSERT_EQ(omf.generateSuffixType(assetName, 1), "");
+	ASSERT_EQ(omf.generateSuffixType(assetName, 2), "-type2");
+	ASSERT_EQ(omf.generateSuffixType(assetName, 3), "-type3");
 
 	omf.setNamingScheme(NAMINGSCHEME_SUFFIX);
-	ASSERT_EQ(omf.generateSuffixType(1), "-type1");
-	ASSERT_EQ(omf.generateSuffixType(2), "-type2");
-	ASSERT_EQ(omf.generateSuffixType(3), "-type3");
+	ASSERT_EQ(omf.generateSuffixType(assetName, 1), "-type1");
+	ASSERT_EQ(omf.generateSuffixType(assetName, 2), "-type2");
+	ASSERT_EQ(omf.generateSuffixType(assetName, 3), "-type3");
 
 	omf.setNamingScheme(NAMINGSCHEME_HASH);
-	ASSERT_EQ(omf.generateSuffixType(1), "");
-	ASSERT_EQ(omf.generateSuffixType(2), "-type2");
-	ASSERT_EQ(omf.generateSuffixType(3), "-type3");
+	ASSERT_EQ(omf.generateSuffixType(assetName, 1), "");
+	ASSERT_EQ(omf.generateSuffixType(assetName, 2), "-type2");
+	ASSERT_EQ(omf.generateSuffixType(assetName, 3), "-type3");
 
 	omf.setNamingScheme(NAMINGSCHEME_COMPATIBILITY);
-	ASSERT_EQ(omf.generateSuffixType(1), "-type1");
-	ASSERT_EQ(omf.generateSuffixType(2), "-type2");
-	ASSERT_EQ(omf.generateSuffixType(3), "-type3");
+	ASSERT_EQ(omf.generateSuffixType(assetName, 1), "-type1");
+	ASSERT_EQ(omf.generateSuffixType(assetName, 2), "-type2");
+	ASSERT_EQ(omf.generateSuffixType(assetName, 3), "-type3");
 }
 
 TEST(PiServer_NamingRules, Prefix)

--- a/tests/unit/C/plugins/common/test_omf_translation_piwebapi.cpp
+++ b/tests/unit/C/plugins/common/test_omf_translation_piwebapi.cpp
@@ -76,7 +76,7 @@ TEST(PIWEBAPI_OMF_transation, TwoTranslationsCompareResult)
 	     ++elem)
 	{
 		// Add into JSON string the OMF transformed Reading data
-		jsonData << OMFData(**elem, TYPE_ID, PI_SERVER_END_POINT, AF_HIERARCHY_1LEVEL).OMFdataVal() << (elem < (readingSet.getAllReadings().end() - 1 ) ? ", " : "");
+		jsonData << OMFData(**elem, CONTAINER_ID, PI_SERVER_END_POINT, AF_HIERARCHY_1LEVEL).OMFdataVal() << (elem < (readingSet.getAllReadings().end() - 1 ) ? ", " : "");
 	}
 
 	jsonData << "]";


### PR DESCRIPTION
Signed-off-by: Stefano <stefano@dianomic.com>

### Work in progress

![image](https://user-images.githubusercontent.com/4919069/123062161-8e7a2e00-d40c-11eb-992a-43afb2f62726.png)

 
###  NAMINGSCHEME_CONCISE

ContainerId = Asset Name

![image](https://user-images.githubusercontent.com/4919069/123261762-6f0bff80-d4f7-11eb-8f26-bbb445b9b4e9.png)

**Type changes**

![image](https://user-images.githubusercontent.com/4919069/123262010-bb573f80-d4f7-11eb-82b8-f9a8a8b54d33.png)

![image](https://user-images.githubusercontent.com/4919069/123262084-cad68880-d4f7-11eb-8e7b-4f1bab7536e3.png)


 


###  NAMINGSCHEME_COMPATIBILITY

![image](https://user-images.githubusercontent.com/4919069/123063220-7eaf1980-d40d-11eb-89f7-37ced7168e76.png)

![image](https://user-images.githubusercontent.com/4919069/123063234-82db3700-d40d-11eb-8b8b-7695ee8a2250.png)


### NAMINGSCHEME_SUFFIX

![image](https://user-images.githubusercontent.com/4919069/123261453-16d4fd80-d4f7-11eb-856c-720dc1f1af94.png)


![image](https://user-images.githubusercontent.com/4919069/123261479-1d637500-d4f7-11eb-8e4c-5a2f97562118.png)

### NAMINGSCHEME_HASH
![image](https://user-images.githubusercontent.com/4919069/123261110-a3cb8700-d4f6-11eb-9e0f-672affda396f.png)


### 2 North instances
2nd uses 
```
curl -s -S -X PUT http://localhost:8081/fledge/category/${north_instance}/NamingScheme -d '{ "value" : "Use Attribute Hash" }' | jq "."
```
![image](https://user-images.githubusercontent.com/4919069/123266678-8994a780-d4fc-11eb-95e7-ac3f8fee381a.png)


###  NAMINGSCHEME_COMPATIBILITY - upgrade

![image](https://user-images.githubusercontent.com/4919069/123601688-425a2f80-d7f8-11eb-8ee7-5f3fc6777599.png)


```
North_Readings_to_PI[11275]: WARNING: xxx2 OMF plugin: current element '4273005507977094880_asset_1' doesn't have 'namingScheme' property, handling naming scheme in compatibility mode
North_Readings_to_PI[11275]: WARNING: xxx2 OMF plugin: current element '4273005507977094880_asset_2' doesn't have 'namingScheme' property, handling naming scheme in compatibility mode

```

![image](https://user-images.githubusercontent.com/4919069/123600932-6b2df500-d7f7-11eb-9cea-1dc823610ea9.png)

![image](https://user-images.githubusercontent.com/4919069/123600961-73863000-d7f7-11eb-9198-55ee78301b5e.png)

