### PR TITLE
FOGL-5040: Removed hard-coded page count value in fetching GitHub repos

### DIFF
--- a/docs/scripts/fledge_plugin_list
+++ b/docs/scripts/fledge_plugin_list
@@ -35,7 +35,10 @@ function table {
 
 output=$1
 rm -f $output
-fledgeRepos=$(curl -sX GET https://api.github.com/orgs/fledge-iot/repos\?per_page=1000)
+# Get total number of respository pages in fledge org.
+fledgeRepoPagesCount=`curl -sI https://api.github.com/orgs/fledge-iot/repos | grep -oP '\d+(?=>; rel="last")'`
+fledgeRepos=$(curl -sX GET https://api.github.com/orgs/fledge-iot/repos\?page=[1-$fledgeRepoPagesCount])
+fledgeRepos="$(echo $fledgeRepos | sed 's/\] \[/,/g')"
 fetchTopicReposPyScript='
 import json,sys;\
 repos=json.load(sys.stdin);\

--- a/docs/scripts/plugin_documentation
+++ b/docs/scripts/plugin_documentation
@@ -97,7 +97,10 @@ Fledge Notification Delivery Plugins
 
 EOFNOTIFY
 
-fledgeRepos=$(curl -sX GET https://api.github.com/orgs/fledge-iot/repos\?per_page=1000)
+# Get total number of respository pages in fledge org.
+fledgeRepoPagesCount=`curl -sI https://api.github.com/orgs/fledge-iot/repos | grep -oP '\d+(?=>; rel="last")'`
+fledgeRepos=$(curl -sX GET https://api.github.com/orgs/fledge-iot/repos\?page=[1-$fledgeRepoPagesCount])
+fledgeRepos="$(echo $fledgeRepos | sed 's/\] \[/,/g')"
 fetchTopicReposPyScript='
 import json,sys;\
 repos=json.load(sys.stdin);\


### PR DESCRIPTION
Signed-off-by: YashTatkondawar <yashtatkondawar@gmail.com>
Note: `?per_page=1000` fetches only 100 repositories which is the maximum limit. For more details please refer to https://docs.github.com/en/rest/guides/traversing-with-pagination#changing-the-number-of-items-received