### PR TITLE
FOGL-5579 ub20 support added in POST repository endpoint

### DIFF
--- a/python/fledge/services/core/api/repos/configure.py
+++ b/python/fledge/services/core/api/repos/configure.py
@@ -37,7 +37,7 @@ async def add_package_repo(request: web.Request) -> web.Response:
             url - Set a repository URL that used for installing packages via apt or yum
             version - Points to the package release version or any custom branch fixes
 
-        curl -sX POST http://localhost:8081/fledge/repository -d '{"url":"http://archives.fledge-iot.org"'
+        curl -sX POST http://localhost:8081/fledge/repository -d '{"url":"http://archives.fledge-iot.org"}'
         curl -sX POST http://localhost:8081/fledge/repository -d '{"url":"http://archives.fledge-iot.org", "version":"latest"}'
     """
     try:
@@ -58,6 +58,9 @@ async def add_package_repo(request: web.Request) -> web.Response:
 
         if 'x86_64-with-Ubuntu-18.04' in _platform:
             os_name = "ubuntu1804"
+            architecture = "x86_64"
+        elif 'x86_64-with-glib' in _platform:
+            os_name = "ubuntu2004"
             architecture = "x86_64"
         elif 'armv7l-with-debian' in _platform:
             os_name = "buster"


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

**Tested on AWS-ub20**
```
$ cat /etc/os-release 
NAME="Ubuntu"
VERSION="20.04.2 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.2 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal

$ python3 -V
Python 3.8.10

$ python3
>>> import platform
>>> platform.platform()
'Linux-5.4.0-1038-aws-x86_64-with-glibc2.29'
```



**Curl Request**
```
$ curl -sX POST http://localhost:8081/fledge/repository -d '{"url":"http://archives.fledge-iot.org"}'
{"message": "Package repository configured successfully.", "output_log": "/usr/local/fledge/data/configure_repo_output.txt"}
```

**Source list**
```
$ cat /etc/apt/sources.list.d/fledge.list 
deb http://archives.fledge-iot.org/latest/ubuntu2004/x86_64/ /
```

**File Content Output**
```
$ cat /usr/local/fledge/data/configure_repo_output.txt
OK
deb http://archives.fledge-iot.org/latest/ubuntu2004/x86_64/ /

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Get:1 http://archives.fledge-iot.org/latest/ubuntu2004/x86_64  InRelease [2070 B]
Hit:2 http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal InRelease
Get:3 http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:4 http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal-backports InRelease [101 kB]
Get:5 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Get:6 http://archives.fledge-iot.org/latest/ubuntu2004/x86_64  Packages [15.9 kB]
Fetched 346 kB in 0s (694 kB/s)
Reading package lists...
Building dependency tree...
Reading state information...
All packages are up to date.
```

**Available Packages**
```
$ sudo apt list | grep fledge

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

fledge-filter-asset/unknown 1.9.1 amd64
fledge-filter-change/unknown 1.9.1 amd64
fledge-filter-delta/unknown 1.9.1 amd64
.......
......
```