### PR TITLE
FOGL-5142: Changed the order of commands

### DIFF
--- a/tests/system/python/scripts/package/remove
+++ b/tests/system/python/scripts/package/remove
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 time sudo apt purge -y fledge
-sudo rm -rf /usr/local/fledge
 # Do not remove fledge-gui if environment is Docker
 if [ "${FLEDGE_ENVIRONMENT}" != "docker" ]; then
     time sudo apt purge -y fledge-gui
 fi
+sudo rm -rf /usr/local/fledge


### PR DESCRIPTION
Signed-off-by: YashTatkondawar <yashtatkondawar@gmail.com>

Changed the order of commands, because if fledge packages are not installed then the purge command fails and exits with a non-zero exit code. This non-zero exit code causes failure in packages-based system tests.