### PR TITLE
documentation fixes

### DIFF
--- a/docs/building_fledge/building_fledge.rst
+++ b/docs/building_fledge/building_fledge.rst
@@ -137,13 +137,13 @@ Fledge is currently based on C/C++ and Python code. The packages needed to build
   $
   ...
   $
-  $ DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq krb5-user
+  $ sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq krb5-user
   Reading package lists... Done
   Building dependency tree
   $
   ...
   $
-  $ DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq libcurl4-openssl-dev
+  $ sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq libcurl4-openssl-dev
   Reading package lists... Done
   Building dependency tree
   $

--- a/docs/quick_start/installing.rst
+++ b/docs/quick_start/installing.rst
@@ -56,13 +56,13 @@ Once complete you can add the repository itself into the apt configuration file 
 
     .. code-block:: console
 
-       sudo add-apt-repository ‘deb http://archives.fledge-iot.org/latest/ubuntu1804/x86_64/ / ‘
+       sudo add-apt-repository "deb http://archives.fledge-iot.org/latest/ubuntu1804/x86_64/ / "
 
   - Users with an Intel or AMD system with Ubuntu 20.04 should run
 
     .. code-block:: console
 
-       sudo add-apt-repository ‘deb http://archives.fledge-iot.org/latest/ubuntu2004/x86_64/ / ‘
+       sudo add-apt-repository "deb http://archives.fledge-iot.org/latest/ubuntu2004/x86_64/ / "
 
     .. note::
         We do not support the `aarch64` architecture with Ubuntu 20.04 yet.
@@ -71,7 +71,7 @@ Once complete you can add the repository itself into the apt configuration file 
 
     .. code-block:: console
 
-       sudo add-apt-repository ‘deb http://archives.fledge-iot.org/latest/ubuntu1804/aarch64/ / ‘
+       sudo add-apt-repository "deb http://archives.fledge-iot.org/latest/ubuntu1804/aarch64/ / "
 
   - Users of the Mendel operating system on a Google Coral create the file /etc/apt/sources.list.d/fledge.list and insert the following content
 
@@ -95,7 +95,7 @@ You may also install multiple packages in a single command. To install the base 
 
 .. code-block:: console
 
-   DEBIAN_FRONTEND=noninteractive sudo apt -y install fledge fledge-gui fledge-south-sinusoid
+   sudo DEBIAN_FRONTEND=noninteractive apt -y install fledge fledge-gui fledge-south-sinusoid
 
 RedHat & CentOS
 ~~~~~~~~~~~~~~~
@@ -163,7 +163,7 @@ Assuming you have downloaded the packages from the download link given above. Us
 
 The key packages to install are the Fledge core and the Fledge User Interface::
 
-  DEBIAN_FRONTEND=noninteractive sudo apt -y install ./fledge-1.8.0-armv7l.deb
+  sudo DEBIAN_FRONTEND=noninteractive apt -y install ./fledge-1.8.0-armv7l.deb
   sudo apt -y install ./fledge-gui-1.8.0.deb
 
 You will need to install one of more South plugins to acquire data.  You can either do this now or when you are adding the data source. For example, to install the plugin for the Sense HAT sensor board, type::


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

1. If you need to install APT packages via sudo with noninteractive, use: sudo before
```
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y [PACKAGE_NAME]
```
2. quote fixes
```
$ sudo add-apt-repository ‘deb http://archives.fledge-iot.org/latest/ubuntu1804/x86_64/ / ‘
Error: need a single repository as argument
```