### PR TITLE
FOGL-5912 fledge version added & 'a' flag which is equivalent to binary file with grep commands to get  full syslogs in support bundle

### DIFF
--- a/python/fledge/services/core/support.py
+++ b/python/fledge/services/core/support.py
@@ -69,7 +69,7 @@ class SupportBuilder:
             tar_file_name = self._out_file_path+"/"+"support-{}.tar.gz".format(file_spec)
             pyz = tarfile.open(tar_file_name, "w:gz")
             try:
-                await self.add_fledge_version(pyz)
+                await self.add_fledge_version_and_schema(pyz)
                 self.add_syslog_fledge(pyz, file_spec)
                 self.add_syslog_storage(pyz, file_spec)
                 cf_mgr = ConfigurationManager(self._storage)
@@ -130,10 +130,11 @@ class SupportBuilder:
             json.dump(data, outfile, indent=4)
         pyz.add(temp_file, arcname=basename(temp_file))
 
-    async def add_fledge_version(self, pyz):
-        temp_file = self._interim_file_path + "/" + "fledge-version"
-        data = await self._storage.query_tbl("version")
-        self.write_to_tar(pyz, temp_file, int(data['rows'][0]['id']))
+    async def add_fledge_version_and_schema(self, pyz):
+        temp_file = self._interim_file_path + "/" + "fledge-info"
+        with open('{}/VERSION'.format(_FLEDGE_ROOT)) as f:
+            lines = [line.rstrip() for line in f]
+        self.write_to_tar(pyz, temp_file, lines)
 
     def add_syslog_fledge(self, pyz, file_spec):
         # The fledge entries from the syslog file

--- a/python/fledge/services/core/support.py
+++ b/python/fledge/services/core/support.py
@@ -132,7 +132,7 @@ class SupportBuilder:
         # The fledge entries from the syslog file
         temp_file = self._interim_file_path + "/" + "syslog-{}".format(file_spec)
         try:
-            subprocess.call("grep '{}' {} > {}".format("Fledge", _SYSLOG_FILE, temp_file), shell=True)
+            subprocess.call("grep -a '{}' {} > {}".format("Fledge", _SYSLOG_FILE, temp_file), shell=True)
         except OSError as ex:
             raise RuntimeError("Error in creating {}. Error-{}".format(temp_file, str(ex)))
         pyz.add(temp_file, arcname=basename(temp_file))
@@ -141,7 +141,7 @@ class SupportBuilder:
         # The contents of the syslog file that relate to the database layer (postgres)
         temp_file = self._interim_file_path + "/" + "syslogStorage-{}".format(file_spec)
         try:
-            subprocess.call("grep '{}' {} > {}".format("Fledge Storage", _SYSLOG_FILE, temp_file), shell=True)
+            subprocess.call("grep -a '{}' {} > {}".format("Fledge Storage", _SYSLOG_FILE, temp_file), shell=True)
         except OSError as ex:
             raise RuntimeError("Error in creating {}. Error-{}".format(temp_file, str(ex)))
         pyz.add(temp_file, arcname=basename(temp_file))


### PR DESCRIPTION
**Fixed items**
- [x] -a flag added to grep command where we missed in support bundle
- [x] fledge version & schema both info added in support bundle as well

See the version file added into support bundle
```
$ tar -xvf support-210910-13-33-26.tar.gz 
fledge-info
syslog-210910-13-33-26
syslogStorage-210910-13-33-26
syslog-si-210910-13-33-26
configuration-210910-13-33-26
audit-210910-13-33-26
schedules-210910-13-33-26
scheduled_processes-210910-13-33-26
statistics-history-210910-13-33-26
plugin-data-210910-13-33-26
streams-210910-13-33-26
service_registry-210910-13-33-26
machine-210910-13-33-26
psinfo-210910-13-33-26
package_logs/
software-210910-13-33-26

```
See the content for version
```
$ cat fledge-info 
[
    "fledge_version=1.9.1",
    "fledge_schema=43"
]
```