### PR TITLE
  FOGL-5977  With sql-in-memory database configuration, readings are ingested in sqlite db

### DIFF
--- a/C/services/common/include/binary_plugin_handle.h
+++ b/C/services/common/include/binary_plugin_handle.h
@@ -13,6 +13,7 @@
 #include <logger.h>
 #include <dlfcn.h>
 #include <plugin_handle.h>
+#include <plugin_manager.h>
 
 /**
  * The BinaryPluginHandle class is used to represent an interface to 
@@ -21,13 +22,27 @@
 class BinaryPluginHandle : public PluginHandle
 {
 	public:
-		BinaryPluginHandle(const char *, const char *path) { handle = dlopen(path, RTLD_LAZY|RTLD_GLOBAL); }
+		// for the Storage plugin
+		BinaryPluginHandle(const char *name, const char *path, tPluginType type) {
+			handle = dlopen(path, RTLD_LAZY);
+
+			Logger::getLogger()->debug("%s - storage plugin / RTLD_LAZY - name :%s: path :%s:", __FUNCTION__, name, path);
+		}
+
+		// for all the others plugins
+		BinaryPluginHandle(const char *name, const char *path)                   {
+			handle = dlopen(path, RTLD_LAZY|RTLD_GLOBAL);
+
+			Logger::getLogger()->debug("%s - other plugin / RTLD_LAZY|RTLD_GLOBAL - name :%s: path :%s:", __FUNCTION__, name, path);
+		}
+
 		~BinaryPluginHandle() { if (handle) dlclose(handle); }
 		void *GetInfo() { return dlsym(handle, "plugin_info"); }
 		void *ResolveSymbol(const char* sym) { return dlsym(handle, sym); }
 		void *getHandle() { return handle; }
 	private:
 		PLUGIN_HANDLE handle; // pointer returned by dlopen on plugin shared lib
+
 };
 
 #endif

--- a/C/services/common/include/plugin_manager.h
+++ b/C/services/common/include/plugin_manager.h
@@ -17,6 +17,12 @@
 #include <list>
 #include <map>
 
+typedef enum PluginType
+{
+	PLUGIN_TYPE_ID_STORAGE,
+	PLUGIN_TYPE_ID_OTHER
+} tPluginType;
+
 /**
  * The manager for plugins.
  *
@@ -37,6 +43,7 @@ class PluginManager {
 				*getInfo(const PLUGIN_HANDLE);
 		void		getInstalledPlugins(const std::string& type,
 						    std::list<std::string>& plugins);
+		void setPluginType(tPluginType type);
 
 	public:
                 static PluginManager* instance;
@@ -53,6 +60,7 @@ class PluginManager {
                 std::map<PLUGIN_HANDLE, PluginHandle*>
 							pluginHandleMap;
                 Logger*					logger;
+				tPluginType				m_pluginType;
 };
 
 #endif

--- a/C/services/common/plugin_manager.cpp
+++ b/C/services/common/plugin_manager.cpp
@@ -52,6 +52,8 @@ PluginManager *PluginManager::getInstance()
 PluginManager::PluginManager()
 {
   logger = Logger::getLogger();
+
+  m_pluginType = PLUGIN_TYPE_ID_OTHER;
 }
 
 enum PLUGIN_TYPE {
@@ -249,6 +251,13 @@ string findPlugin(string name, string _type, string _plugin_path, PLUGIN_TYPE ty
 }
 
 /**
+ * Set Plugin Type
+ */
+void PluginManager::setPluginType(tPluginType type) {
+	m_pluginType = type;
+}
+
+/**
  * Load a given plugin
  */
 PLUGIN_HANDLE PluginManager::loadPlugin(const string& _name, const string& type)
@@ -343,7 +352,14 @@ char		buf[MAXPATHLEN];
   strncpy(buf, path.c_str(), sizeof(buf));
   if (buf[0] && access(buf, F_OK|R_OK) == 0)
   {
-	pluginHandle = new BinaryPluginHandle(name.c_str(), buf);
+	if (m_pluginType == PLUGIN_TYPE_ID_STORAGE)
+	{
+		pluginHandle = new BinaryPluginHandle(name.c_str(), buf, PLUGIN_TYPE_ID_STORAGE);
+	} else
+	{
+		pluginHandle = new BinaryPluginHandle(name.c_str(), buf);
+	}
+
 	hndl = pluginHandle->getHandle();
     if (hndl != NULL)
     {

--- a/C/services/storage/storage.cpp
+++ b/C/services/storage/storage.cpp
@@ -379,6 +379,7 @@ void StorageService::stop()
 bool StorageService::loadPlugin()
 {
 	PluginManager *manager = PluginManager::getInstance();
+	manager->setPluginType(PLUGIN_TYPE_ID_STORAGE);
 
 	const char *plugin = config->getValue("plugin");
 	if (plugin == NULL)


### PR DESCRIPTION
Signed-off-by: Stefano <stefano@dianomic.com>

log samples 
```
Storage[1488]: DEBUG: BinaryPluginHandle - storage plugin / RTLD_LAZY - name :sqlite: path :/home/foglamp/Development/fledge/plugins/storage/sqlite/libsqlite.so:
Storage[1488]: DEBUG: BinaryPluginHandle - storage plugin / RTLD_LAZY - name :sqlitememory: path :/home/foglamp/Development/fledge/plugins/storage/sqlitememory/libsqlitememory.so:

North_Readings_to_PI[1672]: DEBUG: BinaryPluginHandle - other plugin / RTLD_LAZY|RTLD_GLOBAL - name :OMF: path :/home/foglamp/Development/fledge/plugins/north/OMF/libOMF.so:


```