### PR TITLE
FOGL-6054  Fledge reset : Fledge reset does not report if there are errors in the execution of the init.sql

### DIFF
--- a/scripts/plugins/storage/postgres.sh
+++ b/scripts/plugins/storage/postgres.sh
@@ -214,12 +214,20 @@ pg_reset() {
     else
         postgres_log "info" "Building the metadata for the Fledge Plugin 'postgres'" "logonly" "pretty"
     fi
-       
-    eval $PG_SQL -d postgres -q -f $INIT_SQL > /dev/null 2>&1
-    if [[ "$1" == "noisy" ]]; then
-        postgres_log "info" "Build complete." "all" "pretty"
+
+    output=$(eval $PG_SQL -d postgres -q -f $INIT_SQL 2>&1)
+    outputUC=${output^^}
+
+    if [[ "$outputUC" =~ "ERROR" || "$outputUC" =~ "WARNING" || "$outputUC" =~ "FATAL" ]]; then
+
+        postgres_log "err" "${output}" "all"
+        exit 1
     else
-        postgres_log "info" "Build complete." "logonly" "pretty"
+        if [[ "$1" == "noisy" ]]; then
+            postgres_log "info" "Build complete." "all" "pretty"
+        else
+            postgres_log "info" "Build complete." "logonly" "pretty"
+        fi
     fi
 
 }

--- a/scripts/plugins/storage/postgres/init.sql
+++ b/scripts/plugins/storage/postgres/init.sql
@@ -478,7 +478,7 @@ CREATE TABLE fledge.statistics_history_daily (
 );
 
 CREATE INDEX statistics_history_daily_ix1
-    ON statistics_history_daily (year);
+    ON fledge.statistics_history_daily (year);
 
 -- Resources table
 -- A resource and be anything that is available or can be done in Fledge. Examples:

--- a/scripts/plugins/storage/sqlite.sh
+++ b/scripts/plugins/storage/sqlite.sh
@@ -23,7 +23,8 @@
 __author__="Massimiliano Pinto"
 __version__="1.0"
 
-set -e
+# Avoid to stop immediately to report/show the error/reason
+set +e
 
 PLUGIN="sqlite"
 

--- a/scripts/plugins/storage/sqlitelb.sh
+++ b/scripts/plugins/storage/sqlitelb.sh
@@ -19,7 +19,8 @@
 __author__="Massimiliano Pinto"
 __version__="1.0"
 
-set -e
+# Avoid to stop immediately to report/show the error/reason
+set +e
 
 PLUGIN="sqlitelb"
 


### PR DESCRIPTION
Signed-off-by: Stefano <stefano@dianomic.com>

PostgreSQL forcing error 
```
foglamp@ihsdev:~$ echo -e "YES" | ${FLEDGE_SCRIPT} reset
This script will remove all data stored in the server.
Enter YES if you want to continue: [2021-11-09 10:28:52]: Storage script.plugin.storage.postgres err psql:/home/foglamp/Development/fledge/scripts/plugins/storage/postgres/init.sql:51: ERROR:  database "fledge" is being accessed by other users
DETAIL:  There is 1 other session using the database.
psql:/home/foglamp/Development/fledge/scripts/plugins/storage/postgres/init.sql:56: ERROR:  database "fledge" already exists
psql:/home/foglamp/Development/fledge/scripts/plugins/storage/postgres/init.sql:69: ERROR:  schema "fledge" already exists
psql:/home/foglamp/Development/fledge/scripts/plugins/storage/postgres/init.sql:78: ERROR:  relation "asset_messages_id_seq" already exists
psql:/home/foglamp/Development/fledge/scripts/plugins/storage/postgres/init.sql:85: ERROR:  relation "asset_status_changes_id_seq" already exists
psql:/home/foglamp/Development/fledge/scripts/plugins/storage/postgres/init.sql:92: ERROR:  relation "asset_status_id_seq" already exists
...
```

slite - forcing error 

```
oglamp@ihsdev:~$ echo -e "YES" | ${FLEDGE_SCRIPT} reset
This script will remove all data stored in the SQLite3 datafiles:
'/home/foglamp/Development/fledge/data/fledge.db'
'/home/foglamp/Development/fledge/data/readings_1.db'
Enter YES if you want to continue: Cannot initialize '/home/foglamp/Development/fledge/data/fledge.db' for the Fledge Plugin 'sqlite': Error: near line 53: near "CREATE": syntax error
Error: near line 344: unknown column "rolee_id" in foreign key definition
Error: near line 362: no such table: main.role_asset_permissions
Error: near line 365: no such table: main.role_asset_permissions
Error: near line 628: no such table: fledge.log_codes
Error: near line 629: no such table: fledge.log_codes. Exiting


```

slitelb - forcing error 

```
foglamp@ihsdev:~$ echo -e "YES" | ${FLEDGE_SCRIPT} reset
This script will remove all data stored in the SQLite3 datafiles:
'/home/foglamp/Development/fledge/data/fledge.db'
'/home/foglamp/Development/fledge/data/readings.db'
Enter YES if you want to continue: Cannot initialize '/home/foglamp/Development/fledge/data/fledge.db' for the Fledge Plugin 'sqlitelb': Error: near line 53: near "CREATE": syntax error
Error: near line 612: no such table: fledge.log_codes
Error: near line 613: no such table: fledge.log_codes. Exiting

 
```