### PR TITLE
FOGL-6077 - New API addition for multiple delivery channels

### DIFF
--- a/python/fledge/services/core/api/notification.py
+++ b/python/fledge/services/core/api/notification.py
@@ -537,6 +537,18 @@ async def _hit_delete_url(delete_url, data=None):
         return jdoc
 
 
+async def _get_channels(cfg_mgr: ConfigurationManager, notify_instance: str) -> list:
+    prefix = "{}_channel_".format(notify_instance)
+    all_categories = await cfg_mgr.get_all_category_names()
+    categories = [c[0] for c in all_categories if c[0].startswith(prefix)]
+    channel_names = []
+    if categories:
+        for ch in categories:
+            if ch.startswith(prefix):
+                channel_names.append(ch[len(prefix):])
+    return channel_names
+
+
 async def get_delivery_channels(request: web.Request) -> web.Response:
     """ Retrieve a list of all the additional notification channels for the given notification
 
@@ -545,25 +557,16 @@ async def get_delivery_channels(request: web.Request) -> web.Response:
     """
     try:
         notification_instance_name = request.match_info.get('notification_name', None)
-        if notification_instance_name is None:
-            raise ValueError("Notification name is required")
         storage = connect.get_storage_async()
         config_mgr = ConfigurationManager(storage)
         notification_config = await config_mgr._read_category_val(notification_instance_name)
         if notification_config:
-            all_categories = await config_mgr.get_all_category_names()
-            prefix = "{}_channel_".format(notification_instance_name)
-            categories = [c[0] for c in all_categories if c[0].startswith(prefix)]
-            channels = []
-            if categories:
-                for ch in categories:
-                    if ch.startswith(prefix):
-                        channels.append(ch[len(prefix):])
+            channels = await _get_channels(config_mgr, notification_instance_name)
         else:
-            raise ValueError("{} notification instance does not exist".format(notification_instance_name))
-    except ValueError as err:
+            raise NotFoundError("{} notification instance does not exist".format(notification_instance_name))
+    except NotFoundError as err:
         msg = str(err)
-        raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+        raise web.HTTPNotFound(reason=msg, body=json.dumps({"message": msg}))
     except Exception as ex:
         msg = str(ex)
         raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
@@ -575,11 +578,9 @@ async def post_delivery_channel(request: web.Request) -> web.Response:
     """ Add a new delivery channel to an existing notification
         :Example:
             curl -sX POST http://localhost:8081/fledge/notification/overspeed/delivery -d '{"name": "coolant", "config": {"action": {"description": "Perform a control action to turn pump", "type": "boolean", "default": "false"}}}'
-        """
+    """
     try:
         notification_instance_name = request.match_info.get('notification_name', None)
-        if notification_instance_name is None:
-            raise ValueError("Notification name is required.")
         data = await request.json()
         channel_name = data.get('name', None)
         channel_description = data.get('description', "{} delivery channel".format(channel_name))
@@ -603,14 +604,17 @@ async def post_delivery_channel(request: web.Request) -> web.Response:
                                              category_value=channel_config)
             category_info = await config_mgr.get_category_all_items(category_name=channel_name)
             if category_info is None:
-                raise ValueError('No such {} found'.format(channel_name))
+                raise NotFoundError('No such {} category found'.format(channel_name))
             # Create parent-child relationship
             await config_mgr.create_child_category(notification_instance_name, [channel_name])
         else:
-            raise ValueError("{} notification instance does not exist".format(notification_instance_name))
-    except (LookupError, ValueError) as err:
+            raise NotFoundError("{} notification instance does not exist".format(notification_instance_name))
+    except ValueError as err:
         msg = str(err)
         raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+    except NotFoundError as err:
+        msg = str(err)
+        raise web.HTTPNotFound(reason=msg, body=json.dumps({"message": msg}))
     except Exception as ex:
         msg = str(ex)
         raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
@@ -620,7 +624,34 @@ async def post_delivery_channel(request: web.Request) -> web.Response:
 
 
 async def get_delivery_channel_configuration(request: web.Request) -> web.Response:
-    pass
+    """ Retrieve the configuration of a delivery channel
+
+    :Example:
+        curl -sX GET http://localhost:8081/fledge/notification/overspeed/delivery/coolant
+    """
+    notification_instance_name = request.match_info.get('notification_name', None)
+    channel_name = request.match_info.get('channel_name', None)
+    storage = connect.get_storage_async()
+    config_mgr = ConfigurationManager(storage)
+    try:
+        category_name = "{}_channel_{}".format(notification_instance_name, channel_name)
+        notification_config = await config_mgr._read_category_val(notification_instance_name)
+        if notification_config:
+            channels = await _get_channels(config_mgr, notification_instance_name)
+            if channel_name in channels:
+                channel_config = await config_mgr._read_category_val(category_name)
+            else:
+                raise NotFoundError("{} channel does not exist".format(channel_name))
+        else:
+            raise NotFoundError("{} notification instance does not exist".format(notification_instance_name))
+    except NotFoundError as err:
+        msg = str(err)
+        raise web.HTTPNotFound(reason=msg, body=json.dumps({"message": msg}))
+    except Exception as ex:
+        msg = str(ex)
+        raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
+    else:
+        return web.json_response({"config": channel_config})
 
 
 async def delete_delivery_channel(request: web.Request) -> web.Response:

--- a/python/fledge/services/core/api/notification.py
+++ b/python/fledge/services/core/api/notification.py
@@ -25,10 +25,12 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 _help = """
-    -------------------------------------------------------------------------------
-    | GET                            | /fledge/notification/plugin               |
-    | GET POST PUT DELETE            | /fledge/notification                      |
-    -------------------------------------------------------------------------------
+    -----------------------------------------------------------------------------------------------------
+    | GET                            | /fledge/notification/plugin                                      |
+    | GET POST PUT DELETE            | /fledge/notification                                             |
+    | GET POST                       | /fledge/notification/{name}/delivery                             |
+    | GET DELETE                     | /fledge/notification/{notification_name}/delivery/{channel_name} |
+    -----------------------------------------------------------------------------------------------------
 """
 
 _logger = logger.setup()
@@ -534,3 +536,18 @@ async def _hit_delete_url(delete_url, data=None):
     else:
         return jdoc
 
+
+async def get_delivery_channels(request: web.Request) -> web.Response:
+    pass
+
+
+async def post_delivery_channel(request: web.Request) -> web.Response:
+    pass
+
+
+async def get_delivery_channel_configuration(request: web.Request) -> web.Response:
+    pass
+
+
+async def delete_delivery_channel(request: web.Request) -> web.Response:
+    pass

--- a/python/fledge/services/core/routes.py
+++ b/python/fledge/services/core/routes.py
@@ -197,6 +197,13 @@ def setup(app):
     app.router.add_route('POST', '/fledge/notification', notification.post_notification)
     app.router.add_route('PUT', '/fledge/notification/{notification_name}', notification.put_notification)
     app.router.add_route('DELETE', '/fledge/notification/{notification_name}', notification.delete_notification)
+    app.router.add_route('GET', '/fledge/notification/{notification_name}/delivery', notification.get_delivery_channels)
+    app.router.add_route('POST', '/fledge/notification/{notification_name}/delivery',
+                         notification.post_delivery_channel)
+    app.router.add_route('GET', '/fledge/notification/{notification_name}/delivery/{channel_name}',
+                         notification.get_delivery_channel_configuration)
+    app.router.add_route('DELETE', '/fledge/notification/{notification_name}/delivery/{channel_name}',
+                         notification.delete_delivery_channel)
 
     # Snapshot plugins
     app.router.add_route('GET', '/fledge/snapshot/plugins', snapshot_plugins.get_snapshot)


### PR DESCRIPTION
- [x] API added
- [x] Unit tests added
 
Below are the curl API results
Let say **overspeed** is a notification instance name

- [x] **GET** - Delivery channels list
```
$ curl -sX GET http://localhost:8081/fledge/notification/overspeed/delivery | jq
{
  "channels": []
}
```
- [x] **POST** - Add new delivery channel to an existing notification
```
$ curl -sX POST http://localhost:8081/fledge/notification/overspeed/delivery -d '{"name": "coolant", "config": {"action": {"description": "Perform a control action to turn pump", "type": "boolean", "default": "false"}}}' | jq
{
  "category": "overspeed_channel_coolant",
  "description": "coolant delivery channel",
  "config": {
    "action": {
      "description": "Perform a control action to turn pump",
      "type": "boolean",
      "default": "false"
    }
  }
}

# Verify that channel got added into existing notification
$ curl -sX GET http://localhost:8081/fledge/notification/overspeed/delivery | jq
{
  "channels": [
    "coolant"
  ]
}

```
- [x] **GET** - Retrieve the configuration of a delivery channel

```
$ curl -sX GET http://localhost:8081/fledge/notification/overspeed/delivery/coolant | jq
{
  "config": {
    "action": {
      "description": "Perform a control action to turn pump",
      "type": "boolean",
      "default": "false",
      "value": "false"
    }
  }
}
```

- [x] DELETE - Remove a delivery channel

```
$ curl -sX DELETE http://localhost:8081/fledge/notification/overspeed/delivery/coolant | jq
{
  "channels": []
}

# Verify again to check delete category including its parent-child relation
$ curl -sX GET http://localhost:8081/fledge/notification/overspeed/delivery | jq
{
  "channels": []
}

```