### PR TITLE
FOGL-6116 New endpoint added in API to get latest reading for an asset

### DIFF
--- a/tests/unit/python/fledge/services/core/api/test_browser_assets.py
+++ b/tests/unit/python/fledge/services/core/api/test_browser_assets.py
@@ -67,7 +67,7 @@ class TestBrowserAssets:
         return loop.run_until_complete(test_client(app))
 
     def test_routes_count(self, app):
-        assert 9 == len(app.router.resources())
+        assert 10 == len(app.router.resources())
 
     def test_routes_info(self, app):
         for index, route in enumerate(app.router.routes()):
@@ -85,29 +85,34 @@ class TestBrowserAssets:
             elif index == 2:
                 assert "GET" == route.method
                 assert type(route.resource) is DynamicResource
+                assert "/fledge/asset/{asset_code}/latest" == res_info["formatter"]
+                assert str(route.handler).startswith("<function asset_latest")
+            elif index == 3:
+                assert "GET" == route.method
+                assert type(route.resource) is DynamicResource
                 assert "/fledge/asset/{asset_code}/summary" == res_info["formatter"]
                 assert str(route.handler).startswith("<function asset_all_readings_summary")
-            elif index == 3:
+            elif index == 4:
                 assert "GET" == route.method
                 assert type(route.resource) is DynamicResource
                 assert "/fledge/asset/{asset_code}/{reading}" == res_info["formatter"]
                 assert str(route.handler).startswith("<function asset_reading")
-            elif index == 4:
+            elif index == 5:
                 assert "GET" == route.method
                 assert type(route.resource) is DynamicResource
                 assert "/fledge/asset/{asset_code}/{reading}/summary" == res_info["formatter"]
                 assert str(route.handler).startswith("<function asset_summary")
-            elif index == 5:
+            elif index == 6:
                 assert "GET" == route.method
                 assert type(route.resource) is DynamicResource
                 assert "/fledge/asset/{asset_code}/{reading}/series" == res_info["formatter"]
                 assert str(route.handler).startswith("<function asset_averages")
-            elif index == 6:
+            elif index == 7:
                 assert "GET" == route.method
                 assert type(route.resource) is DynamicResource
                 assert "/fledge/asset/{asset_code}/bucket/{bucket_size}" == res_info["formatter"]
                 assert str(route.handler).startswith("<function asset_datapoints_with_bucket_size")
-            elif index == 7:
+            elif index == 8:
                 assert "GET" == route.method
                 assert type(route.resource) is DynamicResource
                 assert "/fledge/asset/{asset_code}/{reading}/bucket/{bucket_size}" == res_info["formatter"]


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

**Sample Output1**

```
With system info plugin

$ curl -sX GET http://localhost:8081/fledge/asset/system%2FcpuUsage_all/latest | jq
[
  {
    "reading": {
      "prcntg_usr": 12.66,
      "prcntg_nice": 0.06,
      "prcntg_sys": 2.45,
      "prcntg_iowait": 1.43,
      "prcntg_irq": 0,
      "prcntg_soft": 0.56,
      "prcntg_steal": 0,
      "prcntg_guest": 0,
      "prcntg_gnice": 0,
      "prcntg_idle": 82.85
    },
    "timestamp": "2021-12-13 13:12:49.479095"
  }
]

Equivalent to below request

$ curl -sX GET http://localhost:8081/fledge/asset/system%2FcpuUsage_all?limit=1 | jq
[
  {
    "reading": {
      "prcntg_usr": 12.66,
      "prcntg_nice": 0.06,
      "prcntg_sys": 2.45,
      "prcntg_iowait": 1.43,
      "prcntg_irq": 0,
      "prcntg_soft": 0.56,
      "prcntg_steal": 0,
      "prcntg_guest": 0,
      "prcntg_gnice": 0,
      "prcntg_idle": 82.85
    },
    "timestamp": "2021-12-13 13:12:49.479095"
  }
]
```

**Sample Output2**
```

With sinusoid plugin

$ curl -sX GET http://localhost:8081/fledge/asset/sinusoid/latest | jq
[
  {
    "reading": {
      "sinusoid": 0.406736643
    },
    "timestamp": "2021-12-13 13:13:33.220711"
  }
]

Equivalent to below request

$ curl -sX GET http://localhost:8081/fledge/asset/sinusoid?limit=1 | jq
[
  {
    "reading": {
      "sinusoid": 0.406736643
    },
    "timestamp": "2021-12-13 13:13:33.220711"
  }
]


```