### PR TITLE
Fogl 6065 - Attach ACL to service and Detach ACL from service endpoints added

### DIFF
--- a/python/fledge/services/core/api/control_service/acl_management.py
+++ b/python/fledge/services/core/api/control_service/acl_management.py
@@ -10,6 +10,7 @@ from aiohttp import web
 
 
 from fledge.common import logger
+from fledge.common.configuration_manager import ConfigurationManager
 from fledge.common.storage_client.exceptions import StorageServerError
 from fledge.common.storage_client.payload_builder import PayloadBuilder
 from fledge.common.web.middleware import has_permission
@@ -27,6 +28,7 @@ _help = """
     --------------------------------------------------------------
     | GET POST            | /fledge/ACL                          |
     | GET PUT DELETE      | /fledge/ACL/{acl_name}               |
+    | PUT                 | /fledge/service/{service_name}/ACL   |
     --------------------------------------------------------------
 """
 
@@ -246,3 +248,83 @@ async def delete_acl(request: web.Request) -> web.Response:
         raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
     else:
         return web.json_response({"message": message})
+
+
+async def attach_acl_to_service(request: web.Request) -> web.Response:
+    """ Attach ACL to a service. A service may only have single ACL associated with it
+
+    :Example:
+        curl -sX PUT http://localhost:8081/fledge/service/Sine/ACL -d '{"acl_name": "testACL"}'
+    """
+    try:
+        svc_name = request.match_info.get('service_name', None)
+        storage = connect.get_storage_async()
+        payload = PayloadBuilder().SELECT(["id", "enabled"]).WHERE(['schedule_name', '=', svc_name]).payload()
+        # check service name existence
+        get_schedules_result = await storage.query_tbl_with_payload('schedules', payload)
+        if 'count' in get_schedules_result:
+            if get_schedules_result['count'] == 0:
+                raise NameNotFoundError('{} service does not exist.'.format(svc_name))
+        else:
+            raise StorageServerError(get_schedules_result)
+        data = await request.json()
+        acl_name = data.get('acl_name', None)
+        if acl_name is not None:
+            if not isinstance(acl_name, str):
+                raise ValueError('ACL must be a string')
+            if acl_name.strip() == "":
+                raise ValueError('ACL cannot be empty')
+        else:
+            raise ValueError('acl name is missing in given payload request')
+        acl_name = acl_name.strip()
+        # check ACL name existence
+        payload = PayloadBuilder().SELECT("name", "service", "url").WHERE(['name', '=', acl_name]).payload()
+        get_acl_result = await storage.query_tbl_with_payload('control_acl', payload)
+        if 'count' in get_acl_result:
+            if get_acl_result['count'] == 0:
+                raise NameNotFoundError('{} ACL does not exist'.format(acl_name))
+        else:
+            raise StorageServerError(get_acl_result)
+        # check ACL existence with service
+        cf_mgr = ConfigurationManager(storage)
+        security_cat_name = "{}Security".format(svc_name)
+        category = await cf_mgr.get_category_all_items(security_cat_name)
+        if category is None:
+            # Create {service_name}Security category and having value with AuthenticationCaller Global switch &
+            # ACL info attached (name is excluded from the ACL dict)
+            category_desc = "Security category for {} service".format(svc_name)
+            del get_acl_result['rows'][0]['name']
+            category_value = {
+                'AuthenticatedCaller':
+                    {
+                        'description': 'Caller authorisation is needed',
+                        'type': 'boolean',
+                        'default': 'false',
+                        'displayName': 'Enable caller authorisation'
+                    },
+                'ACL':
+                    {
+                        'description': 'Service ACL for {}'.format(svc_name),
+                        'type': 'JSON',
+                        'displayName': 'Service ACL',
+                        'default': json.dumps(get_acl_result['rows'][0])
+                    }
+            }
+            await cf_mgr.create_category(category_name=security_cat_name, category_description=category_desc,
+                                         category_value=category_value)
+        else:
+            raise ValueError('A {} service has already ACL attached'.format(svc_name))
+    except StorageServerError as err:
+        msg = "Storage error: {}".format(str(err))
+        raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
+    except NameNotFoundError as err:
+        msg = str(err)
+        raise web.HTTPNotFound(reason=msg, body=json.dumps({"message": msg}))
+    except (TypeError, ValueError) as err:
+        msg = str(err)
+        raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+    except Exception as ex:
+        msg = str(ex)
+        raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
+    else:
+        return web.json_response({"message": "{} ACL attached to {} service successfully".format(acl_name, svc_name)})

--- a/python/fledge/services/core/api/control_service/acl_management.py
+++ b/python/fledge/services/core/api/control_service/acl_management.py
@@ -317,7 +317,9 @@ async def attach_acl_to_service(request: web.Request) -> web.Response:
             }
             await cf_mgr.create_category(category_name=security_cat_name, category_description=category_desc,
                                          category_value=category_value)
-            # TODO: parent-child relation if any
+            add_child_result = await cf_mgr.create_child_category(svc_name, [security_cat_name])
+            if security_cat_name not in add_child_result['children']:
+                raise StorageServerError(add_child_result)
         else:
             raise ValueError('A {} service has already ACL attached'.format(svc_name))
     except StorageServerError as err:

--- a/python/fledge/services/core/routes.py
+++ b/python/fledge/services/core/routes.py
@@ -241,6 +241,7 @@ def setup(app):
     app.router.add_route('PUT', '/fledge/ACL/{acl_name}', acl_management.update_acl)
     app.router.add_route('DELETE', '/fledge/ACL/{acl_name}', acl_management.delete_acl)
     app.router.add_route('PUT', '/fledge/service/{service_name}/ACL', acl_management.attach_acl_to_service)
+    app.router.add_route('DELETE', '/fledge/service/{service_name}/ACL', acl_management.detach_acl_from_service)
 
     # enable cors support
     enable_cors(app)

--- a/python/fledge/services/core/routes.py
+++ b/python/fledge/services/core/routes.py
@@ -240,6 +240,7 @@ def setup(app):
     app.router.add_route('GET', '/fledge/ACL/{acl_name}', acl_management.get_acl)
     app.router.add_route('PUT', '/fledge/ACL/{acl_name}', acl_management.update_acl)
     app.router.add_route('DELETE', '/fledge/ACL/{acl_name}', acl_management.delete_acl)
+    app.router.add_route('PUT', '/fledge/service/{service_name}/ACL', acl_management.attach_acl_to_service)
 
     # enable cors support
     enable_cors(app)


### PR DESCRIPTION
**Curl Sample Output**

- [x] Attach ACL to service 
```
# Prerequisite to test: Assuming that Sine service and testACL  has already created in system

$ curl -H "authorization: $AUTH_TOKEN" -sX PUT http://localhost:8081/fledge/service/Sine/ACL -d '{"acl_name": "testACL"}' | jq
{
  "message": "testACL ACL attached to Sine service successfully"
}

# SineSecurity category is created with above Curl and having value with AuthenticationCaller Global switch + given ACL value
$ curl -H "authorization: $AUTH_TOKEN" -sX GET http://localhost:8081/fledge/category/SineSecurity | jq
{
  "AuthenticatedCaller": {
    "description": "Caller authorisation is needed",
    "type": "boolean",
    "default": "false",
    "displayName": "Enable caller authorisation",
    "value": "false"
  },
  "ACL": {
    "description": "Service ACL for Sine",
    "type": "JSON",
    "displayName": "Service ACL",
    "default": "{\"service\": {\"name\": \"IEC-104\", \"type\": \"notification\"}, \"url\": {\"URL\": \"/fledge/south/operation\"}}",
    "value": "{\"service\": {\"name\": \"IEC-104\", \"type\": \"notification\"}, \"url\": {\"URL\": \"/fledge/south/operation\"}}"
  }
}

# also created Parent-child relation
$ curl -H "authorization: $AUTH_TOKEN" -sX GET http://localhost:8081/fledge/category/Sine/children | jq
{
  "categories": [
    {
      "key": "SineAdvanced",
      "description": "Sine advanced config params",
      "displayName": "SineAdvanced"
    },
    {
      "key": "SineSecurity",
      "description": "Security category for Sine service",
      "displayName": "SineSecurity"
    }
  ]
}

# -ve Case: As service only have a single ACL associated with it
$ curl -H "authorization: $AUTH_TOKEN" -sX PUT http://localhost:8081/fledge/service/Sine/ACL -d '{"acl_name": "testACL"}' | jq
{
  "message": "A Sine service has already ACL attached"
}

```
- [x] Detach ACL from service 
```
$ curl -H "authorization: $AUTH_TOKEN" -sX DELETE http://localhost:8081/fledge/service/Sine/ACL | jq
{
  "message": "ACL detached from Sine service successfully"
}

# When no ACL attached with service and we are trying to delete
$ curl -H "authorization: $AUTH_TOKEN" -sX DELETE http://localhost:8081/fledge/service/Sine/ACL | jq
{
  "message": "Nothing to delete as there is no ACL attached with Sine service"
}
```
