### PR TITLE
FOGL-6240: Handle generic array as JSON value

### DIFF
--- a/C/common/result_set.cpp
+++ b/C/common/result_set.cpp
@@ -67,6 +67,11 @@ ResultSet::ResultSet(const std::string& json)
 					{
 						type = STRING_COLUMN;
 					}
+					// Array of any objects is JSON
+					else if (itr->value.IsArray())
+					{
+						type = JSON_COLUMN;
+					}
 					else
 					{
 						throw new ResultException("Unable to determine column type");


### PR DESCRIPTION
Handle generic array as JSON value

"steps" is an array of generic objects
```
{
  "steps": [
    {
      "write": {
        "order": 0,
        "service": "SIN1",
        "values": {
          "D": "69"
        }
      }
    },
    {
      "a": 5
    }
  ]
}
```