### PR TITLE
FOGL-6239 use rpienviro plugin name in tests instead envirophat

### DIFF
--- a/tests/system/lab/install
+++ b/tests/system/lab/install
@@ -43,5 +43,5 @@ fledge-filter-fft fledge-filter-delta fledge-filter-metadata fledge-filter-chang
 fledge-notify-asset fledge-notify-python35 fledge-notify-email \
 fledge-rule-simple-expression fledge-rule-average \
 fledge-north-httpc \
-fledge-south-sinusoid fledge-south-envirophat fledge-south-randomwalk fledge-south-game fledge-south-modbus fledge-south-http-south
+fledge-south-sinusoid fledge-south-rpienviro fledge-south-randomwalk fledge-south-game fledge-south-modbus fledge-south-http-south
 echo "==================== DONE INSTALLING PLUGINS =================="

--- a/tests/system/lab/test
+++ b/tests/system/lab/test
@@ -413,7 +413,7 @@ curl -sX POST "$URL/service" -d \
 '{
    "name": "Enviro",
    "type": "south",
-   "plugin": "envirophat",
+   "plugin": "rpienviro",
    "enabled": true,
    "config": {
       "assetNamePrefix": {

--- a/tests/system/python/packages/data/package_list.json
+++ b/tests/system/python/packages/data/package_list.json
@@ -7,7 +7,7 @@
 		"rule": ["average", "simple-expression"]
 	}],
 	"p1": [{
-		"south": ["dnp3", "envirophat", "flirax8", "game", "mqtt-sparkplug", "opcua", "playback", "randomwalk"],
+		"south": ["dnp3", "rpienviro", "flirax8", "game", "mqtt-sparkplug", "opcua", "playback", "randomwalk"],
 		"north": ["kafka", "opcua"],
 		"filter": ["change", "delta", "fft", "flirvalidity", "metadata", "rms"],
 		"notify": ["email"],

--- a/tests/system/python/packages/test_lab.py
+++ b/tests/system/python/packages/test_lab.py
@@ -360,9 +360,9 @@ class TestRandomwalk1:
 
 
 @pytest.mark.skipif(os.uname()[4][:3] != 'arm', reason="only compatible with arm architecture")
-class TestEnviroPhat:
+class TestRpiEnviro:
     def test_enviro_phat(self, fledge_url, retries, wait_time):
-        data = {"name": "Enviro", "type": "south", "plugin": "envirophat", "enabled": True,
+        data = {"name": "Enviro", "type": "south", "plugin": "rpienviro", "enabled": True,
                 "config": {"assetNamePrefix": {"value": "e_"}}}
         utils.post_request(fledge_url, "/fledge/service", data)
 

--- a/tests/system/python/rpi/test_e2e_rpi_ephat.py
+++ b/tests/system/python/rpi/test_e2e_rpi_ephat.py
@@ -25,10 +25,10 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 
-SOUTH_PLUGIN = "envirophat"
+SOUTH_PLUGIN = "rpienviro"
 SVC_NAME = "Room-1"
 
-ASSET_PREFIX = "e_"  # default for envirophat South plugin
+ASSET_PREFIX = "e_"  # default asset prefix for rpienviro South plugin
 
 ASSET_NAME_W = "weather"
 SENSOR_READ_KEY_W = {"temperature", "altitude", "pressure"}
@@ -142,7 +142,7 @@ class TestE2eRPiEphatEgress:
                                    asset_name_with_prefix_a, asset_name_with_prefix_c])
         assert Counter(actual_assets) == expected_assets
 
-        # fledge/asset/envirophat%2Fweather
+        # fledge/asset/e%2Fweather
         conn.request("GET", '/fledge/asset/{}'.format(quote(asset_name_with_prefix_w, safe='')))
         r = conn.getresponse()
         assert 200 == r.status
@@ -159,7 +159,7 @@ class TestE2eRPiEphatEgress:
             jdoc = json.loads(r)
             assert len(jdoc), "No data found for asset '{}' and datapoint '{}'".format(asset_name_with_prefix_w, _sensor)
 
-        # fledge/asset/envirophat%2Fmagnetometer
+        # fledge/asset/e%2Fmagnetometer
         conn.request("GET", '/fledge/asset/{}'.format(quote(asset_name_with_prefix_m, safe='')))
         r = conn.getresponse()
         assert 200 == r.status
@@ -177,7 +177,7 @@ class TestE2eRPiEphatEgress:
             assert len(jdoc), "No data found for asset '{}' and datapoint '{}'".format(asset_name_with_prefix_m,
                                                                                        _sensor)
 
-        # fledge/asset/envirophat%2Faccelerometer
+        # fledge/asset/e%2Faccelerometer
         conn.request("GET", '/fledge/asset/{}'.format(quote(asset_name_with_prefix_a, safe='')))
         r = conn.getresponse()
         assert 200 == r.status
@@ -194,7 +194,7 @@ class TestE2eRPiEphatEgress:
             jdoc = json.loads(r)
             assert len(jdoc), "No data found for asset '{}' and datapoint '{}'".format(asset_name_with_prefix_a,
                                                                                        _sensor)
-        # fledge/asset/envirophat%2Frgb
+        # fledge/asset/e%2Frgb
         conn.request("GET", '/fledge/asset/{}'.format(quote(asset_name_with_prefix_c, safe='')))
         r = conn.getresponse()
         assert 200 == r.status


### PR DESCRIPTION
As we renamed the envirohpat plugin with rpienviro. Therefore replaced the occurrences in tests directory.

http://archives.fledge-iot.org/nightly/buster/armv7l/fledge-south-rpienviro_1.9.2-8_armv7l.deb

Signed-off-by: ashish-jabble <ashish@dianomic.com>