### PR TITLE
FOGL-6322: call southPlugin->start() only for async plugins

### DIFF
--- a/C/services/south/south.cpp
+++ b/C/services/south/south.cpp
@@ -432,12 +432,7 @@ void SouthService::start(string& coreAddress, unsigned short corePort)
 				else
 				{
 					Logger::getLogger()->debug("Plugin does not persist data");
-					try {
-						southPlugin->start();
-						started = true;
-					} catch (...) {
-						Logger::getLogger()->debug("Plugin start raised an exception");
-					}
+					started = true;
 				}
 				if (!started)
 				{


### PR DESCRIPTION
FOGL-6322: call southPlugin->start() only for async plugins