### PR TITLE
Title level inconsistency fixes in control documentation

### DIFF
--- a/docs/control.rst
+++ b/docs/control.rst
@@ -366,12 +366,12 @@ The *control dispatcher service* has a small number of configuration items that 
 Two subcategories exist, Server and Advanced.
 
 Server Configuration
-####################
+~~~~~~~~~~~~~~~~~~~~
 
 The server section contains a single option which can be used to either turn on or off the forwarding of control messages to the various services within Fledge. Clicking this option off will turn off all control message routing within Fledge.
 
 Advanced Configuration
-######################
+~~~~~~~~~~~~~~~~~~~~~~
 
 +---------------------+
 | |dispatcher_config| |


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

https://fledge-iot.readthedocs.io/en/develop/control.html#configuration - In develop title is missing
With the given change you will be see the proper title under Configuration header.