### PR TITLE
FOGL-6337: Adding some debug logs around import_array call

### DIFF
--- a/C/common/pythonreading.cpp
+++ b/C/common/pythonreading.cpp
@@ -626,7 +626,9 @@ string PythonReading::errorMessage()
 	string errorMessage = pValue ?
 				    PyBytes_AsString(pyExcValueStr) :
 				    "no error description.";
-
+					
+	Logger::getLogger()->error("Exception from python interpreter: %s", errorMessage.c_str());
+	
 	// Reset error
 	PyErr_Clear();
 
@@ -695,7 +697,12 @@ int PythonReading::InitNumPy()
 		// in the case of failure. Hence the need to return a value. Assume no code after this
 		// line is run
 		PyGILState_STATE state = PyGILState_Ensure();
+		
+		if (PyImport_ImportModule("numpy.core.multiarray") == NULL)
+			throw runtime_error(errorMessage());
+
 		import_array();
+		
 		PyGILState_Release(state);
 	}
 	return 0;


### PR DESCRIPTION
Signed-off-by: Amandeep Singh Arora <aman@dianomic.com>

I added a small change to give better information about the “numpy.core.multiarray failed to import“ error. So it is not really a fix per se but it did help the situation and issue is not seen by me and Yash anymore. 

Also we added “python3-numpy” to list of run-time dependencies in fledge-pkg’s CONTROL file. This is in a separate PR that Yash would send out for review.

 

