### PR TITLE
FOGL-6407: can't free borrowed references; 

### DIFF
--- a/C/services/filter-plugin-interfaces/python/filter_ingest_pymodule/ingest_callback_pymodule.cpp
+++ b/C/services/filter-plugin-interfaces/python/filter_ingest_pymodule/ingest_callback_pymodule.cpp
@@ -155,8 +155,13 @@ void filter_plugin_ingest_fn(PyObject *ingest_callback,
 					   "but object type %s",
 					   Py_TYPE(readingsObj)->tp_name);
 	}
-	if(readingsObj)
-		Py_CLEAR(readingsObj);
+
+	// From: https://docs.python.org/3/c-api/arg.html
+	// Note that any Python object references which are provided to the caller are borrowed references; 
+	// do not decrement their reference count!
+
+	/*if(readingsObj)
+		Py_CLEAR(readingsObj);*/
 
 	if (pyReadingSet)
 	{


### PR DESCRIPTION
Checked with valgrind also - no memory leak related to readings.

This also fixes the crash seen with 3 instances of csv-writer in a single south service instance.


Signed-off-by: Amandeep Singh Arora <aman@dianomic.com>