### PR TITLE
FOGL-6399  Some python pip packages updated which causing CVE alerts

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==4.5.0
+Sphinx==3.5.4
 docutils<0.18

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==1.8.5
+Sphinx==4.5.0
 docutils<0.18

--- a/python/requirements-doc.txt
+++ b/python/requirements-doc.txt
@@ -1,4 +1,0 @@
-docutils==0.13.1
-Sphinx==1.6.2
-sphinx-autobuild==0.6.0
-sphinx_rtd_theme==0.2.4

--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -1,4 +1,4 @@
-pylint==1.9.1
+pylint==2.13.9
 pytest==3.6.4
 pytest-allure-adaptor==1.7.10
 pytest-asyncio==0.10.0


### PR DESCRIPTION
Fixed CVE Alerts for following
- [x] Sphinx and Pylint. Also removed unused doc requirement file.
- [x] aiohttp fixes in FOGL-6306 
- [x] C related CVE alerts removal in https://github.com/fledge-iot/fledge/pull/636
