### PR TITLE
Fogl 6417

### DIFF
--- a/C/common/pythonreading.cpp
+++ b/C/common/pythonreading.cpp
@@ -598,7 +598,6 @@ PyObject *PythonReading::convertDatapoint(Datapoint *dp, bool bytesString)
 		
 			Py_CLEAR(key);
 			Py_CLEAR(childValue);
-			Py_CLEAR(dict);
 		}
 	}
 	else

--- a/C/services/common-plugin-interfaces/python/include/python_plugin_common_interface.h
+++ b/C/services/common-plugin-interfaces/python/include/python_plugin_common_interface.h
@@ -214,7 +214,6 @@ const char *json_dumps(PyObject *json_dict)
 			PyTuple_SetItem(args, 0, pValue);
 			
 			rval = PyObject_Call(method, args, NULL);
-			Py_CLEAR(pValue);
 			Py_CLEAR(args);
 			Py_CLEAR(method);
 			Py_CLEAR(mod);

--- a/C/services/common-plugin-interfaces/python/include/python_plugin_common_interface.h
+++ b/C/services/common-plugin-interfaces/python/include/python_plugin_common_interface.h
@@ -274,7 +274,6 @@ PyObject *mod, *method;
 
 			Logger::getLogger()->debug("%s:%d: method=%p, args=%p, pValue=%p", __FUNCTION__, __LINE__, method, args, pValue);
 			rval = PyObject_Call(method, args, NULL);
-			// Py_CLEAR(pValue); // this is actually required, but if uncommented, it causes a segfault
 			Py_CLEAR(args);
 			Py_CLEAR(method);
 			Py_CLEAR(mod);


### PR DESCRIPTION
PyList_SetItem & PyTuple_SetItem functions “steal” a reference to inserted item, so there is no need to decrement ref count for inserted item.

Signed-off-by: Amandeep Singh Arora <aman@dianomic.com>
