### PR TITLE
FOGL-6412 token is omitted from status output

### DIFF
--- a/scripts/fledge
+++ b/scripts/fledge
@@ -517,17 +517,17 @@ fledge_status() {
                 fledge_log "info" "=== Fledge services:" "outonly" "pretty"
                 fledge_log "info" "fledge.services.core" "outonly" "pretty"
                 ps -ef | grep "fledge.services.storage" | grep -v 'grep' | grep -v awk | awk '{print "fledge.services.storage " $9 " " $10}' || true
-                ps -ef | grep "fledge.services.south " |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.south "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' || true
-                ps -ef | grep "fledge.services.north " |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.north "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' || true
-                ps -ef | grep "fledge.services.notification" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.notification "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' || true
-                ps -ef | grep "fledge.services.dispatcher" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.dispatcher "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' || true
-                ps -ef | grep "fledge.services.bucket" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.bucket "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' || true
+                ps -ef | grep "fledge.services.south " |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.south "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' | sed -e 's/--token.*--name/--name/g' || true
+                ps -ef | grep "fledge.services.north " |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.north "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' | sed -e 's/--token.*--name/--name/g' || true
+                ps -ef | grep "fledge.services.notification" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.notification "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' | sed -e 's/--token.*--name/--name/g' || true
+                ps -ef | grep "fledge.services.dispatcher" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.dispatcher "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' | sed -e 's/--token.*--name/--name/g' || true
+                ps -ef | grep "fledge.services.bucket" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{printf "fledge.services.bucket "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' | sed -e 's/--token.*--name/--name/g' || true
                 # Show Python services (except core)
                 ps -ef | grep -o 'python3 -m fledge.services.*' | grep -o 'fledge.services.*' | grep -v 'fledge.services.core' | grep -v 'fledge.services\.\*' || true
 
                 # Show Tasks
                 fledge_log "info" "=== Fledge tasks:" "outonly" "pretty"
-                ps -ef | grep -v 'cpulimit*' | grep -o 'python3 -m fledge.tasks.*' | grep -o 'fledge.tasks.*'    | grep -v 'fledge.tasks\.\*' || true
+                ps -ef | grep -v 'cpulimit*' | grep -o 'python3 -m fledge.tasks.*' | grep -o 'fledge.tasks.*' | grep -v 'fledge.tasks\.\*' || true
 
                 # Show Tasks in C code
                 ps -ef | grep './tasks.' | grep -v python3 | grep -v grep | grep -v awk | awk '{printf "tasks/sending_process "; for(i=9;i<=NF;++i) printf $i FS; printf "\n"}' || true


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

```
$ ./scripts/fledge status
Fledge v1.9.2 running.
Fledge Uptime:  82941 seconds.
Fledge records: 1273 read, 875 sent, 0 purged.
Fledge does not require authentication.
=== Fledge services:
fledge.services.core
fledge.services.storage --address=0.0.0.0 --port=46455
fledge.services.south --port=46455 --address=127.0.0.1 --name=s 
fledge.services.north --port=46455 --address=127.0.0.1 --name=HTPS 
fledge.services.notification --port=46455 --address=127.0.0.1 --name=AJ Notify 
fledge.services.dispatcher --port=46455 --address=127.0.0.1 --name=DispatcherServer 
=== Fledge tasks:
fledge.tasks.north.sending_process --port=46455 --address=127.0.0.1 --name=HTPP

```