### PR TITLE
FOGL-5195: Add support for control in Python south plugins

### DIFF
--- a/C/services/common-plugin-interfaces/python/include/python_plugin_common_interface.h
+++ b/C/services/common-plugin-interfaces/python/include/python_plugin_common_interface.h
@@ -357,11 +357,25 @@ static PLUGIN_INFORMATION *Py2C_PluginInfo(PyObject* pyRetVal)
 		}
 		else if(!strcmp(ckey, "mode"))
 		{
+			stringstream ss(valStr); 
+			string s;
+
 			info->options = 0;
-			if (!strcmp(valStr, "async"))
+			
+			// Tokenizing w.r.t. pipe '|'
+			while(getline(ss, s, '|'))
 			{
-				info->options |= SP_ASYNC;
+				Logger::getLogger()->debug("%s: mode: Found token %s", __FUNCTION__, s.c_str());
+				if (s.compare("async")==0)
+				{
+					info->options |= SP_ASYNC;
+				}
+				else if (s.compare("control")==0)
+				{
+					info->options |= SP_CONTROL;
+				}
 			}
+
 			delete[] valStr;
 		}
 		else if(!strcmp(ckey, "type"))

--- a/C/services/common-plugin-interfaces/python/include/python_plugin_common_interface.h
+++ b/C/services/common-plugin-interfaces/python/include/python_plugin_common_interface.h
@@ -375,6 +375,8 @@ static PLUGIN_INFORMATION *Py2C_PluginInfo(PyObject* pyRetVal)
 				{
 					info->options |= SP_CONTROL;
 				}
+				else
+					Logger::getLogger()->warn("%s: mode: Unknown token/value %s", __FUNCTION__, s.c_str());
 			}
 
 			delete[] valStr;

--- a/C/services/common-plugin-interfaces/python/include/python_plugin_common_interface.h
+++ b/C/services/common-plugin-interfaces/python/include/python_plugin_common_interface.h
@@ -357,6 +357,7 @@ static PLUGIN_INFORMATION *Py2C_PluginInfo(PyObject* pyRetVal)
 		}
 		else if(!strcmp(ckey, "mode"))
 		{
+			// Need to also handle mode values of the form "poll|control"
 			stringstream ss(valStr); 
 			string s;
 

--- a/C/services/south-plugin-interfaces/python/python_plugin_interface.cpp
+++ b/C/services/south-plugin-interfaces/python/python_plugin_interface.cpp
@@ -35,6 +35,7 @@ extern PLUGIN_INFORMATION *Py2C_PluginInfo(PyObject *);
 std::vector<Reading *>* plugin_poll_fn(PLUGIN_HANDLE);
 void plugin_start_fn(PLUGIN_HANDLE handle);
 void plugin_register_ingest_fn(PLUGIN_HANDLE handle,INGEST_CB2 cb,void * data);
+bool plugin_write_fn(PLUGIN_HANDLE handle, const std::string& name, const std::string& value);
 bool plugin_operation_fn(PLUGIN_HANDLE handle, string operation, int parameterCount, PLUGIN_PARAMETER parameters[]);
 
 
@@ -146,6 +147,13 @@ void *PluginInterfaceInit(const char *pluginName, const char * pluginPathName)
     return pModule;
 }
 
+/**
+ * Function to invoke 'plugin_write' function in python plugin
+ *
+ * @param    handle		Plugin handle from plugin_init_fn
+ * @param    name		Name of parameter to write
+ * @param    value		Value to be written to that parameter
+ */
 bool plugin_write_fn(PLUGIN_HANDLE handle, const std::string& name, const std::string& value)
 {
 	bool rv = false;
@@ -252,7 +260,14 @@ bool plugin_write_fn(PLUGIN_HANDLE handle, const std::string& name, const std::s
 	return rv;
 }
 
-
+/**
+ * Function to invoke 'plugin_operation' function in python plugin
+ *
+ * @param    handle			Plugin handle from plugin_init_fn
+ * @param    operation		Name of operation
+ * @param    parameterCount	Number of parameters in Parameter list
+ * @param    parameters		Parameter list
+ */
 bool plugin_operation_fn(PLUGIN_HANDLE handle, string operation, int parameterCount, PLUGIN_PARAMETER parameters[])
 {
 	bool rv = false;
@@ -364,8 +379,6 @@ bool plugin_operation_fn(PLUGIN_HANDLE handle, string operation, int parameterCo
 
 	return rv;
 }
-
-
 
 /**
  * Returns function pointer that can be invoked to call '_sym' function

--- a/C/services/south-plugin-interfaces/python/python_plugin_interface.cpp
+++ b/C/services/south-plugin-interfaces/python/python_plugin_interface.cpp
@@ -203,9 +203,12 @@ bool plugin_write_fn(PLUGIN_HANDLE handle, const std::string& name, const std::s
 		Logger::getLogger()->fatal("Cannot find method 'plugin_write' "
 					   "in loaded python module '%s'",
 					   it->second->m_name.c_str());
+
+		PyGILState_Release(state);
+		return rv;
 	}
 
-	if (!pFunc || !PyCallable_Check(pFunc))
+	if (!PyCallable_Check(pFunc))
 	{
 		// Failure
 		if (PyErr_Occurred())
@@ -316,9 +319,12 @@ bool plugin_operation_fn(PLUGIN_HANDLE handle, string operation, int parameterCo
 		Logger::getLogger()->fatal("Cannot find method 'plugin_operation' "
 					   "in loaded python module '%s'",
 					   it->second->m_name.c_str());
+
+		PyGILState_Release(state);
+		return rv;
 	}
 
-	if (!pFunc || !PyCallable_Check(pFunc))
+	if (!PyCallable_Check(pFunc))
 	{
 		// Failure
 		if (PyErr_Occurred())

--- a/C/services/south-plugin-interfaces/python/python_plugin_interface.cpp
+++ b/C/services/south-plugin-interfaces/python/python_plugin_interface.cpp
@@ -35,6 +35,7 @@ extern PLUGIN_INFORMATION *Py2C_PluginInfo(PyObject *);
 std::vector<Reading *>* plugin_poll_fn(PLUGIN_HANDLE);
 void plugin_start_fn(PLUGIN_HANDLE handle);
 void plugin_register_ingest_fn(PLUGIN_HANDLE handle,INGEST_CB2 cb,void * data);
+bool plugin_operation_fn(PLUGIN_HANDLE handle, string operation, int parameterCount, PLUGIN_PARAMETER parameters[]);
 
 
 /**
@@ -145,6 +146,226 @@ void *PluginInterfaceInit(const char *pluginName, const char * pluginPathName)
     return pModule;
 }
 
+bool plugin_write_fn(PLUGIN_HANDLE handle, const std::string& name, const std::string& value)
+{
+	bool rv = false;
+
+	if (!handle)
+	{
+		Logger::getLogger()->fatal("plugin_handle: plugin_write(): "
+					   "handle is NULL");
+		return rv;
+	}
+
+	if (!pythonHandles)
+	{
+		Logger::getLogger()->error("pythonHandles map is NULL "
+					   "in plugin_write, plugin handle '%p'",
+					   handle);
+		return rv;
+	}
+
+	// Look for Python module for handle key
+	auto it = pythonHandles->find(handle);
+	if (it == pythonHandles->end() ||
+		!it->second ||
+		!it->second->m_module)
+	{
+		Logger::getLogger()->fatal("plugin_handle: plugin_write(): "
+					   "pModule is NULL, plugin handle '%p'",
+					   handle);
+		return rv;
+	}
+
+	std::mutex mtx;
+	PyObject* pFunc;
+	lock_guard<mutex> guard(mtx);
+	PyGILState_STATE state = PyGILState_Ensure();
+
+	Logger::getLogger()->debug("plugin_handle: plugin_write(): "
+				   "pModule=%p, handle=%p, plugin '%s'",
+				   it->second->m_module,
+				   handle,
+				   it->second->m_name.c_str());
+
+	// Fetch required method in loaded object
+	pFunc = PyObject_GetAttrString(it->second->m_module, "plugin_write");
+	if (!pFunc)
+	{
+		Logger::getLogger()->fatal("Cannot find method 'plugin_write' "
+					   "in loaded python module '%s'",
+					   it->second->m_name.c_str());
+	}
+
+	if (!pFunc || !PyCallable_Check(pFunc))
+	{
+		// Failure
+		if (PyErr_Occurred())
+		{
+			logErrorMessage();
+		}
+
+		Logger::getLogger()->fatal("Cannot call method plugin_write "
+					   "in loaded python module '%s'",
+					   it->second->m_name.c_str());
+		Py_CLEAR(pFunc);
+
+		PyGILState_Release(state);
+		return rv;
+	}
+
+	Logger::getLogger()->debug("plugin_write with name=%s, value=%s", name.c_str(), value.c_str());
+
+	// Call Python method passing an object and 2 C-style strings
+	PyObject* pReturn = PyObject_CallFunction(pFunc,
+						  "Oss",
+						  handle, name.c_str(), value.c_str());
+
+	Py_CLEAR(pFunc);
+
+	// Handle return
+	if (!pReturn)
+	{
+		Logger::getLogger()->error("Called python script method plugin_write : "
+					   "error while getting result object, plugin '%s'",
+					   it->second->m_name.c_str());
+		logErrorMessage();
+	}
+	else
+	{
+		if (PyBool_Check(pReturn))
+		{
+			rv = PyObject_IsTrue(pReturn);
+			Logger::getLogger()->info("plugin_write() returned %s", rv?"TRUE":"FALSE");
+		}
+		else
+		{
+			Logger::getLogger()->error("plugin_handle: plugin_write(): "
+									"got result object '%p' of unexpected type %s, plugin '%s'",
+									pReturn, pReturn->ob_type->tp_name,
+									it->second->m_name.c_str());
+		}
+		Py_CLEAR(pReturn);
+	}
+	PyGILState_Release(state);
+
+	return rv;
+}
+
+
+bool plugin_operation_fn(PLUGIN_HANDLE handle, string operation, int parameterCount, PLUGIN_PARAMETER parameters[])
+{
+	bool rv = false;
+	if (!handle)
+	{
+		Logger::getLogger()->fatal("plugin_handle: plugin_operation(): "
+					   "handle is NULL");
+		return rv;
+	}
+
+	if (!pythonHandles)
+	{
+		Logger::getLogger()->error("pythonHandles map is NULL "
+					   "in plugin_operation, plugin handle '%p'",
+					   handle);
+		return rv;
+	}
+
+	// Look for Python module for handle key
+	auto it = pythonHandles->find(handle);
+	if (it == pythonHandles->end() ||
+		!it->second ||
+		!it->second->m_module)
+	{
+		Logger::getLogger()->fatal("plugin_handle: plugin_operation(): "
+					   "pModule is NULL, plugin handle '%p'",
+					   handle);
+		return rv;
+	}
+
+	std::mutex mtx;
+	PyObject* pFunc;
+	lock_guard<mutex> guard(mtx);
+	PyGILState_STATE state = PyGILState_Ensure();
+
+	Logger::getLogger()->debug("plugin_handle: plugin_operation(): "
+				   "pModule=%p, *handle=%p, plugin '%s'",
+				   it->second->m_module,
+				   handle,
+				   it->second->m_name.c_str());
+
+	// Fetch required method in loaded object
+	pFunc = PyObject_GetAttrString(it->second->m_module, "plugin_operation");
+	if (!pFunc)
+	{
+		Logger::getLogger()->fatal("Cannot find method 'plugin_operation' "
+					   "in loaded python module '%s'",
+					   it->second->m_name.c_str());
+	}
+
+	if (!pFunc || !PyCallable_Check(pFunc))
+	{
+		// Failure
+		if (PyErr_Occurred())
+		{
+			logErrorMessage();
+		}
+
+		Logger::getLogger()->fatal("Cannot call method plugin_operation "
+					   "in loaded python module '%s'",
+					   it->second->m_name.c_str());
+		Py_CLEAR(pFunc);
+
+		PyGILState_Release(state);
+		return rv;
+	}
+
+	Logger::getLogger()->debug("plugin_operation with operation=%s, parameterCount=%d", operation.c_str(), parameterCount);
+
+	PyObject *paramsList = PyList_New(parameterCount);
+	for (int i=0; i<parameterCount; i++)
+	{
+		PyList_SetItem(paramsList, i, Py_BuildValue("(ss)", parameters[i].name.c_str(), parameters[i].value.c_str()) );
+	}
+	
+	// Call Python method passing an object and 2 C-style strings
+	PyObject* pReturn = PyObject_CallFunction(pFunc,
+						  "OsO",
+						  handle, operation.c_str(), paramsList);
+
+	Py_CLEAR(pFunc);
+	Py_CLEAR(paramsList);
+
+	// Handle return
+	if (!pReturn)
+	{
+		Logger::getLogger()->error("Called python script method plugin_operation : "
+					   "error while getting result object, plugin '%s'",
+					   it->second->m_name.c_str());
+		logErrorMessage();
+	}
+	else
+	{
+		if (PyBool_Check(pReturn))
+		{
+			rv = PyObject_IsTrue(pReturn);
+			Logger::getLogger()->info("plugin_operation() returned %s", rv?"TRUE":"FALSE");
+		}
+		else
+		{
+			Logger::getLogger()->error("plugin_handle: plugin_operation(): "
+									"got result object '%p' of unexpected type %s, plugin '%s'",
+									pReturn, pReturn->ob_type->tp_name,
+									it->second->m_name.c_str());
+		}
+		Py_CLEAR(pReturn);
+	}
+	PyGILState_Release(state);
+
+	return rv;
+}
+
+
 
 /**
  * Returns function pointer that can be invoked to call '_sym' function
@@ -167,6 +388,10 @@ void* PluginInterfaceResolveSymbol(const char *_sym, const string& name)
 		return (void *) plugin_start_fn;
 	else if (!sym.compare("plugin_register_ingest"))
 		return (void *) plugin_register_ingest_fn;
+	else if (!sym.compare("plugin_write"))
+		return (void *) plugin_write_fn;
+	else if (!sym.compare("plugin_operation"))
+		return (void *) plugin_operation_fn;
 	else
 	{
 		Logger::getLogger()->fatal("PluginInterfaceResolveSymbol can not find symbol '%s' "

--- a/docs/plugin_developers_guide/03_02_south_python_Control.rst
+++ b/docs/plugin_developers_guide/03_02_south_python_Control.rst
@@ -1,0 +1,129 @@
+Set Point Control
+-----------------
+
+South plugins can also be used to exert control on the underlying device to which they are connected. This is not intended for use as a substitute for real time control systems, but rather as a mechanism to make non-time critical changes to a device or to trigger an operation on the device.
+
+To make a south plugin support control features there are two steps that need to be taken
+
+  - Tag the plugin as supporting control
+
+  - Add the entry points for control
+
+
+Enable Control
+~~~~~~~~~~~~~~
+
+A plugin enables control features by means of the mode field in the plugin information dict which is returned by the *plugin_info* entry point of the plugin. The flag value *control* should be added to the mode field of the plugin. Multiple flag values are separated by the pipe symbol '|'.
+
+.. code-block:: console
+
+    # plugin information dict
+    {
+        'name': 'Sinusoid Poll plugin',
+        'version': '1.9.2',
+        'mode': 'poll|control',
+        'type': 'south',
+        'interface': '1.0',
+        'config': _DEFAULT_CONFIG
+    }
+
+
+Adding this flag will cause the south service to do a number of things when it loads the plugin;
+
+  - The south service will attempt to resolve the two control entry points.
+
+  - A toggle will be added to the advanced configuration category of the service that will permit the disabling of control services.
+
+  - A security category will be added to the south service that contains the access control lists and permissions associated with the service.
+
+Control Entry Points
+~~~~~~~~~~~~~~~~~~~~
+
+Two entry points are supported for control operations in the south plugin
+
+  - **plugin_write**: which is used to set the value of a parameter within the plugin or device
+
+  - **plugin_operation**: which is used to perform an operation on the plugin or device
+
+The south plugin can support one or both of these entry points as appropriate for the plugin.
+
+Write Entry Point
+^^^^^^^^^^^^^^^^^
+
+The write entry point is used to set data in the plugin or write data into the device.
+
+The plugin write entry point is defined as follows
+
+.. code-block:: python
+
+     def plugin_write(handle, name, value)
+
+Where the parameters are;
+
+  - **handle** the handle of the plugin instance
+
+  - **name** the name of the item to be changed
+
+  - **value** a string presentation of the new value to assign to the item
+
+The return value defines if the write was successful or not. True is returned for a successful write.
+
+.. code-block:: python
+
+  def plugin_write(handle, name, value):
+    """ Setpoint write operation
+
+    Args:
+        handle: handle returned by the plugin initialisation call
+        name: Name of parameter to write
+        value: Value to be written to that parameter
+    Returns:
+        bool: Result of the write operation
+    """
+    _LOGGER.info("plugin_write(): name={}, value={}".format(name, value))
+    return True
+
+
+In this case we are merely printing the parameter name and the value to be set for this parameter. Normally control would be used for making a change with the connected device itself, such as changing a PLC register value. This is simply an example to demonstrate the API.
+
+Operation Entry Point
+^^^^^^^^^^^^^^^^^^^^^
+
+The plugin will support an operation entry point. This will execute the given operation synchronously, it is expected that this operation entry point will be called using a separate thread, therefore the plugin should implement operations in a thread safe environment.
+
+The plugin write operation entry point is defined as follows
+
+.. code-block:: python
+
+     def plugin_operation(handle, operation, params)
+
+Where the parameters are;
+
+  - **handle** the handle of the plugin instance
+
+  - **operation** the name of the operation to be executed
+
+  - **params** a list of name/value tuples that are passed to the operation
+
+The *operation* parameter should be used by the plugin to determine which operation is to be performed. The actual parameters are passed in a list of key/value tuples as strings.
+
+The return from the call is a boolean result of the operation, a failure of the operation or a call to an unrecognized operation should be indicated by returning a false value. If the operation succeeds a value of true should be returned.
+
+The following example shows the implementation of the plugin operation entry point.
+
+.. code-block:: python
+
+  def plugin_operation(handle, operation, params):
+    """ Setpoint control operation
+
+    Args:
+        handle: handle returned by the plugin initialisation call
+        operation: Name of operation
+        params: Parameter list
+    Returns:
+        bool: Result of the operation
+    """
+    _LOGGER.info("plugin_operation(): operation={}, params={}".format(operation, params))
+    return True
+
+In the case of a real machine the operation would most likely cause an action on a machine, for example a request to the machine to re-calibrate itself. Above example is just a demonstration of the API.

--- a/docs/plugin_developers_guide/03_south_plugins.rst
+++ b/docs/plugin_developers_guide/03_south_plugins.rst
@@ -141,4 +141,6 @@ It would then respond to the HTTP request and return. Since the handler is embed
   return web.json_response(message)
 
 
+.. include:: 03_02_south_python_Control.rst
+
 .. include:: 03_01_DHT11.rst


### PR DESCRIPTION
Also added support for plugin mode to have multiple flags set (separated by pipe symbol '|') e.g. "poll|control" in python plugins.