### PR TITLE
FOGL-6480: create AuthenticatedCaller item for all services but South ones

### DIFF
--- a/C/services/common/service_security.cpp
+++ b/C/services/common/service_security.cpp
@@ -32,7 +32,17 @@ bool ServiceAuthHandler::createSecurityCategories(ManagementClient* mgtClient)
 	string securityCatName = m_name + string("Security");
 	DefaultConfigCategory defConfigSecurity(securityCatName, string("{}"));
 
-	defConfigSecurity.setDescription(m_name + string(" security config params"));
+	// All services but South ones add 'AuthenticatedCaller' item
+	if (this->getType() != "Southbound")
+		// Add AuthenticatedCaller item, set to "false"
+		defConfigSecurity.addItem("AuthenticatedCaller",
+					"Security config params",
+					"boolean",
+					"false",
+					"false");
+		defConfigSecurity.setItemDisplayName("AuthenticatedCaller",
+					"Enable caller authorisation");
+	}
 
 	// Create/Update category name (we pass keep_original_items=true)
 	mgtClient->addCategory(defConfigSecurity, true);


### PR DESCRIPTION
FOGL-6480: create AuthenticatedCaller item for all services but South ones

The items in the $serviceSecurity category will be added when an ACL is attached to the South service