### PR TITLE
FOGL-6529 return payload as is for Public Proxy API endpoints

### DIFF
--- a/python/fledge/services/core/proxy.py
+++ b/python/fledge/services/core/proxy.py
@@ -121,7 +121,9 @@ async def handler(request):
     if request.method not in allow_methods:
         raise web.HTTPMethodNotAllowed(method=request.method, allowed_methods=allow_methods)
     try:
-        data = await request.json() if request.method != 'GET' else None
+        data = None
+        if request.method in ('POST', 'PUT'):
+            data = await request.json()
         # Find service name as per request.rel_url in proxy dict in-memory
         is_proxy_svc_found = False
         proxy_svc_name = None
@@ -161,6 +163,7 @@ async def _call_microservice_service_api(method: str, protocol: str, address: st
     if token is not None:
         headers['Authorization'] = "Bearer {}".format(token)
     url = "{}://{}:{}/{}".format(protocol, address, port, uri)
+
     try:
         if method == 'GET':
             async with aiohttp.ClientSession() as session:
@@ -194,6 +197,5 @@ async def _call_microservice_service_api(method: str, protocol: str, address: st
             _logger.warning("{} method is not implemented yet.".format(method))
     except Exception as ex:
         _logger.error(str(ex))
-        raise Exception(response)
-    else:
+    finally:
         return response

--- a/python/fledge/services/core/proxy.py
+++ b/python/fledge/services/core/proxy.py
@@ -140,7 +140,7 @@ async def handler(request):
         msg = str(ex)
         raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
     else:
-        return web.json_response({"info": result})
+        return web.json_response(body=result)
 
 
 async def _get_service_record_info_along_with_bearer_token(svc_name):


### PR DESCRIPTION
Sample examples with both sides are given below

```
# POST
Blocked by FOGL-6530

# DELETE
$ curl -sX DELETE http://localhost:40013/bucket/5 | jq
{
  "message": "Delete failed"
}
$ curl -sX DELETE http://localhost:8081/foglamp/bucket/5 | jq
{
  "message": "Delete failed"
}

# GET
$ curl -sX GET http://localhost:40013/bucket/5 | jq
{
  "message": "Invalid bucket id"
}
$ curl -sX GET http://localhost:8081/foglamp/bucket/5 | jq
{
  "message": "Invalid bucket id"
}

# PUT-bucket id
$ curl -sX PUT http://localhost:40013/bucket/6 -d'{ "attributes" : { "day" : "Thursday" } }' | jq
{
  "message": "Bucket updated"
}

$ curl -sX PUT http://localhost:8081/foglamp/bucket/6 -d'{ "attributes" : { "day" : "Thursday" } }' | jq
{
  "message": "Bucket updated"
}

# PUT-match buckets

$ curl -sX PUT http://localhost:40013/bucket/match -d '{ "attributes" : { "type" : "model" } }' | jq
{
  "matches": [
    {
      "bucket": "6",
      "file": "/home/aj/Development/WL-develop/FogLAMP/data/buckets/0/6",
      "attributes": {
        "day": "Thursday",
        "name": "AJ",
        "type": "model"
      }
    }
  ]
}
$ curl -sX PUT http://localhost:8081/foglamp/bucket/match -d '{ "attributes" : { "type" : "model" } }' | jq
{
  "matches": [
    {
      "bucket": "6",
      "file": "/home/aj/Development/WL-develop/FogLAMP/data/buckets/0/6",
      "attributes": {
        "day": "Thursday",
        "name": "AJ",
        "type": "model"
      }
    }
  ]
}

```