### PR TITLE
FOGL-6467: allow a single double quote escape in Postgres PUT endpoint

### DIFF
--- a/C/plugins/storage/postgres/connection.cpp
+++ b/C/plugins/storage/postgres/connection.cpp
@@ -1221,7 +1221,7 @@ SQLBuffer	sql;
 						else
 						{
 							sql.append("'\"");
-							sql.append(escape(str));
+							sql.append(escape_double_quotes(escape(str)));
 							sql.append("\"'");
 						}
 					}


### PR DESCRIPTION
FOGL-6467: allow a single double quote escape in Postgres PUT endpoint