### PR TITLE
Syslogs are overflooded "ERROR: Failure to get StorageAssetTracking record for service" when Asset tracker entry write to storage

### DIFF
--- a/C/services/south/ingest.cpp
+++ b/C/services/south/ingest.cpp
@@ -1255,15 +1255,9 @@ void Ingest::unDeprecateStorageAssetTrackingRecord(StorageAssetTrackingTuple* cu
 			}
 		}
 	}
-	else
-	{
-                m_logger->error("Failure to get StorageAssetTracking record "
-				"for service '%s', asset '%s'",
-				m_serviceName.c_str(),
-				assetName.c_str());
-	}
 
-	delete updatedTuple;
+	if (updatedTuple != nullptr)
+		delete updatedTuple;
 }
 
 


### PR DESCRIPTION
Signed-off-by: Innovative-ashwin <sinha.ashwini111@gmail.com>