### PR TITLE
FOGL-7005 Fix enable/disable a schedule causing double audit entries for Schedule Change event

### DIFF
--- a/python/fledge/services/core/scheduler/scheduler.py
+++ b/python/fledge/services/core/scheduler/scheduler.py
@@ -1159,6 +1159,7 @@ class Scheduler(object):
         if dryrun and is_new_schedule:
             await self._start_task(schedule_row, dryrun=True)
             return
+
         if is_enabled_modified is not None:
             if previous_enabled is None:  # New Schedule
                 # For a new schedule, if enabled is set to True, the schedule will be enabled.
@@ -1169,9 +1170,9 @@ class Scheduler(object):
                 bypass_check = True if previous_enabled != schedule.enabled else None
 
             if is_enabled_modified is True:
-                await self.enable_schedule(schedule.schedule_id, bypass_check=bypass_check)
+                await self.enable_schedule(schedule.schedule_id, bypass_check=bypass_check, record_audit_trail=False)
             else:
-                await self.disable_schedule(schedule.schedule_id, bypass_check=bypass_check)
+                await self.disable_schedule(schedule.schedule_id, bypass_check=bypass_check, record_audit_trail=False)
 
     async def remove_service_from_task_processes(self, service_name):
         """
@@ -1214,7 +1215,7 @@ class Scheduler(object):
                                                                                      schedule_type))
         return False
 
-    async def disable_schedule(self, schedule_id: uuid.UUID, bypass_check=None):
+    async def disable_schedule(self, schedule_id: uuid.UUID, bypass_check=None, record_audit_trail=True):
         """
         Find running Schedule, Terminate running process, Disable Schedule, Update database
 
@@ -1317,12 +1318,13 @@ class Scheduler(object):
             schedule.name,
             str(schedule_id),
             schedule.process_name)
-        audit = AuditLogger(self._storage_async)
-        sch = await self.get_schedule(schedule_id)
-        await audit.information('SCHCH', {'schedule': sch.toDict()})
+        if record_audit_trail:
+            audit = AuditLogger(self._storage_async)
+            sch = await self.get_schedule(schedule_id)
+            await audit.information('SCHCH', {'schedule': sch.toDict()})
         return True, "Schedule successfully disabled"
 
-    async def enable_schedule(self, schedule_id: uuid.UUID, bypass_check=None):
+    async def enable_schedule(self, schedule_id: uuid.UUID, bypass_check=None, record_audit_trail=True):
         """
         Get Schedule, Enable Schedule, Update database, Start Schedule
 
@@ -1368,9 +1370,10 @@ class Scheduler(object):
             schedule.name,
             str(schedule_id),
             schedule.process_name)
-        audit = AuditLogger(self._storage_async)
-        sch = await self.get_schedule(schedule_id)
-        await audit.information('SCHCH', { 'schedule': sch.toDict() })
+        if record_audit_trail:
+            audit = AuditLogger(self._storage_async)
+            sch = await self.get_schedule(schedule_id)
+            await audit.information('SCHCH', { 'schedule': sch.toDict() })
         return True, "Schedule successfully enabled"
 
     async def queue_task(self, schedule_id: uuid.UUID, start_now=True) -> None:

--- a/python/fledge/services/core/scheduler/scheduler.py
+++ b/python/fledge/services/core/scheduler/scheduler.py
@@ -1170,9 +1170,9 @@ class Scheduler(object):
                 bypass_check = True if previous_enabled != schedule.enabled else None
 
             if is_enabled_modified is True:
-                await self.enable_schedule(schedule.schedule_id, bypass_check=bypass_check, record_audit_trail=False)
+                await self.enable_schedule(schedule.schedule_id, bypass_check=bypass_check, record_audit_trail=is_new_schedule)
             else:
-                await self.disable_schedule(schedule.schedule_id, bypass_check=bypass_check, record_audit_trail=False)
+                await self.disable_schedule(schedule.schedule_id, bypass_check=bypass_check, record_audit_trail=is_new_schedule)
 
     async def remove_service_from_task_processes(self, service_name):
         """


### PR DESCRIPTION
note: Add schedule makes two entries SCHAD and SCHCH (as expected in code). 

Now, We should see only one entry for change in schedule, be it enabled or other attributes/properties; individual or along with others .