### PR TITLE
Commented out fixtures for cleaning PI system specially for connector relay system tests.

### DIFF
--- a/tests/system/python/e2e/test_e2e_coap_PI.py
+++ b/tests/system/python/e2e/test_e2e_coap_PI.py
@@ -77,8 +77,13 @@ def start_south_north(reset_and_start_fledge, add_south, start_north_pi_server_c
     dp_list = ['sensor', '']
     asset_dict = {}
     asset_dict[asset_name] = dp_list
-    clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
-                                       [], asset_dict)
+    # For connector relay we should not delete PI Point because
+    # when the PI point is created again (after deletion) the compressing attribute for it
+    # is always true. That means all the data is not stored in PI data archive.
+    # We lose a large proportion of the data because of compressing attribute.
+    # This is problematic for the fixture that verifies the data stored in PI.
+    # clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
+    #                                    [], asset_dict)
 
     # Define the template file for fogbench
     fogbench_template_path = os.path.join(

--- a/tests/system/python/e2e/test_e2e_csv_PI.py
+++ b/tests/system/python/e2e/test_e2e_csv_PI.py
@@ -71,8 +71,13 @@ def start_south_north(reset_and_start_fledge, add_south, start_north_pi_server_c
     dp_list = ['ivalue', 'fvalue', 'svalue', '']
     asset_dict = {}
     asset_dict[asset_name] = dp_list
-    clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
-                                       [], asset_dict)
+    # For connector relay we should not delete PI Point because
+    # when the PI point is created again (after deletion) the compressing attribute for it
+    # is always true. That means all the data is not stored in PI data archive.
+    # We lose a large proportion of the data because of compressing attribute.
+    # This is problematic for the fixture that verifies the data stored in PI.
+    # clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
+    #                                    [], asset_dict)
 
     # Define configuration of fledge south playback service
     south_config = {"assetName": {"value": "{}".format(asset_name)}, "csvFilename": {"value": "{}".format(CSV_NAME)},

--- a/tests/system/python/e2e/test_e2e_csv_multi_filter_pi.py
+++ b/tests/system/python/e2e/test_e2e_csv_multi_filter_pi.py
@@ -72,8 +72,13 @@ class TestE2eCsvMultiFltrPi:
         # 3. ivaluecrest    4. ivaluepeak
         asset_dict = {}
         asset_dict['e2e_filters_RMS'] = dp_list
-        clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
-                                           [], asset_dict)
+        # For connector relay we should not delete PI Point because
+        # when the PI point is created again (after deletion) the compressing attribute for it
+        # is always true. That means all the data is not stored in PI data archive.
+        # We lose a large proportion of the data because of compressing attribute.
+        # This is problematic for the fixture that verifies the data stored in PI.
+        # clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
+        #                                    [], asset_dict)
 
         # Define configuration of fledge south playback service
         south_config = {"assetName": {"value": "{}".format(asset_name)},

--- a/tests/system/python/e2e/test_e2e_expr_pi.py
+++ b/tests/system/python/e2e/test_e2e_expr_pi.py
@@ -70,8 +70,13 @@ class TestE2eExprPi:
         # 3. no data point (Asset name be used in this case.)
         asset_dict = {}
         asset_dict[ASSET_NAME] = dp_list
-        clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
-                                           [], asset_dict)
+        # For connector relay we should not delete PI Point because
+        # when the PI point is created again (after deletion) the compressing attribute for it
+        # is always true. That means all the data is not stored in PI data archive.
+        # We lose a large proportion of the data because of compressing attribute.
+        # This is problematic for the fixture that verifies the data stored in PI.
+        # clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
+        #                                    [], asset_dict)
 
         cfg = {"expression": {"value": "tan(x)"}, "minimumX": {"value": "45"}, "maximumX": {"value": "45"},
                "stepX": {"value": "0"}}

--- a/tests/system/python/e2e/test_e2e_filter_fft_threshold.py
+++ b/tests/system/python/e2e/test_e2e_filter_fft_threshold.py
@@ -74,8 +74,13 @@ class TestE2eFilterFFTThreshold:
         # 3. Band02
         asset_dict = {}
         asset_dict[ASSET + " " + 'FFT'] = dp_list
-        clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
-                                           [], asset_dict)
+        # For connector relay we should not delete PI Point because
+        # when the PI point is created again (after deletion) the compressing attribute for it
+        # is always true. That means all the data is not stored in PI data archive.
+        # We lose a large proportion of the data because of compressing attribute.
+        # This is problematic for the fixture that verifies the data stored in PI.
+        # clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
+        #                                    [], asset_dict)
 
         # Define configuration of Fledge playback service
         south_config = {"assetName": {"value": "{}".format(asset_name)},

--- a/tests/system/python/e2e/test_e2e_modbus_c_pi.py
+++ b/tests/system/python/e2e/test_e2e_modbus_c_pi.py
@@ -82,8 +82,13 @@ class TestE2EModbusCPI:
         dp_list = ['front right', 'rear right', 'front left', 'rear left', '']
         asset_dict = {}
         asset_dict[ASSET_NAME] = dp_list
-        clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
-                                           [], asset_dict)
+        # For connector relay we should not delete PI Point because
+        # when the PI point is created again (after deletion) the compressing attribute for it
+        # is always true. That means all the data is not stored in PI data archive.
+        # We lose a large proportion of the data because of compressing attribute.
+        # This is problematic for the fixture that verifies the data stored in PI.
+        # clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
+        #                                    [], asset_dict)
 
         add_south(SOUTH_PLUGIN, south_branch, fledge_url, service_name=SVC_NAME, config=cfg,
                   plugin_lang="C", start_service=False, plugin_discovery_name=PLUGIN_NAME)

--- a/tests/system/python/e2e/test_e2e_pi_scaleset.py
+++ b/tests/system/python/e2e/test_e2e_pi_scaleset.py
@@ -82,8 +82,13 @@ class TestE2ePiEgressWithScalesetFilter:
         asset_dict[ASSET_NAME] = dp_list
         asset_dict["{}{}".format(ASSET_PREFIX, ASSET_NAME)] = dp_list
 
-        clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
-                                           [], asset_dict)
+        # For connector relay we should not delete PI Point because
+        # when the PI point is created again (after deletion) the compressing attribute for it
+        # is always true. That means all the data is not stored in PI data archive.
+        # We lose a large proportion of the data because of compressing attribute.
+        # This is problematic for the fixture that verifies the data stored in PI.
+        # clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
+        #                                   [], asset_dict)
 
         fogbench_template_path = os.path.join(
             os.path.expandvars('${FLEDGE_ROOT}'), 'data/template.json')

--- a/tests/system/python/e2e/test_e2e_vary_asset_http_pi.py
+++ b/tests/system/python/e2e/test_e2e_vary_asset_http_pi.py
@@ -102,9 +102,13 @@ class TestE2EAssetHttpPI:
         # 5. no data point (Asset name be used in this case.)
         asset_dict = {}
         asset_dict[asset_name] = dp_list
-
-        clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
-                                           [], asset_dict)
+        # For connector relay we should not delete PI Point because
+        # when the PI point is created again (after deletion) the compressing attribute for it
+        # is always true. That means all the data is not stored in PI data archive.
+        # We lose a large proportion of the data because of compressing attribute.
+        # This is problematic for the fixture that verifies the data stored in PI.
+        # clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
+        #                                    [], asset_dict)
 
         south_plugin = "http"
         add_south("http_south", south_branch, fledge_url, config={"assetNamePrefix": {"value": ""}},

--- a/tests/system/python/pair/test_e2e_fledge_pair.py
+++ b/tests/system/python/pair/test_e2e_fledge_pair.py
@@ -112,8 +112,13 @@ class TestE2eFogPairPi:
         dp_list = ['ivalue', '']
         asset_dict = {}
         asset_dict[remote_asset_name] = dp_list
-        clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
-                                           [], asset_dict)
+        # For connector relay we should not delete PI Point because
+        # when the PI point is created again (after deletion) the compressing attribute for it
+        # is always true. That means all the data is not stored in PI data archive.
+        # We lose a large proportion of the data because of compressing attribute.
+        # This is problematic for the fixture that verifies the data stored in PI.
+        # clear_pi_system_through_pi_web_api(pi_host, pi_admin, pi_passwd, pi_db,
+        #                                    [], asset_dict)
 
         if remote_fledge_path is None:
             remote_fledge_path = '/home/{}/fledge'.format(remote_user)


### PR DESCRIPTION
 For connector relay we should not delete PI Point because 
 when the PI point is created again (after deletion) the compressing attribute for it 
 is always true. That means all the data is not stored in PI data archive. 
  We lose a large proportion of the data because of compressing attribute.
 This is problematic for the fixture that verifies the data stored in PI. 