### PR TITLE
FOGL-7060 New user role types & some restrictions added to API as per user

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 fledge_version=2.0.0
-fledge_schema=58
+fledge_schema=59

--- a/python/fledge/common/web/middleware.py
+++ b/python/fledge/common/web/middleware.py
@@ -68,7 +68,7 @@ async def auth_middleware(app, handler):
             token = request.headers.get('authorization')
         except:
             token = request.headers.get('Authorization', None)
-        
+
         if token:
             try:
                 # validate the token and get user id
@@ -82,6 +82,9 @@ async def auth_middleware(app, handler):
                 request.token = token
                 # set if user is admin
                 request.user_is_admin = True if int(request.user["role_id"]) == 1 else False
+                # With "view" based user role only read access operation is allowed
+                if int(request.user["role_id"]) == 3 and request.method != 'GET':
+                    raise web.HTTPForbidden
             except(User.InvalidToken, User.TokenExpired) as e:
                 raise web.HTTPUnauthorized(reason=e)
             except (jwt.DecodeError, jwt.ExpiredSignatureError) as e:

--- a/python/fledge/common/web/middleware.py
+++ b/python/fledge/common/web/middleware.py
@@ -83,12 +83,18 @@ async def auth_middleware(app, handler):
                 # set if user is admin
                 request.user_is_admin = True if int(request.user["role_id"]) == 1 else False
                 # With "view" based user role only read access operation is allowed
+                # logout is also allowed
                 if int(request.user["role_id"]) == 3 and request.method != 'GET':
-                    raise web.HTTPForbidden
+                    if not str(request.path).endswith('/logout'):
+                        raise web.HTTPForbidden
                 # With "data-view" based user role only browser asset read operation is allowed
-                if int(request.user["role_id"]) == 4:
+                # logout is also allowed
+                elif int(request.user["role_id"]) == 4:
                     if request.method == 'GET':
                         if not str(request.path).startswith('/fledge/asset'):
+                            raise web.HTTPForbidden
+                    elif request.method == 'PUT':
+                        if not str(request.path).endswith('/logout'):
                             raise web.HTTPForbidden
                     else:
                         raise web.HTTPForbidden

--- a/python/fledge/common/web/middleware.py
+++ b/python/fledge/common/web/middleware.py
@@ -85,6 +85,13 @@ async def auth_middleware(app, handler):
                 # With "view" based user role only read access operation is allowed
                 if int(request.user["role_id"]) == 3 and request.method != 'GET':
                     raise web.HTTPForbidden
+                # With "data-view" based user role only browser asset read operation is allowed
+                if int(request.user["role_id"]) == 4:
+                    if request.method == 'GET':
+                        if not str(request.path).startswith('/fledge/asset'):
+                            raise web.HTTPForbidden
+                    else:
+                        raise web.HTTPForbidden
             except(User.InvalidToken, User.TokenExpired) as e:
                 raise web.HTTPUnauthorized(reason=e)
             except (jwt.DecodeError, jwt.ExpiredSignatureError) as e:

--- a/python/fledge/common/web/middleware.py
+++ b/python/fledge/common/web/middleware.py
@@ -82,22 +82,8 @@ async def auth_middleware(app, handler):
                 request.token = token
                 # set if user is admin
                 request.user_is_admin = True if int(request.user["role_id"]) == 1 else False
-                # With "view" based user role only read access operation is allowed
-                # logout is also allowed
-                if int(request.user["role_id"]) == 3 and request.method != 'GET':
-                    if not str(request.path).endswith('/logout'):
-                        raise web.HTTPForbidden
-                # With "data-view" based user role only browser asset read operation is allowed
-                # logout is also allowed
-                elif int(request.user["role_id"]) == 4:
-                    if request.method == 'GET':
-                        if not str(request.path).startswith('/fledge/asset'):
-                            raise web.HTTPForbidden
-                    elif request.method == 'PUT':
-                        if not str(request.path).endswith('/logout'):
-                            raise web.HTTPForbidden
-                    else:
-                        raise web.HTTPForbidden
+                # validate request path
+                await validate_requests(request)
             except(User.InvalidToken, User.TokenExpired) as e:
                 raise web.HTTPUnauthorized(reason=e)
             except (jwt.DecodeError, jwt.ExpiredSignatureError) as e:
@@ -170,3 +156,22 @@ def handle_api_exception(ex, _class=None, if_trace=0):
 
     return web.Response(status=500, body=json.dumps({'error': err_msg}).encode('utf-8'),
                         content_type='application/json')
+
+
+async def validate_requests(request):
+    # With "view" based user role only read access operation is allowed
+    # logout is also allowed
+    if int(request.user["role_id"]) == 3 and request.method != 'GET':
+        if not str(request.path).endswith('/logout'):
+            raise web.HTTPForbidden
+    # With "data-view" based user role only browser asset read operation is allowed
+    # logout is also allowed
+    elif int(request.user["role_id"]) == 4:
+        if request.method == 'GET':
+            if not str(request.path).startswith('/fledge/asset'):
+                raise web.HTTPForbidden
+        elif request.method == 'PUT':
+            if not str(request.path).endswith('/logout'):
+                raise web.HTTPForbidden
+        else:
+            raise web.HTTPForbidden

--- a/scripts/plugins/storage/postgres/downgrade/58.sql
+++ b/scripts/plugins/storage/postgres/downgrade/58.sql
@@ -1,0 +1,4 @@
+-- Delete roles
+DELETE FROM fledge.roles WHERE name IN ('view','data-view');
+-- Reset auto increment
+ALTER SEQUENCE fledge.roles_id_seq RESTART WITH 3

--- a/scripts/plugins/storage/postgres/init.sql
+++ b/scripts/plugins/storage/postgres/init.sql
@@ -848,7 +848,9 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA fledge TO PUBLIC;
 DELETE FROM fledge.roles;
 INSERT INTO fledge.roles ( name, description )
      VALUES ('admin', 'All CRUD privileges'),
-            ('user', 'All CRUD operations and self profile management');
+            ('user', 'All CRUD operations and self profile management'),
+            ('view', 'Only to view the configuration'),
+            ('data-view', 'Only read the data in buffer');
 
 
 -- Users

--- a/scripts/plugins/storage/postgres/upgrade/59.sql
+++ b/scripts/plugins/storage/postgres/upgrade/59.sql
@@ -1,0 +1,4 @@
+-- Roles
+INSERT INTO fledge.roles ( name, description )
+     VALUES ('view', 'Only to view the configuration'),
+            ('data-view', 'Only read the data in buffer');

--- a/scripts/plugins/storage/sqlite/downgrade/58.sql
+++ b/scripts/plugins/storage/sqlite/downgrade/58.sql
@@ -1,0 +1,5 @@
+-- Delete roles
+DELETE FROM roles WHERE name IN ('view','data-view');
+-- Reset auto increment
+-- You cannot use ALTER TABLE for that. The autoincrement counter is stored in a separate table named "sqlite_sequence". You can modify the value there
+UPDATE sqlite_sequence SET seq=1 WHERE name="roles";

--- a/scripts/plugins/storage/sqlite/downgrade/58.sql
+++ b/scripts/plugins/storage/sqlite/downgrade/58.sql
@@ -1,5 +1,5 @@
 -- Delete roles
-DELETE FROM roles WHERE name IN ('view','data-view');
+DELETE FROM fledge.roles WHERE name IN ('view','data-view');
 -- Reset auto increment
 -- You cannot use ALTER TABLE for that. The autoincrement counter is stored in a separate table named "sqlite_sequence". You can modify the value there
 UPDATE sqlite_sequence SET seq=1 WHERE name="roles";

--- a/scripts/plugins/storage/sqlite/init.sql
+++ b/scripts/plugins/storage/sqlite/init.sql
@@ -638,7 +638,9 @@ CREATE TABLE fledge.acl_usage (
 DELETE FROM fledge.roles;
 INSERT INTO fledge.roles ( name, description )
      VALUES ('admin', 'All CRUD privileges'),
-            ('user', 'All CRUD operations and self profile management');
+            ('user', 'All CRUD operations and self profile management'),
+            ('view', 'Only to view the configuration'),
+            ('data-view', 'Only read the data in buffer');
 
 -- Users
 DELETE FROM fledge.users;

--- a/scripts/plugins/storage/sqlite/upgrade/59.sql
+++ b/scripts/plugins/storage/sqlite/upgrade/59.sql
@@ -1,0 +1,4 @@
+-- Roles
+INSERT INTO fledge.roles ( name, description )
+     VALUES ('view', 'Only to view the configuration'),
+            ('data-view', 'Only read the data in buffer');

--- a/scripts/plugins/storage/sqlitelb/downgrade/58.sql
+++ b/scripts/plugins/storage/sqlitelb/downgrade/58.sql
@@ -1,0 +1,5 @@
+-- Delete roles
+DELETE FROM roles WHERE name IN ('view','data-view');
+-- Reset auto increment
+-- You cannot use ALTER TABLE for that. The autoincrement counter is stored in a separate table named "sqlite_sequence". You can modify the value there
+UPDATE sqlite_sequence SET seq=1 WHERE name="roles";

--- a/scripts/plugins/storage/sqlitelb/downgrade/58.sql
+++ b/scripts/plugins/storage/sqlitelb/downgrade/58.sql
@@ -1,5 +1,5 @@
 -- Delete roles
-DELETE FROM roles WHERE name IN ('view','data-view');
+DELETE FROM fledge.roles WHERE name IN ('view','data-view');
 -- Reset auto increment
 -- You cannot use ALTER TABLE for that. The autoincrement counter is stored in a separate table named "sqlite_sequence". You can modify the value there
 UPDATE sqlite_sequence SET seq=1 WHERE name="roles";

--- a/scripts/plugins/storage/sqlitelb/init.sql
+++ b/scripts/plugins/storage/sqlitelb/init.sql
@@ -622,7 +622,9 @@ CREATE TABLE fledge.acl_usage (
 DELETE FROM fledge.roles;
 INSERT INTO fledge.roles ( name, description )
      VALUES ('admin', 'All CRUD privileges'),
-            ('user', 'All CRUD operations and self profile management');
+            ('user', 'All CRUD operations and self profile management'),
+            ('view', 'Only to view the configuration'),
+            ('data-view', 'Only read the data in buffer');
 
 -- Users
 DELETE FROM fledge.users;

--- a/scripts/plugins/storage/sqlitelb/upgrade/59.sql
+++ b/scripts/plugins/storage/sqlitelb/upgrade/59.sql
@@ -1,0 +1,4 @@
+-- Roles
+INSERT INTO fledge.roles ( name, description )
+     VALUES ('view', 'Only to view the configuration'),
+            ('data-view', 'Only read the data in buffer');

--- a/tests/system/python/api/test_authentication.py
+++ b/tests/system/python/api/test_authentication.py
@@ -112,8 +112,10 @@ class TestAuthenticationAPI:
         r = r.read().decode()
         jdoc = json.loads(r)
         assert {'roles': [{'description': 'All CRUD privileges', 'id': 1, 'name': 'admin'},
-                          {'description': 'All CRUD operations and self profile management',
-                           'id': 2, 'name': 'user'}]} == jdoc
+                          {'description': 'All CRUD operations and self profile management', 'id': 2, 'name': 'user'},
+                          {'id': 3, 'name': 'view', 'description': 'Only to view the configuration'},
+                          {'id': 4, 'name': 'data-view', 'description': 'Only read the data in buffer'}
+                          ]} == jdoc
 
     @pytest.mark.parametrize(("form_data", "expected_values"), [
         ({"username": "any1", "password": "User@123", "real_name": "AJ", "description": "Nerd user"},

--- a/tests/system/python/api/test_authentication.py
+++ b/tests/system/python/api/test_authentication.py
@@ -126,7 +126,17 @@ class TestAuthenticationAPI:
                    'description': ''}, 'message': 'admin1 user has been created successfully'}),
         ({"username": "bogus", "password": "Fl3dG$", "role_id": 2},
          {'user': {'userName': 'bogus', 'userId': 5, 'roleId': 2, 'accessMethod': 'any', 'realName': '',
-                   'description': ''}, 'message': 'bogus user has been created successfully'})
+                   'description': ''}, 'message': 'bogus user has been created successfully'}),
+        ({"username": "view", "password": "V!3w@1", "role_id": 3, "real_name": "View",
+          "description": "Only to view the configuration"},
+         {'user': {
+             'userName': 'view', 'userId': 6, 'roleId': 3, 'accessMethod': 'any', 'realName': 'View',
+             'description': 'Only to view the configuration'}, 'message': 'view user has been created successfully'}),
+        ({"username": "dataView", "password": "DV!3w@1", "role_id": 4, "real_name": "DataView",
+          "description": "Only read the data in buffer"},
+         {'user': {
+             'userName': 'dataview', 'userId': 7, 'roleId': 4, 'accessMethod': 'any', 'realName': 'DataView',
+             'description': 'Only read the data in buffer'}, 'message': 'dataview user has been created successfully'})
     ])
     def test_create_user(self, fledge_url, form_data, expected_values):
         conn = http.client.HTTPConnection(fledge_url)

--- a/tests/system/python/api/test_endpoints_with_different_user_types.py
+++ b/tests/system/python/api/test_endpoints_with_different_user_types.py
@@ -1,0 +1,373 @@
+# -*- coding: utf-8 -*-
+
+# FLEDGE_BEGIN
+# See: http://fledge-iot.readthedocs.io/
+# FLEDGE_END
+
+""" Test REST API endpoints with different user types """
+
+import http.client
+import json
+import time
+import pytest
+
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2022 Dianomic Systems"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+TOKEN = None
+VIEW_USERNAME = "view"
+VIEW_PWD = "V!3w@1"
+DATA_VIEW_USERNAME = "dataview"
+DATA_VIEW_PWD = "DV!3w$"
+
+
+@pytest.fixture
+def change_to_auth_mandatory(fledge_url, wait_time):
+    # Wait for fledge server to start
+    time.sleep(wait_time)
+    conn = http.client.HTTPConnection(fledge_url)
+    conn.request("PUT", '/fledge/category/rest_api', json.dumps({"authentication": "mandatory"}))
+    r = conn.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    jdoc = json.loads(r)
+    assert "mandatory" == jdoc['authentication']['value']
+
+    conn.request("PUT", '/fledge/restart', json.dumps({}))
+    r = conn.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    jdoc = json.loads(r)
+    assert "Fledge restart has been scheduled." == jdoc['message']
+
+
+def test_setup(reset_and_start_fledge, change_to_auth_mandatory, fledge_url, wait_time):
+    time.sleep(wait_time * 2)
+    conn = http.client.HTTPConnection(fledge_url)
+    # Admin login
+    conn.request("POST", "/fledge/login", json.dumps({"username": "admin", "password": "fledge"}))
+    r = conn.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    jdoc = json.loads(r)
+    assert "Logged in successfully." == jdoc['message']
+    assert "token" in jdoc
+    assert jdoc['admin']
+    admin_token = jdoc["token"]
+    # Create view user
+    view_payload = {"username": VIEW_USERNAME, "password": VIEW_PWD, "role_id": 3, "real_name": "View",
+                    "description": "Only to view the configuration"}
+    conn.request("POST", "/fledge/admin/user", body=json.dumps(view_payload), headers={"authorization": admin_token})
+    r = conn.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    jdoc = json.loads(r)
+    assert "{} user has been created successfully".format(VIEW_USERNAME) == jdoc["message"]
+
+    # Create Data view user
+    data_view_payload = {"username": DATA_VIEW_USERNAME, "password": DATA_VIEW_PWD, "role_id": 4,
+                         "real_name": "DataView", "description": "Only read the data in buffer"}
+    conn.request("POST", "/fledge/admin/user", body=json.dumps(data_view_payload),
+                 headers={"authorization": admin_token})
+    r = conn.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    jdoc = json.loads(r)
+    assert "{} user has been created successfully".format(DATA_VIEW_USERNAME) == jdoc["message"]
+
+
+class TestAPIEndpointsWithViewUserType:
+    def test_login(self, fledge_url, wait_time):
+        time.sleep(wait_time * 2)
+        conn = http.client.HTTPConnection(fledge_url)
+        conn.request("POST", "/fledge/login", json.dumps({"username": VIEW_USERNAME, "password": VIEW_PWD}))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert "Logged in successfully." == jdoc['message']
+        assert "token" in jdoc
+        assert not jdoc['admin']
+        global TOKEN
+        TOKEN = jdoc["token"]
+
+    @pytest.mark.parametrize(("method", "route_path", "http_status_code"), [
+        # common
+        ("GET", "/fledge/ping", 200), ("PUT", "/fledge/shutdown", 403), ("PUT", "/fledge/restart", 403),
+        # health
+        ("GET", "/fledge/health/storage", 200), ("GET", "/fledge/health/logging", 200),
+        # user & roles
+        ("GET", "/fledge/user", 200), ("PUT", "/fledge/user", 403), ("PUT", "/fledge/user/1/password", 403),
+        ("GET", "/fledge/user/role", 200),
+        # auth
+        ("POST", "/fledge/login", 403), ("PUT", "/fledge/31/logout", 401),
+        ("GET", "/fledge/auth/ott", 200),
+        # admin
+        ("POST", "/fledge/admin/user", 403), ("DELETE", "/fledge/admin/3/delete", 403), ("PUT", "/fledge/admin/3", 403),
+        ("PUT", "/fledge/admin/3/enable", 403), ("PUT", "/fledge/admin/3/reset", 403),
+        # category
+        ("GET", "/fledge/category", 200), ("POST", "/fledge/category", 403), ("GET", "/fledge/category/General", 200),
+        ("PUT", "/fledge/category/General", 403), ("DELETE", "/fledge/category/General", 403),
+        ("POST", "/fledge/category/General/children", 403), ("GET", "/fledge/category/General/children", 200),
+        ("DELETE", "/fledge/category/General/children/Advanced", 403),
+        ("DELETE", "/fledge/category/General/parent", 403),
+        ("GET", "/fledge/category/rest_api/allowPing", 200), ("PUT", "/fledge/category/rest_api/allowPing", 403),
+        ("DELETE", "/fledge/category/rest_api/allowPing/value", 403),
+        ("POST", "/fledge/category/rest_api/allowPing/upload", 403),
+        # schedule processes & schedules
+        ("GET", "/fledge/schedule/process", 200), ("POST", "/fledge/schedule/process", 403),
+        ("GET", "/fledge/schedule/process/purge", 200),
+        ("GET", "/fledge/schedule", 200), ("POST", "/fledge/schedule", 403), ("GET", "/fledge/schedule/type", 200),
+        ("GET", "/fledge/schedule/2176eb68-7303-11e7-8cf7-a6006ad3dba0", 200),
+        ("PUT", "/fledge/schedule/2176eb68-7303-11e7-8cf7-a6006ad3dba0/enable", 403),
+        ("PUT", "/fledge/schedule/2176eb68-7303-11e7-8cf7-a6006ad3dba0/disable", 403),
+        ("PUT", "/fledge/schedule/enable", 403), ("PUT", "/fledge/schedule/disable", 403),
+        ("POST", "/fledge/schedule/start/2176eb68-7303-11e7-8cf7-a6006ad3dba0", 403),
+        ("PUT", "/fledge/schedule/2176eb68-7303-11e7-8cf7-a6006ad3dba0", 403),
+        ("DELETE", "/fledge/schedule/2176eb68-7303-11e7-8cf7-a6006ad3dba0", 403),
+        # tasks
+        ("GET", "/fledge/task", 200), ("GET", "/fledge/task/state", 200), ("GET", "/fledge/task/latest", 200),
+        ("GET", "/fledge/task/123", 404), ("PUT", "/fledge/task/123/cancel", 403),
+        ("POST", "/fledge/scheduled/task", 403), ("DELETE", "/fledge/scheduled/task/blah", 403),
+        # service
+        ("POST", "/fledge/service", 403), ("GET", "/fledge/service", 200), ("DELETE", "/fledge/service/blah", 403),
+        # ("GET", "/fledge/service/available", 200), -- checked manually and commented out only to avoid apt-update
+        ("GET", "/fledge/service/installed", 200),
+        ("PUT", "/fledge/service/Southbound/blah/update", 403), ("POST", "/fledge/service/blah/otp", 403),
+        # south & north
+        ("GET", "/fledge/south", 200), ("GET", "/fledge/north", 200),
+        # asset browse
+        ("GET", "/fledge/asset", 200), ("GET", "/fledge/asset/sinusoid", 200),
+        ("GET", "/fledge/asset/sinusoid/latest", 200),
+        # TODO: FOGL-7096; it should be with 404
+        ("GET", "/fledge/asset/sinusoid/summary", 500), ("GET", "/fledge/asset/sinusoid/sinusoid", 200),
+        ("GET", "/fledge/asset/sinusoid/sinusoid/summary", 404), ("GET", "/fledge/asset/sinusoid/sinusoid/series", 200),
+        ("GET", "/fledge/asset/sinusoid/bucket/1", 200), ("GET", "/fledge/asset/sinusoid/sinusoid/bucket/1", 200),
+        ("GET", "/fledge/structure/asset", 200), ("DELETE", "/fledge/asset", 403),
+        ("DELETE", "/fledge/asset/sinusoid", 403),
+        # asset tracker
+        ("GET", "/fledge/track", 200), ("GET", "/fledge/track/storage/assets", 200),
+        ("PUT", "/fledge/track/service/foo/asset/bar/event/Ingest", 403),
+        # statistics
+        ("GET", "/fledge/statistics", 200), ("GET", "/fledge/statistics/history", 200),
+        ("GET", "/fledge/statistics/rate?periods=1&statistics=FOO", 200),
+        # audit trail
+        ("POST", "/fledge/audit", 403), ("GET", "/fledge/audit", 200), ("GET", "/fledge/audit/logcode", 200),
+        ("GET", "/fledge/audit/severity", 200),
+        # backup & restore
+        ("GET", "/fledge/backup", 200), ("POST", "/fledge/backup", 403), ("POST", "/fledge/backup/upload", 403),
+        ("GET", "/fledge/backup/status", 200), ("GET", "/fledge/backup/123", 404),
+        ("DELETE", "/fledge/backup/123", 403), ("GET", "/fledge/backup/123/download", 404),
+        ("PUT", "/fledge/backup/123/restore", 403),
+        # package update
+        # ("GET", "/fledge/update", 200), -- checked manually and commented out only to avoid apt-update run
+        ("PUT", "/fledge/update", 403),
+        # certs store
+        ("GET", "/fledge/certificate", 200), ("POST", "/fledge/certificate", 403),
+        ("DELETE", "/fledge/certificate/user", 403),
+        # support bundle
+        ("GET", "/fledge/support", 200), ("GET", "/fledge/support/foo", 400), ("POST", "/fledge/support", 403),
+        # syslogs & package logs
+        ("GET", "/fledge/syslog", 200), ("GET", "/fledge/package/log", 200), ("GET", "/fledge/package/log/foo", 400),
+        ("GET", "/fledge/package/install/status", 404),
+        # plugins
+        ("GET", "/fledge/plugins/installed", 200),
+        # ("GET", "/fledge/plugins/available", 200), -- checked manually and commented out only to avoid apt-update
+        ("POST", "/fledge/plugins", 403), ("PUT", "/fledge/plugins/south/sinusoid/update", 403),
+        ("DELETE", "/fledge/plugins/south/sinusoid", 403), ("GET", "/fledge/service/foo/persist", 404),
+        ("GET", "/fledge/service/foo/plugin/omf/data", 404), ("POST", "/fledge/service/foo/plugin/omf/data", 403),
+        ("DELETE", "/fledge/service/foo/plugin/omf/data", 403),
+        # filters
+        ("POST", "/fledge/filter", 403), ("PUT", "/fledge/filter/foo/pipeline", 403),
+        ("GET", "/fledge/filter/foo/pipeline", 404), ("GET", "/fledge/filter/bar", 404), ("GET", "/fledge/filter", 200),
+        ("DELETE", "/fledge/filter/foo/pipeline", 403), ("DELETE", "/fledge/filter/bar", 403),
+        # snapshots
+        ("GET", "/fledge/snapshot/plugins", 403), ("POST", "/fledge/snapshot/plugins", 403),
+        ("PUT", "/fledge/snapshot/plugins/1", 403), ("DELETE", "/fledge/snapshot/plugins/1", 403),
+        ("GET", "/fledge/snapshot/category", 403), ("POST", "/fledge/snapshot/category", 403),
+        ("PUT", "/fledge/snapshot/category/1", 403), ("DELETE", "/fledge/snapshot/category/1", 403),
+        ("GET", "/fledge/snapshot/schedule", 403), ("POST", "/fledge/snapshot/schedule", 403),
+        ("PUT", "/fledge/snapshot/schedule/1", 403), ("DELETE", "/fledge/snapshot/schedule/1", 403),
+        # repository
+        ("POST", "/fledge/repository", 403),
+        # ACL
+        ("POST", "/fledge/ACL", 403), ("GET", "/fledge/ACL", 200), ("GET", "/fledge/ACL/foo", 404),
+        ("PUT", "/fledge/ACL/foo", 403), ("DELETE", "/fledge/ACL/foo", 403), ("PUT", "/fledge/service/foo/ACL", 403),
+        ("DELETE", "/fledge/service/foo/ACL", 403),
+        # python packages
+        ("GET", "/fledge/python/packages", 200), ("POST", "/fledge/python/package", 403),
+        # notification
+        ("GET", "/fledge/notification", 200), ("GET", "/fledge/notification/plugin", 404),
+        ("GET", "/fledge/notification/type", 200), ("GET", "/fledge/notification/N1", 400),
+        ("POST", "/fledge/notification", 403), ("PUT", "/fledge/notification/N1", 403),
+        ("DELETE", "/fledge/notification/N1", 403), ("GET", "/fledge/notification/N1/delivery", 404),
+        ("POST", "/fledge/notification/N1/delivery", 403), ("GET", "/fledge/notification/N1/delivery/C1", 404),
+        ("DELETE", "/fledge/notification/N1/delivery/C1", 403)
+    ])
+    def test_endpoints(self, fledge_url, method, route_path, http_status_code, storage_plugin):
+        # FIXME: Once below JIRA's are resolved
+        if storage_plugin == 'postgres':
+            if route_path == '/fledge/structure/asset':
+                pytest.skip('Due to FOGL-7098')
+            elif route_path == '/fledge/statistics/rate?periods=1&statistics=FOO':
+                pytest.skip('Due to FOGL-7097')
+        conn = http.client.HTTPConnection(fledge_url)
+        conn.request(method, route_path, headers={"authorization": TOKEN})
+        r = conn.getresponse()
+        assert http_status_code == r.status
+        r.read().decode()
+
+    def test_logout_me(self, fledge_url):
+        conn = http.client.HTTPConnection(fledge_url)
+        conn.request("PUT", '/fledge/logout', headers={"authorization": TOKEN})
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert jdoc['logout']
+
+
+class TestAPIEndpointsWithDataViewUserType:
+    def test_login(self, fledge_url, wait_time):
+        time.sleep(wait_time * 2)
+        conn = http.client.HTTPConnection(fledge_url)
+        conn.request("POST", "/fledge/login", json.dumps({"username": DATA_VIEW_USERNAME, "password": DATA_VIEW_PWD}))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert "Logged in successfully." == jdoc['message']
+        assert "token" in jdoc
+        assert not jdoc['admin']
+        global TOKEN
+        TOKEN = jdoc["token"]
+
+    @pytest.mark.parametrize(("method", "route_path", "http_status_code"), [
+        # common
+        ("GET", "/fledge/ping", 403), ("PUT", "/fledge/shutdown", 403), ("PUT", "/fledge/restart", 403),
+        # health
+        ("GET", "/fledge/health/storage", 403), ("GET", "/fledge/health/logging", 403),
+        # user & roles
+        ("GET", "/fledge/user", 403), ("PUT", "/fledge/user", 403), ("PUT", "/fledge/user/1/password", 403),
+        ("GET", "/fledge/user/role", 403),
+        # auth
+        ("POST", "/fledge/login", 403), ("PUT", "/fledge/31/logout", 401),
+        ("GET", "/fledge/auth/ott", 403),
+        # admin
+        ("POST", "/fledge/admin/user", 403), ("DELETE", "/fledge/admin/3/delete", 403), ("PUT", "/fledge/admin/3", 403),
+        ("PUT", "/fledge/admin/3/enable", 403), ("PUT", "/fledge/admin/3/reset", 403),
+        # category
+        ("GET", "/fledge/category", 403), ("POST", "/fledge/category", 403), ("GET", "/fledge/category/General", 403),
+        ("PUT", "/fledge/category/General", 403), ("DELETE", "/fledge/category/General", 403),
+        ("POST", "/fledge/category/General/children", 403), ("GET", "/fledge/category/General/children", 403),
+        ("DELETE", "/fledge/category/General/children/Advanced", 403),
+        ("DELETE", "/fledge/category/General/parent", 403),
+        ("GET", "/fledge/category/rest_api/allowPing", 403), ("PUT", "/fledge/category/rest_api/allowPing", 403),
+        ("DELETE", "/fledge/category/rest_api/allowPing/value", 403),
+        ("POST", "/fledge/category/rest_api/allowPing/upload", 403),
+        # schedule processes & schedules
+        ("GET", "/fledge/schedule/process", 403), ("POST", "/fledge/schedule/process", 403),
+        ("GET", "/fledge/schedule/process/purge", 403),
+        ("GET", "/fledge/schedule", 403), ("POST", "/fledge/schedule", 403), ("GET", "/fledge/schedule/type", 403),
+        ("GET", "/fledge/schedule/2176eb68-7303-11e7-8cf7-a6006ad3dba0", 403),
+        ("PUT", "/fledge/schedule/2176eb68-7303-11e7-8cf7-a6006ad3dba0/enable", 403),
+        ("PUT", "/fledge/schedule/2176eb68-7303-11e7-8cf7-a6006ad3dba0/disable", 403),
+        ("PUT", "/fledge/schedule/enable", 403), ("PUT", "/fledge/schedule/disable", 403),
+        ("POST", "/fledge/schedule/start/2176eb68-7303-11e7-8cf7-a6006ad3dba0", 403),
+        ("PUT", "/fledge/schedule/2176eb68-7303-11e7-8cf7-a6006ad3dba0", 403),
+        ("DELETE", "/fledge/schedule/2176eb68-7303-11e7-8cf7-a6006ad3dba0", 403),
+        # tasks
+        ("GET", "/fledge/task", 403), ("GET", "/fledge/task/state", 403), ("GET", "/fledge/task/latest", 403),
+        ("GET", "/fledge/task/123", 403), ("PUT", "/fledge/task/123/cancel", 403),
+        ("POST", "/fledge/scheduled/task", 403), ("DELETE", "/fledge/scheduled/task/blah", 403),
+        # service
+        ("POST", "/fledge/service", 403), ("GET", "/fledge/service", 403), ("DELETE", "/fledge/service/blah", 403),
+        ("GET", "/fledge/service/available", 403), ("GET", "/fledge/service/installed", 403),
+        ("PUT", "/fledge/service/Southbound/blah/update", 403), ("POST", "/fledge/service/blah/otp", 403),
+        # south & north
+        ("GET", "/fledge/south", 403), ("GET", "/fledge/north", 403),
+        # asset browse
+        ("GET", "/fledge/asset", 200), ("GET", "/fledge/asset/sinusoid", 200),
+        ("GET", "/fledge/asset/sinusoid/latest", 200),
+        # TODO: FOGL-7096; it should be with 404
+        ("GET", "/fledge/asset/sinusoid/summary", 500), ("GET", "/fledge/asset/sinusoid/sinusoid", 200),
+        ("GET", "/fledge/asset/sinusoid/sinusoid/summary", 404), ("GET", "/fledge/asset/sinusoid/sinusoid/series", 200),
+        ("GET", "/fledge/asset/sinusoid/bucket/1", 200), ("GET", "/fledge/asset/sinusoid/sinusoid/bucket/1", 200),
+        ("GET", "/fledge/structure/asset", 403), ("DELETE", "/fledge/asset", 403),
+        ("DELETE", "/fledge/asset/sinusoid", 403),
+        # asset tracker
+        ("GET", "/fledge/track", 403), ("GET", "/fledge/track/storage/assets", 403),
+        ("PUT", "/fledge/track/service/foo/asset/bar/event/Ingest", 403),
+        # statistics
+        ("GET", "/fledge/statistics", 403), ("GET", "/fledge/statistics/history", 403),
+        ("GET", "/fledge/statistics/rate?periods=1&statistics=FOO", 403),
+        # audit trail
+        ("POST", "/fledge/audit", 403), ("GET", "/fledge/audit", 403), ("GET", "/fledge/audit/logcode", 403),
+        ("GET", "/fledge/audit/severity", 403),
+        # backup & restore
+        ("GET", "/fledge/backup", 403), ("POST", "/fledge/backup", 403), ("POST", "/fledge/backup/upload", 403),
+        ("GET", "/fledge/backup/status", 403), ("GET", "/fledge/backup/123", 403),
+        ("DELETE", "/fledge/backup/123", 403), ("GET", "/fledge/backup/123/download", 403),
+        ("PUT", "/fledge/backup/123/restore", 403),
+        # package update
+        # ("GET", "/fledge/update", 200), -- checked manually and commented out only to avoid apt-update
+        ("PUT", "/fledge/update", 403),
+        # certs store
+        ("GET", "/fledge/certificate", 403), ("POST", "/fledge/certificate", 403),
+        ("DELETE", "/fledge/certificate/user", 403),
+        # support bundle
+        ("GET", "/fledge/support", 403), ("GET", "/fledge/support/foo", 403), ("POST", "/fledge/support", 403),
+        # syslogs & package logs
+        ("GET", "/fledge/syslog", 403), ("GET", "/fledge/package/log", 403), ("GET", "/fledge/package/log/foo", 403),
+        ("GET", "/fledge/package/install/status", 403),
+        # plugins
+        ("GET", "/fledge/plugins/installed", 403), ("GET", "/fledge/plugins/available", 403),
+        ("POST", "/fledge/plugins", 403), ("PUT", "/fledge/plugins/south/sinusoid/update", 403),
+        ("DELETE", "/fledge/plugins/south/sinusoid", 403), ("GET", "/fledge/service/foo/persist", 403),
+        ("GET", "/fledge/service/foo/plugin/omf/data", 403), ("POST", "/fledge/service/foo/plugin/omf/data", 403),
+        ("DELETE", "/fledge/service/foo/plugin/omf/data", 403),
+        # filters
+        ("POST", "/fledge/filter", 403), ("PUT", "/fledge/filter/foo/pipeline", 403),
+        ("GET", "/fledge/filter/foo/pipeline", 403), ("GET", "/fledge/filter/bar", 403), ("GET", "/fledge/filter", 403),
+        ("DELETE", "/fledge/filter/foo/pipeline", 403), ("DELETE", "/fledge/filter/bar", 403),
+        # snapshots
+        ("GET", "/fledge/snapshot/plugins", 403), ("POST", "/fledge/snapshot/plugins", 403),
+        ("PUT", "/fledge/snapshot/plugins/1", 403), ("DELETE", "/fledge/snapshot/plugins/1", 403),
+        ("GET", "/fledge/snapshot/category", 403), ("POST", "/fledge/snapshot/category", 403),
+        ("PUT", "/fledge/snapshot/category/1", 403), ("DELETE", "/fledge/snapshot/category/1", 403),
+        ("GET", "/fledge/snapshot/schedule", 403), ("POST", "/fledge/snapshot/schedule", 403),
+        ("PUT", "/fledge/snapshot/schedule/1", 403), ("DELETE", "/fledge/snapshot/schedule/1", 403),
+        # repository
+        ("POST", "/fledge/repository", 403),
+        # ACL
+        ("POST", "/fledge/ACL", 403), ("GET", "/fledge/ACL", 403), ("GET", "/fledge/ACL/foo", 403),
+        ("PUT", "/fledge/ACL/foo", 403), ("DELETE", "/fledge/ACL/foo", 403), ("PUT", "/fledge/service/foo/ACL", 403),
+        ("DELETE", "/fledge/service/foo/ACL", 403),
+        # python packages
+        ("GET", "/fledge/python/packages", 403), ("POST", "/fledge/python/package", 403),
+        # notification
+        ("GET", "/fledge/notification", 403), ("GET", "/fledge/notification/plugin", 403),
+        ("GET", "/fledge/notification/type", 403), ("GET", "/fledge/notification/N1", 403),
+        ("POST", "/fledge/notification", 403), ("PUT", "/fledge/notification/N1", 403),
+        ("DELETE", "/fledge/notification/N1", 403), ("GET", "/fledge/notification/N1/delivery", 403),
+        ("POST", "/fledge/notification/N1/delivery", 403), ("GET", "/fledge/notification/N1/delivery/C1", 403),
+        ("DELETE", "/fledge/notification/N1/delivery/C1", 403)
+    ])
+    def test_endpoints(self, fledge_url, method, route_path, http_status_code):
+        conn = http.client.HTTPConnection(fledge_url)
+        conn.request(method, route_path, headers={"authorization": TOKEN})
+        r = conn.getresponse()
+        assert http_status_code == r.status
+        r.read().decode()
+
+    def test_logout_me(self, fledge_url):
+        conn = http.client.HTTPConnection(fledge_url)
+        conn.request("PUT", '/fledge/logout', headers={"authorization": TOKEN})
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert jdoc['logout']


### PR DESCRIPTION
**Items**
- [x] Update the CRUD API to support these user types.
- [x] Implement testing on all the API endpoints such that a view user can only call GET end points.
- [x] Implement testing on all API endpoints such that the data_view user can only access GET endpoints where the stub of the URL is /fledge/asset
- [x] New System tests added for different user types & existing system tests updated 

**Storage engine**
- [x] Sqlite
- [x] Sqlitelb
- [x] PostgreSQL