### PR TITLE
Update 2.0.1RC

### DIFF
--- a/C/common/management_client.cpp
+++ b/C/common/management_client.cpp
@@ -1742,13 +1742,16 @@ bool ManagementClient::addStorageAssetTrackingTuple(const std::string& service,
 					const int& count)
 {
 	ostringstream convert;
-
-	std::string d = datapoints;
-	for ( int i = 0; i < datapoints.size(); ++i)
-	{
-		if (d[i] == ',') d.insert(i, "\",\"" );
-		i = i+2;
-	}
+	std::string d ;
+        for ( int i = 0; i < datapoints.size(); ++i)
+        {
+                if (datapoints[i] == ',')
+                {
+                        d.append("\",\"");
+                }
+                else
+                        d.append(1,datapoints[i]);
+        }
 
 	try {
 		convert << "{ \"service\" : \"" << JSONescape(service) << "\", ";

--- a/C/common/management_client.cpp
+++ b/C/common/management_client.cpp
@@ -1760,6 +1760,11 @@ bool ManagementClient::addStorageAssetTrackingTuple(const std::string& service,
 		convert << " \"count\" : " << count << " } }";
 
 		auto res = this->getHttpClient()->request("POST", "/fledge/track", convert.str());
+		if (res->status_code[0] == '2') // A 2xx response
+                {
+                        return true;
+                }
+
 		Document doc;
 		string content = res->content.string();
 		doc.Parse(content.c_str());
@@ -1770,11 +1775,6 @@ bool ManagementClient::addStorageAssetTrackingTuple(const std::string& service,
 								httpError?"HTTP error during":"Failed to parse result of", 
 								content.c_str());
 			return false;
-		}
-		if (doc.HasMember("fledge"))
-		{
-			const char *reg_id = doc["fledge"].GetString();
-			return true;
 		}
 		else if (doc.HasMember("message"))
 		{

--- a/python/fledge/services/core/api/configuration.py
+++ b/python/fledge/services/core/api/configuration.py
@@ -250,12 +250,13 @@ async def set_configuration_item(request):
                        WHEN: if non-admin user is trying to update 
                        THEN: 403 Forbidden case 
     """
-    if request.user and (category_name == 'rest_api' and config_item == 'authentication'):
-        if not request.user_is_admin:
-            msg = "Admin role permissions required to change the {} value for category {}.".format(
-                config_item, category_name)
-            _logger.warning(msg)
-            raise web.HTTPForbidden(reason=msg, body=json.dumps({"message": msg}))
+    if hasattr(request, "user"):
+        if request.user and (category_name == 'rest_api' and config_item == 'authentication'):
+            if not request.user_is_admin:
+                msg = "Admin role permissions required to change the {} value for category {}.".format(
+                    config_item, category_name)
+                _logger.warning(msg)
+                raise web.HTTPForbidden(reason=msg, body=json.dumps({"message": msg}))
 
     data = await request.json()
     cf_mgr = ConfigurationManager(connect.get_storage_async())
@@ -326,13 +327,16 @@ async def update_configuration_item_bulk(request):
                            WHEN: if non-admin user is trying to update 
                            THEN: 403 Forbidden case 
         """
-        config_items = [k for k, v in data.items() if k == 'authentication']
-        if request.user and (category_name == 'rest_api' and config_items):
-            if not request.user_is_admin:
-                msg = "Admin role permissions required to change the authentication value for category {}.".format(
-                    category_name)
-                _logger.warning(msg)
-                return web.HTTPForbidden(reason=msg, body=json.dumps({"message": msg}))
+        
+        
+        if hasattr(request, "user"):
+            config_items = [k for k, v in data.items() if k == 'authentication']
+            if request.user and (category_name == 'rest_api' and config_items):
+                if not request.user_is_admin:
+                    msg = "Admin role permissions required to change the authentication value for category {}.".format(
+                        category_name)
+                    _logger.warning(msg)
+                    return web.HTTPForbidden(reason=msg, body=json.dumps({"message": msg}))
         cf_mgr = ConfigurationManager(connect.get_storage_async())
         try:
             is_core_mgt = request.is_core_mgt


### PR DESCRIPTION
Fixes regarding the below JIRAs have been cherry-picked:

1- FOGL-7072 Error logs coming repeatedly for storage tracker entries while ingesting
2- FOGL-7073 Asset tracker repeated errors are appearing in syslogs when we re-adding a service with old (deleted) name
3- FOGL-7080 Postgres storage plugin - north task is causing dataSent more than dataRead