### PR TITLE
FOGL-7179: Set session level time zone for Postgres DB connection to 'UTC'

### DIFF
--- a/C/plugins/storage/postgres/connection.cpp
+++ b/C/plugins/storage/postgres/connection.cpp
@@ -350,6 +350,14 @@ Connection::Connection()
 			connectErrorTime = time(0);
 		}
 	}
+	
+	logSQL("Set", "session time zone 'UTC' ");
+	PGresult *res = PQexec(dbConnection, " set session time zone 'UTC' ");
+	if (PQresultStatus(res) != PGRES_COMMAND_OK)
+	{
+		Logger::getLogger()->error("set session time zone failed: %s", PQerrorMessage(dbConnection));
+	}
+	PQclear(res);
 }
 
 /**


### PR DESCRIPTION
With this setting, all timezone-aware timestamps are returned in 'UTC' rather than configured time zone.

Signed-off-by: Amandeep Singh Arora <aman@dianomic.com>