### PR TITLE
FOGL-7227 Run purge operations on readings plugins if different from the

### DIFF
--- a/C/services/storage/storage.cpp
+++ b/C/services/storage/storage.cpp
@@ -92,6 +92,7 @@ string	       coreAddress = "localhost";
 bool	       daemonMode = true;
 string	       myName = SERVICE_NAME;
 bool           returnPlugin = false;
+bool           returnReadingsPlugin = false;
 string	       logLevel = "warning";
 
 	for (int i = 1; i < argc; i++)
@@ -116,16 +117,26 @@ string	       logLevel = "warning";
 		{
 			returnPlugin = true;
 		}
+		else if (!strncmp(argv[i], "--readingsplugin", 8))
+		{
+			returnReadingsPlugin = true;
+		}
 		else if (!strncmp(argv[i], "--logLevel=", 11))
 		{
 			logLevel = &argv[i][11];
 		}
 	}
 
-	if (returnPlugin == false && daemonMode && makeDaemon() == -1)
+	if (returnPlugin == false && returnReadingsPlugin == false && daemonMode && makeDaemon() == -1)
 	{
 		// Failed to run in daemon mode
 		cout << "Failed to run as deamon - proceeding in interactive mode." << endl;
+	}
+
+	if (returnPlugin && returnReadingsPlugin)
+	{
+		cout << "You can not specify --plugin and --readingsplugin together";
+		exit(1);
 	}
 
 	StorageService *service = new StorageService(myName);
@@ -133,6 +144,10 @@ string	       logLevel = "warning";
 	if (returnPlugin)
 	{
 		cout << service->getPluginName() << " " << service->getPluginManagedStatus() << endl;
+	}
+	else if (returnReadingsPlugin)
+	{
+		cout << service->getReadingPluginName() << " " << service->getPluginManagedStatus() << endl;
 	}
 	else
 	{
@@ -521,4 +536,17 @@ string StorageService::getPluginName()
 string StorageService::getPluginManagedStatus()
 {
 	return string(config->getValue("managedStatus"));
+}
+
+/**
+ * Return the name of the configured reading plugin
+ */
+string StorageService::getReadingPluginName()
+{
+	string rval = config->getValue("readingPlugin");
+	if (rval.empty())
+	{
+		rval = config->getValue("plugin");
+	}
+	return rval;
 }

--- a/scripts/common/get_readings_plugin.sh
+++ b/scripts/common/get_readings_plugin.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 ##--------------------------------------------------------------------
-## Copyright (c) 2017 OSIsoft, LLC
+## Copyright (c) 2022 OSIsoft, LLC
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
 ## You may obtain a copy of the License at
 ##
-#     http://www.apache.org/licenses/LICENSE-2.0
+##     http://www.apache.org/licenses/LICENSE-2.0
 ##
 ## Unless required by applicable law or agreed to in writing, software
 ## distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,25 +16,17 @@
 ## limitations under the License.
 ##--------------------------------------------------------------------
 
-##
-## This script is used to get information regarding the Storage Plugin
+__author__="Massimiliano Pinto"
+__version__="1.0"
 
-
-get_engine_management() {
-
-  storage_info=( $($FLEDGE_ROOT/scripts/services/storage --plugin) )
-
-  if [ "${storage_info[0]}" != "$1" ]; then
-	  # Not the storage plugin, maybe beign used for readings
-    storage_info=( $($FLEDGE_ROOT/scripts/services/storage --readingplugin) )
-    if [ "${storage_info[0]}" != "$1" ]; then
-	    echo ""
-    else
-    	echo "${storage_info[1]}"
-    fi
-  else
-    echo "${storage_info[1]}"
-  fi
-
+# Get the storage database plugin from the Storage microservice cache file
+get_readings_plugin() {
+if [ "${FLEDGE_ROOT}" ]; then
+    $FLEDGE_ROOT/scripts/services/storage --readingsPlugin | cut -d' ' -f1
+elif [ -x scripts/services/storage ]; then
+    scripts/services/storage --readingsPlugin | cut -d' ' -f1
+else
+    logger "Unable to find Fledge storage script."
+    exit 1
+fi
 }
-

--- a/scripts/services/storage
+++ b/scripts/services/storage
@@ -41,6 +41,9 @@ else
 	if [[ "$1" != "--plugin" ]]; then
             write_log "" "scripts.services.storage" "info" "Fledge storage microservice found in FLEDGE_ROOT location: ${FLEDGE_ROOT}" "logonly" ""
 	fi
+	if [[ "$1" != "--readingsPlugin" ]]; then
+            write_log "" "scripts.services.storage" "info" "Fledge storage microservice found in FLEDGE_ROOT location: ${FLEDGE_ROOT}" "logonly" ""
+	fi
     fi
 fi
 
@@ -50,6 +53,18 @@ if [[ "$1" != "--plugin" ]]; then
     FLEDGE_SCHEMA=`cat ${FLEDGE_VERSION_FILE} | tr -d ' ' | grep -i "FLEDGE_SCHEMA=" | sed -e 's/\(.*\)=\(.*\)/\2/g'`
     # Get storage engine
     res=(`${storageExec} --plugin`)
+    storagePlugin=${res[0]}
+    managedEngine=${res[1]}
+    # Call plugin check: this will create database if not set yet
+   ${pluginScriptPath}/${storagePlugin}.sh init ${FLEDGE_SCHEMA} ${managedEngine}
+fi
+
+if [[ "$1" != "--readingsPlugin" ]]; then
+    # Get db schema
+    FLEDGE_VERSION_FILE="${FLEDGE_ROOT}/VERSION"
+    FLEDGE_SCHEMA=`cat ${FLEDGE_VERSION_FILE} | tr -d ' ' | grep -i "FLEDGE_SCHEMA=" | sed -e 's/\(.*\)=\(.*\)/\2/g'`
+    # Get storage engine
+    res=(`${storageExec} --readingsPlugin`)
     storagePlugin=${res[0]}
     managedEngine=${res[1]}
     # Call plugin check: this will create database if not set yet

--- a/scripts/storage
+++ b/scripts/storage
@@ -26,6 +26,7 @@
 
 # Include common code
 source "${FLEDGE_ROOT}/scripts/common/get_storage_plugin.sh"
+source "${FLEDGE_ROOT}/scripts/common/get_readings_plugin.sh"
 
 PLUGIN_TO_USE=""
 
@@ -40,6 +41,7 @@ storage_log() {
 
 
 PLUGIN_TO_USE=`get_storage_plugin`
+READINGS_PLUGIN_TO_USE=`get_readings_plugin`
 if [[ "${#PLUGIN_TO_USE}" -eq 0 ]]; then
     storage_log "err" "Missing plugin from Fledge storage service" "all" "pretty"
 fi
@@ -54,8 +56,39 @@ if [[ ! -x "$PLUGIN_SCRIPT" ]]; then
 
 fi
 
-# Pass action in $1 and FLEDGE_VERSION in $2
-source "$PLUGIN_SCRIPT" $1 $2
+# The reset must be executed on both the storage and readings plugins, if the
+# readings are stored in a different plugin. On the readings plugin this becomes
+# a purge operation.
+#
+# The purge action is only executed via the readings plugin if defined, or
+# the main storage plugin is not defined.
+
+if [[ "$1" == "reset" ]] ; then
+	# Pass action in $1 and FLEDGE_VERSION in $2
+	source "$PLUGIN_SCRIPT" $1 $2
+
+	if [[ "$PLUGIN_TO_USE" != "$READINGS_PLUGIN_TO_USE" ]]; then
+		READINGS_SCRIPT="$FLEDGE_ROOT/scripts/plugins/storage/$READINGS_PLUGIN_TO_USE.sh"
+		if [[ -x "$READINGS_SCRIPT" ]]; then
+			source "$READINGS_SCRIPT" purge $2
+		fi
+	fi
+elif [[ "$1" == "purge" ]]; then
+	# Pass action in $1 and FLEDGE_VERSION in $2
+
+	if [[ "$PLUGIN_TO_USE" != "$READINGS_PLUGIN_TO_USE" ]]; then
+		READINGS_SCRIPT="$FLEDGE_ROOT/scripts/plugins/storage/$READINGS_PLUGIN_TO_USE.sh"
+		# Soem readings plugins, notably sqlitememory, do not have a script
+		if [[ -x "$READINGS_SCRIPT" ]]; then
+		    source "$READINGS_SCRIPT" $1 $2
+	        fi
+	else
+		source "$PLUGIN_SCRIPT" $1 $2
+	fi
+else
+	# Pass any other operation to the storage plugin
+	source "$PLUGIN_SCRIPT" $1 $2
+fi
 
 # exit cannot be used because the script is sourced.
 #exit $?


### PR DESCRIPTION
storage plugin.

No one issue that could be improved is that two warnings are issued when doing a reset operations, one for each plugin.

Signed-off-by: Mark Riddoch <mark@dianomic.com>