### PR TITLE
FOGL-7179: Request Postgres DB to return UTC timestamps for audit log query

### DIFF
--- a/C/plugins/storage/postgres/connection.cpp
+++ b/C/plugins/storage/postgres/connection.cpp
@@ -443,6 +443,13 @@ SQLBuffer	jsonConstraints;	// Extra constraints to add to where clause
 								sql.append("\"");
 								sql.append((*itr)["column"].GetString());
 								sql.append("\"");
+								Logger::getLogger()->info("itr->HasMember(\"timezone\")=%s", itr->HasMember("timezone")?"True":"False");
+								if (itr->HasMember("timezone") && (*itr)["timezone"].IsString())
+								{
+									sql.append(" AT TIME ZONE '");
+									sql.append((*itr)["timezone"].GetString());
+									sql.append("' ");
+								}
 								sql.append(", '");
 								sql.append((*itr)["format"].GetString());
 								sql.append("')");

--- a/python/fledge/services/core/api/audit.py
+++ b/python/fledge/services/core/api/audit.py
@@ -211,7 +211,7 @@ async def get_audit_entries(request):
     try:
         # HACK: This way when we can more future we do not get an exponential
         # explosion of if statements
-        payload = PayloadBuilder().SELECT("code", "level", "log", "ts")\
+        payload = PayloadBuilder().SELECT("code", "level", "log", '{"column": "ts", "timezone": "UTC"}')\
             .ALIAS("return", ("ts", 'timestamp')).FORMAT("return", ("ts", "YYYY-MM-DD HH24:MI:SS.MS"))\
             .WHERE(['1', '=', 1])
 
@@ -219,7 +219,7 @@ async def get_audit_entries(request):
             if len(source_list) == 1:
                 payload.AND_WHERE(['code', '=', source])
             else:
-                payload = PayloadBuilder().SELECT("code", "level", "log", "ts") \
+                payload = PayloadBuilder().SELECT("code", "level", "log", '{"column": "ts", "timezone": "UTC"}') \
                     .ALIAS("return", ("ts", 'timestamp')).FORMAT("return", ("ts", "YYYY-MM-DD HH24:MI:SS.MS"))
                 payload.WHERE(['code', 'in', source_list])
         if severity is not None:


### PR DESCRIPTION
This is an alternate solution specifically for queries to a non-reading table to Postgres DB.

Alternate solution is in https://github.com/fledge-iot/fledge/pull/900.

If PR 900 is acceptable, that might be the better and universal solution, assuming no further application code assumes such retrieved timestamps to be in local timezone and attempts a subsequent conversion to UTC again.

Signed-off-by: Amandeep Singh Arora <aman@dianomic.com>