### PR TITLE
FOGL-7222 - Authentication system API tests & other non -notification tests fixes on CentOS9 stream

### DIFF
--- a/python/fledge/common/utils.py
+++ b/python/fledge/common/utils.py
@@ -124,3 +124,17 @@ def is_debian():
     if id_like is not None and any(x in id_like.lower() for x in ['centos', 'rhel', 'redhat', 'fedora']):
         return False
     return True
+
+
+def get_open_ssl_version(version_string=True):
+    """ Open SSL version info
+
+    Args:
+        version_string
+
+    Returns:
+        When version_string is True - The version string of the OpenSSL library loaded by the interpreter
+        When version_string is False - A tuple of five integers representing version information about the OpenSSL library
+    """
+    import ssl
+    return ssl.OPENSSL_VERSION if version_string else ssl.OPENSSL_VERSION_INFO

--- a/tests/system/python/api/test_plugin_discovery.py
+++ b/tests/system/python/api/test_plugin_discovery.py
@@ -115,7 +115,8 @@ class TestPluginDiscovery:
         assert 'fledge-south-sinusoid' == plugins[0]['packageName']
 
         # install one more south plugin (C version)
-        install_plugin(_type, plugin='random', plugin_lang='C')
+        # FIXME: BRANCH when testing is done in main FOGL-7260 branch
+        install_plugin(_type, plugin='random', plugin_lang='C', branch='compilation-fixes-centos9-stream')
         conn.request("GET", '/fledge/plugins/installed?type={}'.format(_type))
         r = conn.getresponse()
         assert 200 == r.status
@@ -179,7 +180,8 @@ class TestPluginDiscovery:
 
     def test_delivery_plugins_installed(self, fledge_url, _type='notify'):
         # install slack delivery plugin
-        install_plugin(_type, plugin='slack', plugin_lang='C')
+        # FIXME: BRANCH when testing is done in main FOGL-7260 branch
+        install_plugin(_type, plugin='slack', plugin_lang='C', branch='compilation-fixes-centos9-stream')
         conn = http.client.HTTPConnection(fledge_url)
         conn.request("GET", '/fledge/plugins/installed?type={}'.format(_type))
         r = conn.getresponse()
@@ -196,7 +198,8 @@ class TestPluginDiscovery:
 
     def test_rule_plugins_installed(self, fledge_url, _type='rule'):
         # install OutOfBound rule plugin
-        install_plugin(_type, plugin='outofbound', plugin_lang='C')
+        # FIXME: BRANCH when testing is done in main FOGL-7260 branch
+        install_plugin(_type, plugin='outofbound', plugin_lang='C', branch='compilation-fixes-centos9-stream')
         conn = http.client.HTTPConnection(fledge_url)
         conn.request("GET", '/fledge/plugins/installed?type={}'.format(_type))
         r = conn.getresponse()

--- a/tests/system/python/api/test_service.py
+++ b/tests/system/python/api/test_service.py
@@ -40,8 +40,9 @@ FILTER_NAME = 'meta'
 def install_plugins():
     plugin_and_service.install('south', plugin='randomwalk')
     plugin_and_service.install('south', plugin='http')
-    plugin_and_service.install('south', plugin='benchmark', plugin_lang='C')
-    plugin_and_service.install('south', plugin='random', plugin_lang='C')
+    # FIXME: BRANCH when testing is done in main FOGL-7260 branch
+    plugin_and_service.install('south', plugin='benchmark', plugin_lang='C', branch='compilation-fixes-centos9-stream')
+    plugin_and_service.install('south', plugin='random', plugin_lang='C', branch='compilation-fixes-centos9-stream')
     plugin_and_service.install('south', plugin='csv-async', plugin_lang='C')
 
 

--- a/tests/system/python/scripts/install_c_plugin
+++ b/tests/system/python/scripts/install_c_plugin
@@ -43,7 +43,8 @@ install_binary_file () {
    then
         # fledge-service-notification repo is required to build notificationRule Plugins
         service_repo_name='fledge-service-notification'
-        git clone -b ${BRANCH_NAME} --single-branch https://github.com/fledge-iot/${service_repo_name}.git /tmp/${service_repo_name}
+        # FIXME: BRANCH_NAME when testing is done in main FOGL-7260 branch
+        git clone -b develop --single-branch https://github.com/fledge-iot/${service_repo_name}.git /tmp/${service_repo_name}
         export NOTIFICATION_SERVICE_INCLUDE_DIRS=/tmp/${service_repo_name}/C/services/common/include
    fi
    


### PR DESCRIPTION
`fledge_nightly_build_centos_stream_9/27/` - Now those tests are passing

Note: Tests file will be reverted in FOGL-7260 branch & other TODO comments for x509 strict check