### PR TITLE
FOGL-7298 OMF Connector relay fix - 2.1.0rc

### DIFF
--- a/C/plugins/north/OMF/include/omf.h
+++ b/C/plugins/north/OMF/include/omf.h
@@ -23,6 +23,8 @@
 // Remove or comment out the line below to prevent the forcing
 // of the version
 #define EDS_OMF_VERSION	"1.0"
+#define CR_OMF_VERSION	"1.0"
+
 
 #define TYPE_ID_DEFAULT     1
 #define FAKE_ASSET_KEY      "_default_start_id_"

--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -1204,9 +1204,10 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 
 		string outData;
 		// Use old style complex types if the user has forced it via configuration,
-		// we are running against an EDS endpoint or we have types defined for this
+		// we are running against an EDS endpoint or Connector Relay or we have types defined for this
 		// asset already
-		if (legacyType || m_PIServerEndpoint == ENDPOINT_EDS ||
+		if (legacyType || m_PIServerEndpoint == ENDPOINT_EDS || 
+		        m_PIServerEndpoint == ENDPOINT_CR ||
 				m_OMFDataTypes->find(keyComplete) != m_OMFDataTypes->end())
 		{
 			// Legacy type support

--- a/C/plugins/north/OMF/plugin.cpp
+++ b/C/plugins/north/OMF/plugin.cpp
@@ -980,6 +980,13 @@ uint32_t plugin_send(const PLUGIN_HANDLE handle,
 		connInfo->omfversion = EDS_OMF_VERSION;
 	}
 #endif
+
+	// Version for Connector Relay is 1.0 only.
+	if (connInfo->PIServerEndpoint == ENDPOINT_CR)
+	{
+		connInfo->omfversion = CR_OMF_VERSION;
+	}
+
 	connInfo->omf->setOMFVersion(connInfo->omfversion);
 
 	// Generates the prefix to have unique asset_id across different levels of hierarchies
@@ -997,8 +1004,14 @@ uint32_t plugin_send(const PLUGIN_HANDLE handle,
 	connInfo->omf->setStaticData(&connInfo->staticData);
 	connInfo->omf->setNotBlockingErrors(connInfo->notBlockingErrors);
 
-	connInfo->omf->setLegacyMode(connInfo->legacy);
-
+	if (connInfo->omfversion == "1.1" || connInfo->omfversion == "1.0") {
+		Logger::getLogger()->info("Setting LegacyType to be true for OMF Version '%s'. This will force use old style complex types. ", connInfo->omfversion.c_str());
+		connInfo->omf->setLegacyMode(true);
+	}
+	else
+	{
+		connInfo->omf->setLegacyMode(connInfo->legacy);
+	}
 	// Send the readings data to the PI Server
 	uint32_t ret = connInfo->omf->sendToServer(readings,
 						   connInfo->compression);


### PR DESCRIPTION
Can now send data to connector relay. Firced legacy =true for omf versions 1.1 and 1.0