### PR TITLE
FOGL-7311 python pip packages info added in support bundle

### DIFF
--- a/python/fledge/services/core/api/python_packages.py
+++ b/python/fledge/services/core/api/python_packages.py
@@ -5,12 +5,11 @@
 # FLEDGE_END
 
 import logging
-import pkg_resources
-import json
 import asyncio
-
-from aiohttp import web
+import json
 from typing import List
+import pkg_resources
+from aiohttp import web
 
 from fledge.common import logger
 from fledge.common.audit_logger import AuditLogger
@@ -53,7 +52,7 @@ async def get_packages(request: web.Request) -> web.Response:
 async def install_package(request: web.Request) -> web.Response:
     """
     Args:
-        Request: '{ "package"   :   "numpy", 
+        request: '{ "package"   :   "numpy",
                     "version"   :   "1.2"   #optional
                   }'
 
@@ -84,29 +83,30 @@ async def install_package(request: web.Request) -> web.Response:
     installed_package, installed_version = get_installed_package_info(input_package_name)
 
     if installed_package:
-         #Package already exists
+        # Package already exists
         _LOGGER.info("Package: {} Version: {} already installed.".format(installed_package, installed_version))
         return web.HTTPConflict(reason="Package already installed.", 
-                                body=json.dumps({"message":"Package {} version {} already installed."
+                                body=json.dumps({"message": "Package {} version {} already installed."
                                                 .format(installed_package, installed_version)}))
 
-    #Package not found, install package via pip
-    pip_process = await asyncio.create_subprocess_shell('python3 -m pip install '+ install_args, 
+    # Package not found, install package via pip
+    pip_process = await asyncio.create_subprocess_shell('python3 -m pip install ' + install_args,
                                                         stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
     
     stdout, stderr = await pip_process.communicate()
     if pip_process.returncode == 0:
         _LOGGER.info("Package: {} successfully installed", format(input_package_name))
         try:
-            #Audit log entry: PIPIN
+            # Audit log entry: PIPIN
             storage_client = connect.get_storage_async()
             pip_audit_log = AuditLogger(storage_client)
-            audit_message = {"package":input_package_name, "status": "Success"}
+            audit_message = {"package": input_package_name, "status": "Success"}
             if input_package_version:
                 audit_message["version"] = input_package_version
             await pip_audit_log.information('PIPIN', audit_message)
         except:
-            _LOGGER.exception("Failed to log the audit entry for PIPIN, for package {} install", format(input_package_name))
+            _LOGGER.exception("Failed to log the audit entry for PIPIN, for package {} install", format(
+                input_package_name))
 
         response = "Package {} version {} installed successfully.".format(input_package_name, input_package_version)
         if not input_package_version:

--- a/python/fledge/services/core/api/python_packages.py
+++ b/python/fledge/services/core/api/python_packages.py
@@ -10,8 +10,9 @@ import json
 import asyncio
 
 from aiohttp import web
+from typing import List
+
 from fledge.common import logger
-from fledge.services.core import connect
 from fledge.common.audit_logger import AuditLogger
 from fledge.services.core import connect
 
@@ -28,6 +29,13 @@ _help = """
 """
 _LOGGER = logger.setup(__name__, level=logging.INFO)
 
+
+def get_packages_installed() -> List:
+    package_ws = pkg_resources.WorkingSet()
+    installed_pkgs = [{'package': dist.project_name, 'version': dist.version} for dist in package_ws]
+    return installed_pkgs
+
+
 async def get_packages(request: web.Request) -> web.Response:
     """
     Args:
@@ -39,9 +47,7 @@ async def get_packages(request: web.Request) -> web.Response:
     :Example:
            curl -X GET http://localhost:8081/fledge/python/packages
     """
-    package_ws = pkg_resources.WorkingSet()
-    installed_pkgs = [{'package':dist.project_name,'version': dist.version} for dist in package_ws]
-    return web.json_response({'packages': installed_pkgs})
+    return web.json_response({'packages': get_packages_installed()})
 
 
 async def install_package(request: web.Request) -> web.Response:

--- a/python/fledge/services/core/support.py
+++ b/python/fledge/services/core/support.py
@@ -24,6 +24,7 @@ from fledge.common.common import _FLEDGE_ROOT, _FLEDGE_DATA
 from fledge.common.configuration_manager import ConfigurationManager
 from fledge.common.plugin_discovery import PluginDiscovery
 from fledge.common.storage_client import payload_builder
+from fledge.services.core.api.python_packages import get_packages_installed
 from fledge.services.core.api.service import get_service_records, get_service_installed
 from fledge.services.core.connect import *
 
@@ -98,6 +99,7 @@ class SupportBuilder:
                 self.add_script_dir_content(pyz)
                 self.add_package_log_dir_content(pyz)
                 self.add_software_list(pyz, file_spec)
+                self.add_python_packages_list(pyz, file_spec)
             finally:
                 pyz.close()
         except Exception as ex:
@@ -291,6 +293,11 @@ class SupportBuilder:
             "services": get_service_installed()
         }
         temp_file = self._interim_file_path + "/" + "software-{}".format(file_spec)
+        self.write_to_tar(pyz, temp_file, data)
+
+    def add_python_packages_list(self, pyz, file_spec) -> None:
+        data = {'packages': get_packages_installed()}
+        temp_file = self._interim_file_path + "/" + "python-packages-{}".format(file_spec)
         self.write_to_tar(pyz, temp_file, data)
 
     def exclude_pycache(self, tar_info):


### PR DESCRIPTION
See the below output for downloaded support bundle

```
$ tar -tvf support-230116-12-49-59.tar.gz 
-rw-rw-r-- aj/aj            54 2023-01-16 12:49 fledge-info
-rw-rw-r-- aj/aj         64436 2023-01-16 12:49 syslog-230116-12-49-59
-rw-rw-r-- aj/aj         10264 2023-01-16 12:49 syslogStorage-230116-12-49-59
-rw-rw-r-- aj/aj         20675 2023-01-16 12:49 configuration-230116-12-49-59
-rw-rw-r-- aj/aj         24051 2023-01-16 12:49 audit-230116-12-49-59
-rw-rw-r-- aj/aj          2621 2023-01-16 12:49 schedules-230116-12-49-59
-rw-rw-r-- aj/aj          1978 2023-01-16 12:49 scheduled_processes-230116-12-49-59
-rw-rw-r-- aj/aj         10551 2023-01-16 12:49 statistics-history-230116-12-49-59
-rw-rw-r-- aj/aj            34 2023-01-16 12:49 plugin-data-230116-12-49-59
-rw-rw-r-- aj/aj            34 2023-01-16 12:49 streams-230116-12-49-59
-rw-rw-r-- aj/aj           687 2023-01-16 12:49 service_registry-230116-12-49-59
-rw-rw-r-- aj/aj          1986 2023-01-16 12:49 machine-230116-12-49-59
-rw-rw-r-- aj/aj           404 2023-01-16 12:49 psinfo-230116-12-49-59
drwxrwxr-x aj/aj             0 2022-12-13 15:58 package_logs/
-rw-rw-r-- aj/aj          4250 2023-01-16 12:50 software-230116-12-49-59
-rw-rw-r-- aj/aj         19854 2023-01-16 12:50 python-packages-230116-12-49-59

```
[python-packages-230116-12-49-59.zip](https://github.com/fledge-iot/fledge/files/10423388/python-packages-230116-12-49-59.zip)

