### PR TITLE
Optimisation for adding milliseconds to timestamps

### DIFF
--- a/C/common/reading.cpp
+++ b/C/common/reading.cpp
@@ -287,24 +287,34 @@ char  assetTime[DATE_TIME_BUFFER_LEN + 20];
 	if (dateFormat != FMT_ISO8601 && addMS)
 	{
 		// Add microseconds
-		snprintf(micro_s,
-			 sizeof(micro_s),
-			 ".%06lu",
-			 m_timestamp.tv_usec);
+		unsigned long usec = m_timestamp.tv_usec;
+		register char *p = micro_s;
+		register unsigned long divisor = 100000;
+		*p++ = '.';
+		for (int i = 0; i < 6; i++)
+		{
+			*p++ = '0' + (usec / divisor % 10);
+			divisor /= 10;
+		}
+		*p = '\0';
 
 		// Add date_time + microseconds
 		if (dateFormat != FMT_ISO8601MS)
 		{
-			snprintf(assetTime, sizeof(assetTime), "%s%s", date_time, micro_s);
+			strcpy(assetTime, date_time);
+			strcat(assetTime, micro_s);
 		}
 		else
 		{
-			string dt(date_time);
-			size_t pos = dt.find_first_of("+");
-			pos--;
-			snprintf(assetTime, sizeof(assetTime), "%s%s%s",
-					dt.substr(0, pos).c_str(),
-				       	micro_s, dt.substr(pos).c_str());
+			register char *p = date_time;
+			while (*p && *p != '+')
+				p++;
+			p--;
+			int n = p - date_time;
+			strncpy(assetTime, date_time, n);
+			assetTime[n] = 0;
+			strcat(assetTime, micro_s);
+			strcat(assetTime, p);
 		}
 		return string(assetTime);
 	}


### PR DESCRIPTION
Signed-off-by: Mark Riddoch <mark@dianomic.com>

Aman, it struck me this morning that given your optimisation for caching the seconds we could; also improve on the sub-second portion by avoiding sprint, that is known to be slow, for both the number conversation and the string concatenation. Also in the FMT_ISO8601MS case doing the conversion to the C++ string is slow.

New verses original times with this code for the abstracted portion
```
original test1: 10000 iterations took 0.002458 seconds
original test2: 10000 iterations took 0.005415 seconds
     new test1: 10000 iterations took 0.001551 seconds
     new test2: 10000 iterations took 0.001933 seconds
```