### PR TITLE
FOGL-7421 Add mechanism for C++ plugins to add audit data and implement

### DIFF
--- a/C/common/audit_logger.cpp
+++ b/C/common/audit_logger.cpp
@@ -1,0 +1,76 @@
+/*
+ * Fledge Singleton Audit Logger interface
+ *
+ * Copyright (c) 2023 Dianomic Systems
+ *
+ * Released under the Apache 2.0 Licence
+ *
+ * Author: Mark Riddoch
+ */
+
+#include <audit_logger.h>
+
+AuditLogger *AuditLogger::m_instance = 0;
+
+using namespace std;
+
+/**
+ * Constructor for an audit logger that is passed
+ * the management client. This must be called early in
+ * a service or task creation before any audit logs are
+ * created.
+ *
+ * @param mgmt	Pointer to the management client
+ */
+AuditLogger::AuditLogger(ManagementClient *mgmt) : m_mgmt(mgmt)
+{
+	m_instance = this;
+}
+
+/**
+ * Destructor for an audit logger
+ */
+AuditLogger::~AuditLogger()
+{
+}
+
+/**
+ * Get the audit logger singleton
+ */
+AuditLogger *AuditLogger::getLogger()
+{
+	if (!m_instance)
+	{
+		Logger::getLogger()->error("An attempt has been made to obtain the audit logger before it has been created.");
+	}
+	return m_instance;
+}
+
+void AuditLogger::auditLog(const string& code,
+			const string& level,
+			const string& data)
+{
+	if (m_instance)
+	{
+		m_instance->audit(code, level, data);
+	}
+	else
+	{
+		Logger::getLogger()->error("An attempt has been made to log an audit event when no audit logger is available");
+		Logger::getLogger()->error("Audit event is: %s, %s, %s", code.c_str(), level.c_str(), data.c_str());
+	}
+}
+
+/**
+ * Log an audit message
+ *
+ * @param code	The audit code
+ * @param level	The audit level
+ * @param data	Optional data associated with the audit entry
+ */
+void AuditLogger::audit(const string& code,
+			const string& level,
+			const string& data)
+{
+	m_mgmt->addAuditEntry(code, level, data);
+}

--- a/C/common/include/audit_logger.h
+++ b/C/common/include/audit_logger.h
@@ -1,0 +1,39 @@
+#ifndef _AUDIT_LOGGER_H
+#define _AUDIT_LOGGER_H
+/*
+ * Fledge Singleton Audit Logger interface
+ *
+ * Copyright (c) 2023 Dianomic Systems
+ *
+ * Released under the Apache 2.0 Licence
+ *
+ * Author: Mark Riddoch
+ */
+
+#include <logger.h>
+#include <management_client.h>
+#include <string>
+
+/**
+ * A singleton class for access to the audit logger within services. The
+ * service must create this with the maagement client before any access to it is used.
+ */
+class AuditLogger {
+	public:
+		AuditLogger(ManagementClient *mgmt);
+		~AuditLogger();
+
+		static AuditLogger	*getLogger();
+		static void		auditLog(const std::string& code,
+						const std::string& level,
+						const std::string& data = "");
+
+		void			audit(const std::string& code,
+						const std::string& level,
+						const std::string& data = "");
+
+	private:
+		static AuditLogger	*m_instance;
+		ManagementClient	*m_mgmt;
+};
+#endif

--- a/C/common/include/process.h
+++ b/C/common/include/process.h
@@ -12,6 +12,7 @@
 
 #include <storage_client.h>
 #include <management_client.h>
+#include <audit_logger.h>
 #include <string.h>
 
 /**
@@ -44,6 +45,7 @@ class FledgeProcess
 		ManagementClient* 	m_client;
 		StorageClient*		m_storage;
 		Logger*			m_logger;
+		AuditLogger*		m_auditLogger;
 };
 
 #endif

--- a/C/common/process.cpp
+++ b/C/common/process.cpp
@@ -144,6 +144,9 @@ FledgeProcess::FledgeProcess(int argc, char** argv) :
 	// Connection to Fledge core microservice
 	m_client = new ManagementClient(m_core_mngt_host, m_core_mngt_port);
 
+	// Create Audit Logger
+	m_auditLogger = new AuditLogger(m_client);
+
 	// Storage layer handle
 	ServiceRecord storageInfo("Fledge Storage");
 

--- a/C/plugins/north/OMF/include/omf.h
+++ b/C/plugins/north/OMF/include/omf.h
@@ -95,12 +95,14 @@ class OMF
 		 * Constructor:
 		 * pass server URL path, OMF_type_id and producerToken.
 		 */
-		OMF(HttpSender& sender,
+		OMF(const std::string& name,
+		    HttpSender& sender,
                     const std::string& path,
 		    const long typeId,
 		    const std::string& producerToken);
 
-		OMF(HttpSender& sender,
+		OMF(const std::string& name,
+		    HttpSender& sender,
 		    const std::string& path,
 		    std::map<std::string, OMFDataTypes>& types,
 		    const std::string& producerToken);
@@ -223,7 +225,7 @@ class OMF
 		bool getAFMapEmptyMetadata() const { return m_AFMapEmptyMetadata; };
 
 		bool getConnected() const { return m_connected; };
-		void setConnected(const bool connectionStatus) { m_connected = connectionStatus; };
+		void setConnected(const bool connectionStatus);
 
 		void setLegacyMode(bool legacy) { m_legacy = legacy; };
 
@@ -499,6 +501,11 @@ private:
 		 * Force the data to be sent using the legacy, complex OMF types
 		 */
 		bool			m_legacy;
+
+		/**
+		 * Service name
+		 */
+		const std::string	m_name;
 };
 
 /**

--- a/C/plugins/north/OMF/plugin.cpp
+++ b/C/plugins/north/OMF/plugin.cpp
@@ -410,15 +410,15 @@ typedef struct
 {
 	HttpSender	*sender;                // HTTPS connection
 	OMF 		*omf;                   // OMF data protocol
-	bool        sendFullStructure;      // It sends the minimum OMF structural messages to load data into Data Archive if disabled
+	bool		sendFullStructure;      // It sends the minimum OMF structural messages to load data into Data Archive if disabled
 	bool		compression;            // whether to compress readings' data
 	string		protocol;               // http / https
 	string		hostAndPort;            // hostname:port for SimpleHttps
-	unsigned int	retrySleepTime;     // Seconds between each retry
+	unsigned int	retrySleepTime;     	// Seconds between each retry
 	unsigned int	maxRetry;	        // Max number of retries in the communication
 	unsigned int	timeout;	        // connect and operation timeout
-	string		path;		            // PI Server application path
-	long		typeId;		            // OMF protocol type-id prefix
+	string		path;		        // PI Server application path
+	long		typeId;		        // OMF protocol type-id prefix
 	string		producerToken;	        // PI Server connector token
 	string		formatNumber;	        // OMF protocol Number format
 	string		formatInteger;	        // OMF protocol Integer format
@@ -458,6 +458,7 @@ typedef struct
 			assetsDataTypes;
 	string		omfversion;
 	bool		legacy;
+	string		name;
 } CONNECTOR_INFO;
 
 unsigned long calcTypeShort                (const string& dataTypes);
@@ -520,6 +521,7 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* configData)
 	 */
 	// Allocate connector struct
 	CONNECTOR_INFO *connInfo = new CONNECTOR_INFO;
+	connInfo->name = configData->getName();
 
 	// PIServerEndpoint handling
 	string PIServerEndpoint = configData->getValue("PIServerEndpoint");
@@ -961,7 +963,8 @@ uint32_t plugin_send(const PLUGIN_HANDLE handle,
 	}
 
 	// Allocate the OMF class that implements the PI Server data protocol
-	connInfo->omf = new OMF(*connInfo->sender,
+	connInfo->omf = new OMF(connInfo->name,
+			        *connInfo->sender,
 				connInfo->path,
 				connInfo->assetsDataTypes,
 				connInfo->producerToken);

--- a/C/services/north/include/north_service.h
+++ b/C/services/north/include/north_service.h
@@ -18,6 +18,7 @@
 #include <filter_plugin.h>
 #include <mutex>
 #include <condition_variable>
+#include <audit_logger.h>
 
 #define SERVICE_NAME  "Fledge North"
 
@@ -78,5 +79,6 @@ class NorthService : public ServiceAuthHandler {
 		bool				m_allowControl;
 		bool				m_dryRun;
 		bool				m_requestRestart;
+		AuditLogger			*m_auditLogger;
 };
 #endif

--- a/C/services/north/north.cpp
+++ b/C/services/north/north.cpp
@@ -35,6 +35,7 @@
 #include <syslog.h>
 #include <stdarg.h>
 #include <string_utils.h>
+#include <audit_logger.h>
 
 #define SERVICE_TYPE "Northbound"
 
@@ -327,6 +328,8 @@ void NorthService::start(string& coreAddress, unsigned short corePort)
 				managementListener,	// Management port
 				m_token);		// Token);
 		m_mgtClient = new ManagementClient(coreAddress, corePort);
+
+		m_auditLogger = new AuditLogger(m_mgtClient);
 
 		// Create an empty North category if one doesn't exist
 		DefaultConfigCategory northConfig(string("North"), string("{}"));

--- a/C/services/south/include/south_service.h
+++ b/C/services/south/include/south_service.h
@@ -18,6 +18,7 @@
 #include <filter_plugin.h>
 #include <plugin_data.h>
 #include <storage_asset_tracking.h>
+#include <audit_logger.h>
 
 #define MAX_SLEEP	5		// Maximum number of seconds the service will sleep during a poll cycle
 
@@ -119,6 +120,7 @@ class SouthService : public ServiceAuthHandler {
 		std::condition_variable		m_pollCV;
 		std::mutex			m_pollMutex;
 		bool				m_doPoll;
+		AuditLogger			*m_auditLogger;
 
 };
 #endif

--- a/C/services/south/south.cpp
+++ b/C/services/south/south.cpp
@@ -286,6 +286,9 @@ void SouthService::start(string& coreAddress, unsigned short corePort)
 		// Allocate and save ManagementClient object
 		m_mgtClient = new ManagementClient(coreAddress, corePort);
 
+		// Create the audit logger instance
+		m_auditLogger = new AuditLogger(m_mgtClient);
+
 		// Create an empty South category if one doesn't exist
 		DefaultConfigCategory southConfig(string("South"), string("{}"));
 		southConfig.setDescription("South");

--- a/tests/unit/C/plugins/common/test_omf_translation.cpp
+++ b/tests/unit/C/plugins/common/test_omf_translation.cpp
@@ -318,7 +318,7 @@ TEST(OMF_transation, OneReading)
 TEST(OMF_transation, SuperSet)
 {
 	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
-	OMF omf(sender, "/", 1, "ABC");
+	OMF omf("test", sender, "/", 1, "ABC");
 	// Build a ReadingSet from JSON
 	ReadingSet readingSet(readings_with_different_datapoints);
 	vector<Reading *>readings = readingSet.getAllReadings();
@@ -444,7 +444,7 @@ TEST(OMF_AfHierarchy, HandleAFMapNamesGood)
 
 	// Dummy initializations
 	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
-	OMF omf(sender, "/", 1, "ABC");
+	OMF omf("test", sender, "/", 1, "ABC");
 
 	omf.setAFMap(af_hierarchy_test01);
 
@@ -474,7 +474,7 @@ TEST(OMF_AfHierarchy, HandleAFMapEmpty)
 
 	// Dummy initializations
 	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
-	OMF omf(sender, "/", 1, "ABC");
+	OMF omf("test", sender, "/", 1, "ABC");
 
 	// Test
 	omf.setAFMap(af_hierarchy_test02);
@@ -494,7 +494,7 @@ TEST(OMF_AfHierarchy, HandleAFMapNamesBad)
 
 	// Dummy initializations
 	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
-	OMF omf(sender, "/", 1, "ABC");
+	OMF omf("test", sender, "/", 1, "ABC");
 
 	omf.setAFMap(af_hierarchy_test01);
 	MetadataRulesExist = omf.getMetadataRulesExist();
@@ -510,7 +510,7 @@ TEST(PiServer_NamingRules, NamingRulesCheck)
 
 	// Dummy initializations
 	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
-	OMF omf(sender, "/", 1, "ABC");
+	OMF omf("test", sender, "/", 1, "ABC");
 
 	ASSERT_EQ(omf.ApplyPIServerNamingRulesInvalidChars("asset_1", &changed), "asset_1");
 	ASSERT_EQ(changed, false);
@@ -547,7 +547,7 @@ TEST(PiServer_NamingRules, Suffix)
 	string assetName;
 	// Dummy initializations
 	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
-	OMF omf(sender, "/", 1, "ABC");
+	OMF omf("test", sender, "/", 1, "ABC");
 
 	assetName = "asset_1";
 
@@ -578,7 +578,7 @@ TEST(PiServer_NamingRules, Prefix)
 
 	// Dummy initializations
 	SimpleHttps sender("0.0.0.0:0", 10, 10, 10, 1);
-	OMF omf(sender, "/", 1, "ABC");
+	OMF omf("test", sender, "/", 1, "ABC");
 
 	asset="asset_1";
 


### PR DESCRIPTION
example in OMF north plugin

Improvements to OMF are required to be able to report all variants of the audit log, this is merely an example of the mechanism, currently.

Signed-off-by: Mark Riddoch <mark@dianomic.com>