### PR TITLE
FOGL-7428A: Clean up error logs

### DIFF
--- a/C/plugins/north/OMF/linkdata.cpp
+++ b/C/plugins/north/OMF/linkdata.cpp
@@ -28,6 +28,30 @@
 using namespace std;
 
 /**
+ * Create a comma-separated string of all Datapoint names in a Reading
+ *
+ * @param reading	Reading
+ * @return			Datapoint names in the Reading
+ */
+static std::string DataPointNamesAsString(const Reading& reading)
+{
+	std::string dataPointNames;
+
+	for (Datapoint *datapoint : reading.getReadingData())
+	{
+		dataPointNames.append(datapoint->getName());
+		dataPointNames.append(",");
+	}
+
+	if (dataPointNames.size() > 0)
+	{
+		dataPointNames.resize(dataPointNames.size() - 1);	// remove trailing comma
+	}
+
+	return dataPointNames;
+}
+
+/**
  * OMFLinkedData constructor, generates the OMF message containing the data
  *
  * @param reading           Reading for which the OMF message must be generated
@@ -70,7 +94,7 @@ string OMFLinkedData::processReading(const Reading& reading, const string&  AFHi
 	const vector<Datapoint*> data = reading.getReadingData();
 	vector<string> skippedDatapoints;
 
-	Logger::getLogger()->info("Processing %s with new OMF method", assetName.c_str());
+	Logger::getLogger()->debug("Processing %s (%s) using Linked Types", assetName.c_str(), DataPointNamesAsString(reading).c_str());
 
 	bool needDelim = false;
 	if (m_assetSent->find(assetName) == m_assetSent->end())
@@ -209,7 +233,7 @@ string OMFLinkedData::processReading(const Reading& reading, const string&  AFHi
 		string msg = "The asset " + assetName + " had a number of datapoints, " + points + " that are not supported by OMF and have been omitted";
 		OMF::reportAsset(assetName, "warn", msg);
 	}
-	Logger::getLogger()->debug("Created data messasges %s", outData.c_str());
+	Logger::getLogger()->debug("Created data messages %s", outData.c_str());
 	return outData;
 }
 

--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -1459,7 +1459,7 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 	 */
 
 	// Create header for Readings data
-	vector<pair<string, string>> readingData = OMF::createMessageHeader("Data");
+	vector<pair<string, string>> readingData = OMF::createMessageHeader("Data", "update");
 	if (compression)
 		readingData.push_back(pair<string, string>("compression", "gzip"));
 
@@ -4766,7 +4766,7 @@ bool OMF::sendBaseTypes()
 		m_connected = false;
 		return false;
 	}
-	Logger::getLogger()->info("Base types successully sent");
+	Logger::getLogger()->debug("Base types successfully sent");
 	return true;
 }
 


### PR DESCRIPTION
Moved setting of OMF Version to _plugin_start_; this does not need to be repeated in _plugin_send_. Cleaned up error messages. Recategorized many _Info_ messages as _Debug_. Changed _action_ code for Linked Type Data messages from _create_ to _update_ which avoids creating duplicate PI data values if sending of data is repeated. I did not edit any of the REST error messages labelled "FIXME;" I think they are reasonable as-is.