### PR TITLE
FOGL-7507: add exception handler to configuration change

### DIFF
--- a/C/services/common/management_api.cpp
+++ b/C/services/common/management_api.cpp
@@ -195,23 +195,23 @@ void ManagementApi::configChange(shared_ptr<HttpServer::Response> response, shar
 {
 ostringstream convert;
 string responsePayload;
-string	category, items, payload;
+string payload;
 
 	try
-	{
+	{	
 		payload = request->content.string();
-		ConfigCategoryChange	conf(payload);
+		ConfigCategoryChange conf(payload);
 		ConfigHandler	*handler = ConfigHandler::getInstance(NULL);
 		handler->configChange(conf.getName(), conf.itemsToJSON(true));
-		convert << "{ \"message\" ; \"Config change accepted\" }";
-	}
-	catch(const ConfigMalformed& e)
-	{
-		convert << "{ \"exception\" : \"ConfigMalformed\",  \"message\" : \"" << e.what() << "\"}";
+		convert << "{ \"message\" : \"Config change accepted\" }";
 	}
 	catch(const std::exception& e)
 	{
-		convert << "{ \"exception\" : \"Any\",  \"message\" : \"" << e.what() << "\"}";
+		convert << "{ \"exception\" : \"" << e.what() << "\" }";
+	}
+	catch(...)
+	{
+		convert << "{ \"exception\" : \"generic\" }";
 	}
 	
 	responsePayload = convert.str();

--- a/C/services/common/management_api.cpp
+++ b/C/services/common/management_api.cpp
@@ -197,11 +197,23 @@ ostringstream convert;
 string responsePayload;
 string	category, items, payload;
 
-	payload = request->content.string();
-	ConfigCategoryChange	conf(payload);
-	ConfigHandler	*handler = ConfigHandler::getInstance(NULL);
-	handler->configChange(conf.getName(), conf.itemsToJSON(true));
-	convert << "{ \"message\" ; \"Config change accepted\" }";
+	try
+	{
+		payload = request->content.string();
+		ConfigCategoryChange	conf(payload);
+		ConfigHandler	*handler = ConfigHandler::getInstance(NULL);
+		handler->configChange(conf.getName(), conf.itemsToJSON(true));
+		convert << "{ \"message\" ; \"Config change accepted\" }";
+	}
+	catch(const ConfigMalformed& e)
+	{
+		convert << "{ \"exception\" : \"ConfigMalformed\",  \"message\" : \"" << e.what() << "\"}";
+	}
+	catch(const std::exception& e)
+	{
+		convert << "{ \"exception\" : \"Any\",  \"message\" : \"" << e.what() << "\"}";
+	}
+	
 	responsePayload = convert.str();
 	respond(response, responsePayload);
 }


### PR DESCRIPTION
Errors in JSON configuration files have been causing crashes in the north service. This can occur if the JSON is malformed but also if any subsequent processing fails. This has been addressed by adding an exception handler to the configuration change method.