### PR TITLE
FOGL-7567: Modified to remove delay in asset creation

### DIFF
--- a/C/plugins/storage/sqlite/common/include/readings_catalogue.h
+++ b/C/plugins/storage/sqlite/common/include/readings_catalogue.h
@@ -131,11 +131,10 @@ public:
 
 	void          preallocateReadingsTables(int dbId);
 	bool          loadAssetReadingCatalogue();
-	bool          loadEmptyAssetReadingCatalogue();
+	bool          loadEmptyAssetReadingCatalogue(bool clean = true);
 
 	bool          latestDbUpdate(sqlite3 *dbHandle, int newDbId);
 	void          preallocateNewDbsRange(int dbIdStart, int dbIdEnd);
-	tyReadingReference getEmptyReadingTableReference(std::string& asset);
 	tyReadingReference getReadingReference(Connection *connection, const char *asset_code);
 	bool          attachDbsToAllConnections();
 	std::string   sqlConstructMultiDb(std::string &sqlCmdBase, std::vector<std::string>  &assetCodes, bool considerExclusion=false);
@@ -177,7 +176,7 @@ private:
 
 	} tyReadingsAvailable;
 
-	ReadingsCatalogue(){};
+	ReadingsCatalogue() { };
 
 	bool          createNewDB(sqlite3 *dbHandle, int newDbId,  int startId, NEW_DB_OPERATION attachAllDb);
 	int           getUsedTablesDbId(int dbId);
@@ -228,6 +227,7 @@ private:
 		// asset_code  - reading Table Id, Db Id
 		// {"",         ,{1               ,1 }}
 	};
+	std::mutex m_emptyReadingTableMutex;
 public:
 	TransactionBoundary				m_tx;
 

--- a/tests/system/python/packages/test_multiple_assets.py
+++ b/tests/system/python/packages/test_multiple_assets.py
@@ -326,7 +326,7 @@ class TestMultiAssets:
                            total_benchmark_services * 2, num_assets_per_service)
     
     def test_multiple_assets_with_reconfig(self, reset_fledge, start_north, read_data_from_pi_web_api, 
-                                           skip_verify_north_interface, fledge_url, num_assets, wait_fix, 
+                                           skip_verify_north_interface, fledge_url, num_assets,
                                            wait_time, retries, pi_host, pi_port, pi_admin, pi_passwd, pi_db):
         """ Test addition of multiple assets with reconfiguration of south service.
             reset_fledge: Fixture to reset fledge
@@ -367,11 +367,7 @@ class TestMultiAssets:
 
         verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)
         
-        # FIX ME: FOGL-7567, Due to increase in timing of asset creation, time spent in reconfig asset also increases.
-        # Remove the WAIT_FIX, Once FOGL-7567 is resolved.
-        WAIT_FIX =  wait_fix + num_assets//100
-        
-        verify_asset(fledge_url, total_assets, WAIT_FIX, wait_time)
+        verify_asset(fledge_url, total_assets,  num_assets//100, wait_time)
         verify_asset_tracking_details(fledge_url, total_assets, total_benchmark_services, num_assets_per_service)
 
         old_ping_result = verify_ping(fledge_url, skip_verify_north_interface, wait_time, retries)


### PR DESCRIPTION
A separate non-blocking thread is used to schedule to check for empty table to remove delay in asset creation.
Purge schedule and purge option from developer tab also uses same class method which is being in thread. So working fine with manual purge from developer tab and purge schedule.
