### PR TITLE
FOGL-7579 package name handling in Plugins PUT & DELETE API

### DIFF
--- a/python/fledge/services/core/api/plugins/remove.py
+++ b/python/fledge/services/core/api/plugins/remove.py
@@ -31,9 +31,9 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 _help = """
-    -------------------------------------------------------------------------------
-    | DELETE             | /fledge/plugins/{plugin-type}/{plugin-name}            |
-    -------------------------------------------------------------------------------
+    --------------------------------------------------------------------
+    | DELETE             | /fledge/plugins/{package_name}              |
+    --------------------------------------------------------------------
 """
 
 _logger = logger.setup(__name__, level=logging.INFO)
@@ -43,7 +43,7 @@ PYTHON_PLUGIN_PATH = _FLEDGE_ROOT+'/python/fledge/plugins/'
 C_PLUGINS_PATH = _FLEDGE_ROOT+'/plugins/'
 
 
-# only work with above version of core 2.1.0 version
+# only work with core 2.1.0 onwards version
 async def remove_package(request: web.Request) -> web.Response:
     """Remove installed Package
 
@@ -59,7 +59,7 @@ async def remove_package(request: web.Request) -> web.Response:
     try:
         package_name = request.match_info.get('package_name', "fledge-")
         package_name = package_name.replace(" ", "")
-        response = {}
+        final_response = {}
         if not package_name.startswith("fledge-"):
             raise ValueError("Package name should start with 'fledge-' prefix.")
         plugin_type = package_name.split("-", 2)[1]
@@ -132,7 +132,7 @@ async def remove_package(request: web.Request) -> web.Response:
                 p.start()
                 msg = "{} plugin remove started.".format(plugin_name)
                 status_link = "fledge/package/{}/status?id={}".format(action, uid)
-                response = {"message": msg, "id": uid, "statusLink": status_link}
+                final_response = {"message": msg, "id": uid, "statusLink": status_link}
         else:
             raise StorageServerError
     except (ValueError, RuntimeError) as err:
@@ -149,7 +149,7 @@ async def remove_package(request: web.Request) -> web.Response:
         _logger.error("Failed to delete {} package. {}".format(package_name, msg))
         raise web.HTTPInternalServerError(reason=msg, body=json.dumps({'message': msg}))
     else:
-        return web.json_response(response)
+        return web.json_response(final_response)
 
 
 def _uninstall(pkg_name: str, version: str, uid: uuid, storage: connect) -> tuple:

--- a/python/fledge/services/core/api/plugins/update.py
+++ b/python/fledge/services/core/api/plugins/update.py
@@ -36,6 +36,147 @@ _help = """
 _logger = logger.setup(__name__, level=logging.INFO)
 
 
+async def update_package(request: web.Request) -> web.Response:
+    """ Update Package
+
+    package_name: package name of plugin
+
+    Example:
+        curl -sX PUT http://localhost:8081/fledge/plugins/fledge-south-modbus
+        curl -sX PUT http://localhost:8081/fledge/plugins/fledge-north-http-north
+        curl -sX PUT http://localhost:8081/fledge/plugins/fledge-filter-scale
+        curl -sX PUT http://localhost:8081/fledge/plugins/fledge-notify-alexa
+        curl -sX PUT http://localhost:8081/fledge/plugins/fledge-rule-watchdog
+    """
+
+    try:
+        valid_plugin_types = ['north', 'south', 'filter', 'notify', 'rule']
+        package_name = request.match_info.get('package_name', "fledge-")
+        package_name = package_name.replace(" ", "")
+        final_response = {}
+        if not package_name.startswith("fledge-"):
+            raise ValueError("Package name should start with 'fledge-' prefix.")
+        plugin_type = package_name.split("-", 2)[1]
+        if not plugin_type:
+            raise ValueError('Invalid Package name. Check and verify the package name in plugins installed.')
+        if plugin_type not in valid_plugin_types:
+            raise ValueError("Invalid plugin type. Please provide valid type: {}".format(valid_plugin_types))
+        installed_plugins = PluginDiscovery.get_plugins_installed(plugin_type, False)
+        plugin_info = [_plugin["name"] for _plugin in installed_plugins if _plugin["packageName"] == package_name]
+        if not plugin_info:
+            raise KeyError("{} package not found. Either package is not installed or missing in plugins installed."
+                           "".format(package_name))
+        plugin_name = plugin_info[0]
+        # Check Pre-conditions from Packages table
+        # if status is -1 (Already in progress) then return as rejected request
+        action = 'update'
+        storage_client = connect.get_storage_async()
+        select_payload = PayloadBuilder().SELECT("status").WHERE(['action', '=', action]).AND_WHERE(
+            ['name', '=', package_name]).payload()
+        result = await storage_client.query_tbl_with_payload('packages', select_payload)
+        response = result['rows']
+        if response:
+            exit_code = response[0]['status']
+            if exit_code == -1:
+                msg = "{} package {} already in progress.".format(package_name, action)
+                return web.HTTPTooManyRequests(reason=msg, body=json.dumps({"message": msg}))
+            # Remove old entry from table for other cases
+            delete_payload = PayloadBuilder().WHERE(['action', '=', action]).AND_WHERE(
+                ['name', '=', package_name]).payload()
+            await storage_client.delete_from_tbl("packages", delete_payload)
+
+        schedules = []
+        notifications = []
+        if plugin_type in ['notify', 'rule']:
+            # Check Notification service is enabled or not
+            payload = PayloadBuilder().SELECT("id", "enabled", "schedule_name").WHERE(['process_name', '=',
+                                                                                       'notification_c']).payload()
+            result = await storage_client.query_tbl_with_payload('schedules', payload)
+            sch_info = result['rows']
+            if sch_info and sch_info[0]['enabled'] == 't':
+                # Find notification instances which are used by requested plugin name
+                # If its config item 'enable' is true then update to false
+                config_mgr = ConfigurationManager(storage_client)
+                all_notifications = await config_mgr._read_all_child_category_names("Notifications")
+                for notification in all_notifications:
+                    notification_config = await config_mgr._read_category_val(notification['child'])
+                    notification_name = notification_config['name']['value']
+                    channel = notification_config['channel']['value']
+                    rule = notification_config['rule']['value']
+                    is_enabled = True if notification_config['enable']['value'] == 'true' else False
+                    if (channel == plugin_name and is_enabled) or (rule == plugin_name and is_enabled):
+                        _logger.warning(
+                            "Disabling {} notification instance, as {} {} plugin is being updated...".format(
+                                notification_name, plugin_name, plugin_type))
+                        await config_mgr.set_category_item_value_entry(notification_name, "enable", "false")
+                        notifications.append(notification_name)
+        else:
+            # FIXME: if any south/north service or task doesnot have tracked by Fledge;
+            #  then we need to handle the case to disable the service or task if enabled
+            # Tracked plugins from asset tracker
+            tracked_plugins = await _get_plugin_and_sch_name_from_asset_tracker(plugin_type)
+            filters_used_by = []
+            if plugin_type == 'filter':
+                # In case of filter, for asset_tracker table we are inserting filter category_name in plugin column
+                # instead of filter plugin name by Design
+                # Hence below query is required to get actual plugin name from filters table
+                storage_client = connect.get_storage_async()
+                payload = PayloadBuilder().SELECT("name").WHERE(['plugin', '=', plugin_name]).payload()
+                result = await storage_client.query_tbl_with_payload('filters', payload)
+                filters_used_by = [r['name'] for r in result['rows']]
+            for p in tracked_plugins:
+                if (plugin_name == p['plugin'] and not plugin_type == 'filter') or (
+                        p['plugin'] in filters_used_by and plugin_type == 'filter'):
+                    sch_info = await _get_sch_id_and_enabled_by_name(p['service'])
+                    if sch_info[0]['enabled'] == 't':
+                        status, reason = await server.Server.scheduler.disable_schedule(uuid.UUID(sch_info[0]['id']))
+                        if status:
+                            _logger.warning("Disabling {} {} instance, as {} plugin is being updated...".format(
+                                p['service'], plugin_type, plugin_name))
+                            schedules.append(sch_info[0]['id'])
+        # Insert record into Packages table
+        insert_payload = PayloadBuilder().INSERT(id=str(uuid.uuid4()), name=package_name, action=action, status=-1,
+                                                 log_file_uri="").payload()
+        result = await storage_client.insert_into_tbl("packages", insert_payload)
+        response = result['response']
+        if response:
+            select_payload = PayloadBuilder().SELECT("id").WHERE(['action', '=', action]).AND_WHERE(
+                ['name', '=', package_name]).payload()
+            result = await storage_client.query_tbl_with_payload('packages', select_payload)
+            response = result['rows']
+            if response:
+                pn = "{}-{}".format(action, package_name)
+                uid = response[0]['id']
+                p = multiprocessing.Process(name=pn,
+                                            target=do_update,
+                                            args=(server.Server.is_rest_server_http_enabled,
+                                                  server.Server._host, server.Server.core_management_port,
+                                                  storage_client, plugin_type, plugin_name, package_name, uid,
+                                                  schedules, notifications))
+                p.daemon = True
+                p.start()
+                msg = "{} {} started.".format(package_name, action)
+                status_link = "fledge/package/{}/status?id={}".format(action, uid)
+                final_response = {"message": msg, "id": uid, "statusLink": status_link}
+        else:
+            raise StorageServerError
+    except KeyError as err:
+        msg = str(err)
+        raise web.HTTPNotFound(reason=msg, body=json.dumps({'message': msg}))
+    except ValueError as err:
+        msg = str(err)
+        raise web.HTTPBadRequest(reason=msg, body=json.dumps({'message': msg}))
+    except StorageServerError as e:
+        msg = e.error
+        raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": "Storage error: {}".format(msg)}))
+    except Exception as ex:
+        msg = str(ex)
+        _logger.error("Failed to update {} package. {}".format(package_name, msg))
+        raise web.HTTPInternalServerError(reason=msg, body=json.dumps({'message': msg}))
+    else:
+        return web.json_response(final_response)
+
+
 async def update_plugin(request: web.Request) -> web.Response:
     """ update plugin
 
@@ -55,15 +196,8 @@ async def update_plugin(request: web.Request) -> web.Response:
         # only OMF is an inbuilt plugin
         if name.lower() == 'omf':
             raise ValueError("Cannot update an inbuilt {} plugin.".format(name.upper()))
-        if _type == 'notify':
-            installed_dir_name = 'notificationDelivery'
-        elif _type == 'rule':
-            installed_dir_name = 'notificationRule'
-        else:
-            installed_dir_name = _type
-
         # Check requested plugin name is installed or not
-        installed_plugins = PluginDiscovery.get_plugins_installed(installed_dir_name, False)
+        installed_plugins = PluginDiscovery.get_plugins_installed(_type, False)
         plugin_info = [(_plugin["name"], _plugin["packageName"]) for _plugin in installed_plugins]
         package_name = "fledge-{}-{}".format(_type, name.lower().replace('_', '-'))
         plugin_found = False
@@ -159,7 +293,7 @@ async def update_plugin(request: web.Request) -> web.Response:
                                             target=do_update,
                                             args=(server.Server.is_rest_server_http_enabled,
                                                   server.Server._host, server.Server.core_management_port,
-                                                  storage_client, installed_dir_name, _type, name, package_name, uid,
+                                                  storage_client, _type, name, package_name, uid,
                                                   schedules, notifications))
                 p.daemon = True
                 p.start()
@@ -241,7 +375,7 @@ def _update_repo_sources_and_plugin(pkg_name: str) -> tuple:
     return ret_code, link
 
 
-def do_update(http_enabled: bool, host: str, port: int, storage: connect, dir_name: str, _type: str, plugin_name: str,
+def do_update(http_enabled: bool, host: str, port: int, storage: connect, _type: str, plugin_name: str,
               pkg_name: str, uid: str, schedules: list, notifications: list) -> None:
     _logger.info("{} package update started...".format(pkg_name))
     protocol = "HTTP" if http_enabled else "HTTPS"
@@ -255,7 +389,7 @@ def do_update(http_enabled: bool, host: str, port: int, storage: connect, dir_na
     if code == 0:
         # Audit info
         audit = AuditLogger(storage)
-        installed_plugins = PluginDiscovery.get_plugins_installed(dir_name, False)
+        installed_plugins = PluginDiscovery.get_plugins_installed(_type, False)
         version = [p["version"] for p in installed_plugins if p['name'] == plugin_name]
         audit_detail = {'packageName': pkg_name}
         if version:

--- a/python/fledge/services/core/api/plugins/update.py
+++ b/python/fledge/services/core/api/plugins/update.py
@@ -29,13 +29,14 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 _help = """
-    -------------------------------------------------------------------------------
-    | PUT             | /fledge/plugin/{type}/{name}/update                       |
-    -------------------------------------------------------------------------------
+    ------------------------------------------------------------------------
+    | PUT             | /fledge/plugins/{package_name}                     |
+    ------------------------------------------------------------------------
 """
 _logger = logger.setup(__name__, level=logging.INFO)
 
 
+# only work with core 2.1.0 onwards version
 async def update_package(request: web.Request) -> web.Response:
     """ Update Package
 
@@ -177,6 +178,7 @@ async def update_package(request: web.Request) -> web.Response:
         return web.json_response(final_response)
 
 
+# only work with lesser or equal to version of core 2.1.0 version
 async def update_plugin(request: web.Request) -> web.Response:
     """ update plugin
 

--- a/python/fledge/services/core/routes.py
+++ b/python/fledge/services/core/routes.py
@@ -182,6 +182,7 @@ def setup(app):
         app.router.add_route('PUT', '/fledge/plugins/{type}/{name}/update', plugins_update.update_plugin)
         app.router.add_route('DELETE', '/fledge/plugins/{type}/{name}', plugins_remove.remove_plugin)
     else:
+        # routes available 2.1.0 onwards
         app.router.add_route('PUT', '/fledge/plugins/{package_name}', plugins_update.update_package)
         app.router.add_route('DELETE', '/fledge/plugins/{package_name}', plugins_remove.remove_package)
     # plugin data

--- a/python/fledge/services/core/routes.py
+++ b/python/fledge/services/core/routes.py
@@ -5,38 +5,21 @@
 # FLEDGE_END
 
 from fledge.services.core import proxy
-
-from fledge.services.core.api import auth
+from fledge.services.core.api import asset_tracker, auth, backup_restore, browser, certificate_store, filters, health, notification, north, package_log, python_packages, south, support, service, task, update
 from fledge.services.core.api import audit as api_audit
-from fledge.services.core.api import browser
 from fledge.services.core.api import common as api_common
 from fledge.services.core.api import configuration as api_configuration
 from fledge.services.core.api import scheduler as api_scheduler
 from fledge.services.core.api import statistics as api_statistics
-from fledge.services.core.api import backup_restore
-from fledge.services.core.api import update
-from fledge.services.core.api import service
-from fledge.services.core.api import certificate_store
-from fledge.services.core.api import support
-from fledge.services.core.api import task
-from fledge.services.core.api import asset_tracker
-from fledge.services.core.api import south
-from fledge.services.core.api import north
-from fledge.services.core.api import filters
-from fledge.services.core.api import notification
 from fledge.services.core.api.plugins import data as plugin_data
 from fledge.services.core.api.plugins import install as plugins_install, discovery as plugins_discovery
 from fledge.services.core.api.plugins import update as plugins_update
 from fledge.services.core.api.plugins import remove as plugins_remove
 from fledge.services.core.api.snapshot import plugins as snapshot_plugins
 from fledge.services.core.api.snapshot import table as snapshot_table
-from fledge.services.core.api import package_log
 from fledge.services.core.api.repos import configure as configure_repo
 from fledge.services.core.api.control_service import script_management
 from fledge.services.core.api.control_service import acl_management
-from fledge.services.core.api import python_packages
-from fledge.services.core.api import health
-
 
 
 __author__ = "Ashish Jabble, Praveen Garg, Massimiliano Pinto, Amarendra K Sinha"
@@ -193,9 +176,14 @@ def setup(app):
     app.router.add_route('GET', '/fledge/plugins/installed', plugins_discovery.get_plugins_installed)
     app.router.add_route('GET', '/fledge/plugins/available', plugins_discovery.get_plugins_available)
     app.router.add_route('POST', '/fledge/plugins', plugins_install.add_plugin)
-    app.router.add_route('PUT', '/fledge/plugins/{type}/{name}/update', plugins_update.update_plugin)
-    app.router.add_route('DELETE', '/fledge/plugins/{type}/{name}', plugins_remove.remove_plugin)
-
+    if api_common.get_version() <= "2.1.0":
+        """Note: This is only for to maintain the backward compatibility. (having core version<=2.1.0)
+         Plugin Update & Delete routes on the basis of type & installed name"""
+        app.router.add_route('PUT', '/fledge/plugins/{type}/{name}/update', plugins_update.update_plugin)
+        app.router.add_route('DELETE', '/fledge/plugins/{type}/{name}', plugins_remove.remove_plugin)
+    else:
+        #app.router.add_route('PUT', '/fledge/plugins/{package_name}', plugins_update.update_package)
+        app.router.add_route('DELETE', '/fledge/plugins/{package_name}', plugins_remove.remove_package)
     # plugin data
     app.router.add_route('GET', '/fledge/service/{service_name}/persist', plugin_data.get_persist_plugins)
     app.router.add_route('GET', '/fledge/service/{service_name}/plugin/{plugin_name}/data', plugin_data.get)

--- a/python/fledge/services/core/routes.py
+++ b/python/fledge/services/core/routes.py
@@ -182,7 +182,7 @@ def setup(app):
         app.router.add_route('PUT', '/fledge/plugins/{type}/{name}/update', plugins_update.update_plugin)
         app.router.add_route('DELETE', '/fledge/plugins/{type}/{name}', plugins_remove.remove_plugin)
     else:
-        #app.router.add_route('PUT', '/fledge/plugins/{package_name}', plugins_update.update_package)
+        app.router.add_route('PUT', '/fledge/plugins/{package_name}', plugins_update.update_package)
         app.router.add_route('DELETE', '/fledge/plugins/{package_name}', plugins_remove.remove_package)
     # plugin data
     app.router.add_route('GET', '/fledge/service/{service_name}/persist', plugin_data.get_persist_plugins)

--- a/tests/unit/python/fledge/services/core/api/plugins/test_remove.py
+++ b/tests/unit/python/fledge/services/core/api/plugins/test_remove.py
@@ -12,12 +12,12 @@ import asyncio
 
 from aiohttp import web
 
-from fledge.services.core import routes
-from fledge.services.core import connect
+from fledge.common.plugin_discovery import PluginDiscovery
+from fledge.common.storage_client.storage_client import StorageClientAsync
+from fledge.services.core import connect, routes
+from fledge.services.core.api import common
 from fledge.services.core.api.plugins import remove as plugins_remove
 from fledge.services.core.api.plugins.exceptions import *
-from fledge.common.storage_client.storage_client import StorageClientAsync
-from fledge.common.plugin_discovery import PluginDiscovery
 
 
 __author__ = "Ashish Jabble"
@@ -36,28 +36,25 @@ class TestPluginRemove:
         routes.setup(app)
         return loop.run_until_complete(test_client(app))
 
-    @pytest.mark.parametrize("_type", [
-        "blah",
-        1,
-        "notificationDelivery"
-        "notificationRule"
-    ])
+    RUN_TESTS_BEFORE_210_VERSION = False if common.get_version() <= "2.1.0" else True
+
+    @pytest.mark.skipif(RUN_TESTS_BEFORE_210_VERSION, reason="requires lesser or equal to core 2.1.0 version")
+    @pytest.mark.parametrize("_type", ["blah", 1, "notificationDelivery", "notificationRule"])
     async def test_bad_type_plugin(self, client, _type):
         resp = await client.delete('/fledge/plugins/{}/name'.format(_type), data=None)
         assert 400 == resp.status
         assert "Invalid plugin type. Please provide valid type: ['north', 'south', 'filter', 'notify', 'rule']" == \
                resp.reason
 
+    @pytest.mark.skipif(RUN_TESTS_BEFORE_210_VERSION, reason="requires lesser or equal to core 2.1.0 version")
     @pytest.mark.parametrize("name", ["OMF", "omf", "Omf"])
     async def test_bad_update_of_inbuilt_plugin(self, client, name):
         resp = await client.delete('/fledge/plugins/north/{}'.format(name), data=None)
         assert 400 == resp.status
         assert "Cannot delete an inbuilt OMF plugin." == resp.reason
 
-    @pytest.mark.parametrize("name", [
-        "http-south",
-        "random"
-    ])
+    @pytest.mark.skipif(RUN_TESTS_BEFORE_210_VERSION, reason="requires lesser or equal to core 2.1.0 version")
+    @pytest.mark.parametrize("name", ["http-south", "random"])
     async def test_bad_name_plugin(self, client, name):
         plugin_installed = [{"name": "sinusoid", "type": "south", "description": "Sinusoid Poll Plugin",
                              "version": "1.8.1", "installedDirectory": "south/sinusoid",
@@ -80,6 +77,7 @@ class TestPluginRemove:
             assert {'message': expected_msg} == response
         plugin_installed_patch.assert_called_once_with('south', False)
 
+    @pytest.mark.skipif(RUN_TESTS_BEFORE_210_VERSION, reason="requires lesser or equal to core 2.1.0 version")
     async def test_plugin_in_use(self, client):
         async def async_mock(return_value):
             return return_value
@@ -117,6 +115,7 @@ class TestPluginRemove:
             plugin_usage_patch.assert_called_once_with(_type, name)
         plugin_installed_patch.assert_called_once_with(_type, False)
 
+    @pytest.mark.skipif(RUN_TESTS_BEFORE_210_VERSION, reason="requires lesser or equal to core 2.1.0 version")
     async def test_notify_plugin_in_use(self, client):
         async def async_mock(return_value):
             return return_value
@@ -156,6 +155,7 @@ class TestPluginRemove:
             plugin_usage_patch.assert_called_once_with(plugin_installed_dirname)
         plugin_installed_patch.assert_called_once_with(plugin_type_installed_dir, False)
 
+    @pytest.mark.skipif(RUN_TESTS_BEFORE_210_VERSION, reason="requires lesser or equal to core 2.1.0 version")
     async def test_package_already_in_progress(self, client):
         async def async_mock(return_value):
             return return_value
@@ -213,6 +213,7 @@ class TestPluginRemove:
             plugin_usage_patch.assert_called_once_with(_type, name)
         plugin_installed_patch.assert_called_once_with(_type, False)
 
+    @pytest.mark.skipif(RUN_TESTS_BEFORE_210_VERSION, reason="requires lesser or equal to core 2.1.0 version")
     async def test_package_when_not_in_use(self, client):
         
         async def async_mock(return_value):

--- a/tests/unit/python/fledge/services/core/api/plugins/test_update.py
+++ b/tests/unit/python/fledge/services/core/api/plugins/test_update.py
@@ -51,6 +51,12 @@ class TestPluginUpdate:
         assert 400 == resp.status
         assert "Invalid plugin type. Must be one of 'south' , north', 'filter', 'notify' or 'rule'" == resp.reason
 
+    @pytest.mark.parametrize("name", ["OMF", "omf", "Omf"])
+    async def test_bad_update_of_inbuilt_plugin(self, client, name):
+        resp = await client.put('/fledge/plugins/north/{}/update'.format(name), data=None)
+        assert 400 == resp.status
+        assert "Cannot update an inbuilt OMF plugin." == resp.reason
+
     @pytest.mark.parametrize("_type, plugin_installed_dirname", [
         ('south', 'Random'),
         ('north', 'http_north')


### PR DESCRIPTION
~Note: I haven't changed the param in request - name Vs PackageName. So we need to decide for the backward compatability by checking fledge core version `check > 2.1.0`; as this endpoint is only use by FogLAMP Manage.~



~As this endpoint is to update the package. So we should request with package name to make more clarity in the endpoint.~



New endpoints available with 2.1.0 onwards core version. More, details added on JIRA
```
PUT /fledge/plugins/{package_name}
DELETE /fledge/plugins/{package_name}
```