### PR TITLE
FOGL-7589: Fixed typos in OMF base types JSON

### DIFF
--- a/C/plugins/north/OMF/include/basetypes.h
+++ b/C/plugins/north/OMF/include/basetypes.h
@@ -52,7 +52,7 @@ static const char *baseOMFTypes = QUOTE(
 	      "properties":{
 		 "Integer16":{
 		    "type":["integer","null"],
-		    "format":"int16",
+		    "format":"int16"
 		 },
 		 "Time":{
 		    "type":"string",
@@ -68,7 +68,7 @@ static const char *baseOMFTypes = QUOTE(
 	      "properties":{
 		 "Integer32":{
 		    "type":["integer","null"],
-		    "format":"int32",
+		    "format":"int32"
 		 },
 		 "Time":{
 		    "type":"string",
@@ -84,7 +84,7 @@ static const char *baseOMFTypes = QUOTE(
 	      "properties":{
 		 "Integer64":{
 		    "type":["integer","null"],
-		    "format":"int64",
+		    "format":"int64"
 		 },
 		 "Time":{
 		    "type":"string",
@@ -100,7 +100,7 @@ static const char *baseOMFTypes = QUOTE(
 	      "properties":{
 		 "UInteger16":{
 		    "type":["integer","null"],
-		    "format":"uint16",
+		    "format":"uint16"
 		 },
 		 "Time":{
 		    "type":"string",
@@ -116,7 +116,7 @@ static const char *baseOMFTypes = QUOTE(
 	      "properties":{
 		 "UInteger32":{
 		    "type":["integer","null"],
-		    "format":"uint32",
+		    "format":"uint32"
 		 },
 		 "Time":{
 		    "type":"string",
@@ -132,7 +132,7 @@ static const char *baseOMFTypes = QUOTE(
 	      "properties":{
 		 "UInteger64":{
 		    "type":["integer","null"],
-		    "format":"uint64",
+		    "format":"uint64"
 		 },
 		 "Time":{
 		    "type":"string",


### PR DESCRIPTION
There were a few trailing commas in the integer type definitions in the baseOMFTypes JSON string. The PI Web API overlooked this but AVEVA Data Hub (ADH) could not process the JSON and logged an error instead. This affected subsequent Stream creation. This has been fixed.