### PR TITLE
FOGL-7599 CONCH audit log record added when configuration change happens

### DIFF
--- a/python/fledge/common/configuration_manager.py
+++ b/python/fledge/common/configuration_manager.py
@@ -1138,7 +1138,15 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                     else:
                         await self._update_category(category_name, category_val_prepared, category_description,
                                                     display_name)
-
+                        diff = set(category_val_prepared) - set(category_val_storage)
+                        if diff:
+                            audit = AuditLogger(self._storage)
+                            audit_details = {
+                                'category': category_name,
+                                'oldValue': category_val_storage,
+                                'newValue': category_val_prepared
+                            }
+                            await audit.information('CONCH', audit_details)
             is_acl, config_item, found_cat_name, found_value = await \
                 self.search_for_ACL_recursive_from_cat_name(category_name)
             _logger.debug("check if there is {} create category function  for category {} ".format(is_acl,

--- a/python/fledge/common/configuration_manager.py
+++ b/python/fledge/common/configuration_manager.py
@@ -1143,6 +1143,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                             audit = AuditLogger(self._storage)
                             audit_details = {
                                 'category': category_name,
+                                'item': "configurationChange",
                                 'oldValue': category_val_storage,
                                 'newValue': category_val_prepared
                             }

--- a/tests/unit/python/fledge/common/test_configuration_manager.py
+++ b/tests/unit/python/fledge/common/test_configuration_manager.py
@@ -1273,7 +1273,8 @@ class TestConfigurationManager:
                                             assert cat is None
                                         searchaclpatch.assert_called_once_with('catname')
                                     auditinfopatch.assert_called_once_with(
-                                        'CONCH', {'category': 'catname', 'oldValue': {}, 'newValue': {'bla': 'bla'}})
+                                        'CONCH', {'category': 'catname', 'item': 'configurationChange', 'oldValue': {},
+                                                  'newValue': {'bla': 'bla'}})
                             updatepatch.assert_called_once_with('catname', {'bla': 'bla'}, 'catdesc', 'catname')
                         callbackpatch.assert_called_once_with('catname')
                     mergepatch.assert_called_once_with({}, {}, False, 'catname')


### PR DESCRIPTION
Below is one of example to show audit **CONCH** record entry when having different configuration

```
{
  "audit": [{
  "details": {
    "category": "sine", 
    "item": "configurationChange",
    "oldValue": {"plugin": {"description": "Sinusoid Poll Plugin which implements sine wave with data points", "type": "string", "default": "sinusoid", "readonly": "true", "value": "sinusoid"}, "assetName": {"description": "Name of Asset", "type": "string", "default": "sinusoid", "displayName": "Asset name", "mandatory": "true", "value": "sinusoid"}}, 
    "newValue": {"plugin": {"description": "Sinusoid Poll Plugin which implements sine wave with data points", "type": "string", "readonly": "true", "default": "sinusoid", "value": "sinusoid"}, "assetName": {"description": "Name of Asset", "type": "string", "displayName": "Asset name", "mandatory": "true", "default": "sinusoid", "value": "sinusoid"}, "tagName": {"description": "Tag Name", "type": "string", "displayName": "Tag Name", "default": "tag", "value": "tag"}}
  }, 
  "severity": "INFORMATION", 
  "source": "CONCH", 
  "timestamp": "2023-04-05 11:50:16.143"
  }]
}
```