### PR TITLE
some log fixes in python API

### DIFF
--- a/python/fledge/services/core/api/task.py
+++ b/python/fledge/services/core/api/task.py
@@ -176,6 +176,7 @@ EOF
                 return web.HTTPBadRequest(reason=msg)
             plugin_config = plugin_info['config']
             if not plugin_config:
+                plugin_module_path = "{}/plugins/{}/{}".format(_FLEDGE_ROOT, task_type, plugin)
                 raise web.HTTPNotFound(reason='Plugin "{}" import problem from path "{}"'.format(
                     plugin, plugin_module_path))
         except TypeError as ex:

--- a/python/fledge/services/core/api/utils.py
+++ b/python/fledge/services/core/api/utils.py
@@ -27,7 +27,7 @@ def get_plugin_info(name, dir):
         out, err = p.communicate()
         res = out.decode("utf-8")
         jdoc = json.loads(res)
-    except OSError as err:
+    except (OSError, ValueError) as err:
         _logger.error("{} C plugin get info failed due to {}".format(name, str(err)))
         return {}
     except subprocess.CalledProcessError as err:
@@ -35,8 +35,6 @@ def get_plugin_info(name, dir):
             _logger.error("{} C plugin get info failed '{}' due to {}".format(name, err.output, str(err)))
         else:
             _logger.error("{} C plugin get info failed due to {}".format(name, str(err)))
-        return {}
-    except ValueError as err:
         return {}
     except Exception as ex:
         _logger.error("{} C plugin get info failed due to {}".format(name, str(ex)))


### PR DESCRIPTION
Fixed items
- [x] plugin module path value fixes in tasks API when C plugin try is not found
- [x] Plugin discovery utils log fixes when C plugin fails with ValueError exception. In FOGL-7431 work I have accidentally remove the logger for the given case. 