### PR TITLE
FOGL-7432 - multiline traceback utility method added in python logger

### DIFF
--- a/python/fledge/common/logger.py
+++ b/python/fledge/common/logger.py
@@ -7,6 +7,7 @@
 """ Fledge Logger """
 import os
 import subprocess
+import traceback
 import logging
 from logging.handlers import SysLogHandler
 
@@ -23,10 +24,10 @@ r"""Send log entries to /var/log/syslog
 """
 CONSOLE = 1
 """Send log entries to STDERR"""
-
-
-FLEDGE_LOGS_DESTINATION = 'FLEDGE_LOGS_DESTINATION'  # env variable
-default_destination = SYSLOG    # default for fledge
+FLEDGE_LOGS_DESTINATION = 'FLEDGE_LOGS_DESTINATION'
+"""Log destination environment variable"""
+default_destination = SYSLOG
+"""Default destination of logger"""
 
 
 def set_default_destination(destination: int):
@@ -116,6 +117,18 @@ def setup(logger_name: str = None,
     return logger
 
 
+def multiline_stack_trace(ex, msg=None, ex_traceback=None):
+    """Splitting the log messages at the newline/carriage return.
+    Used in separation of log for each frame in the stack trace"""
+    if ex_traceback is None:
+        ex_traceback = ex.__traceback__
+    trace_msg = traceback.format_exception(ex.__class__, ex, ex_traceback)
+    if msg is not None and msg:
+        trace_msg[:0] = ["{}\n".format(msg)]
+    lines = [line.strip('\n') for line in trace_msg]
+    return lines
+
+
 class FLCoreLogger:
     """
     Singleton FLCoreLogger class. This class is only instantiated ONCE. It is to keep a consistent
@@ -203,3 +216,6 @@ class FLCoreLogger:
         else:
             log_level = logging.WARNING
         logging.root.setLevel(log_level)
+
+    def multiline_traceback(self, ex, msg=None, ex_traceback=None):
+        return multiline_stack_trace(ex, msg, ex_traceback)

--- a/python/fledge/services/core/api/audit.py
+++ b/python/fledge/services/core/api/audit.py
@@ -130,7 +130,8 @@ async def create_audit_entry(request):
             raise web.HTTPInternalServerError(reason=err_msg, body=json.dumps({"message": err_msg}))
     except Exception as ex:
         msg = str(ex)
-        _logger.error("Failed to log audit entry. {}".format(msg))
+        [_logger.error(line) for line in FLCoreLogger().multiline_traceback(
+            ex, msg="Failed to log audit entry.")]
         raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
     else:
         return web.json_response(message)
@@ -270,7 +271,8 @@ async def get_audit_entries(request):
             res.append(r)
     except Exception as ex:
         msg = str(ex)
-        _logger.error("Get Audit log entry failed. {}".format(msg))
+        [_logger.error(line) for line in FLCoreLogger().multiline_traceback(
+            ex, msg="Failed to fetch log audit entry.")]
         raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
     else:
         return web.json_response({'audit': res, 'totalCount': total_count})

--- a/python/fledge/services/core/server.py
+++ b/python/fledge/services/core/server.py
@@ -1216,7 +1216,8 @@ class Server:
                         cls._audit = AuditLogger(cls._storage_client_async)
                         await cls._audit.information('SRVRG', {'name': service_name})
                 except Exception as ex:
-                    _logger.info("Failed to audit registration: %s", str(ex))
+                    [_logger.error(msg) for msg in logger.multiline_stack_trace(
+                        ex, msg="Failed to audit registration.")]
             except service_registry_exceptions.AlreadyExistsWithTheSameName:
                 raise web.HTTPBadRequest(reason='A Service with the same name already exists')
             except service_registry_exceptions.AlreadyExistsWithTheSameAddressAndPort:

--- a/tests/unit/python/fledge/services/core/api/test_audit.py
+++ b/tests/unit/python/fledge/services/core/api/test_audit.py
@@ -184,7 +184,7 @@ class TestAudit:
                 resp = await client.get('/fledge/audit')
                 assert 500 == resp.status
                 assert msg == resp.reason
-            assert 1 == patch_logger.call_count
+            assert patch_logger.called
 
     async def test_create_audit_entry(self, client, loop):
         request_data = {"source": "LMTR", "severity": "warning", "details": {"message": "Engine oil pressure low"}}
@@ -239,4 +239,5 @@ class TestAudit:
                 resp = await client.post('/fledge/audit', data=json.dumps(request_data))
                 assert 500 == resp.status
                 assert "__init__() should return None, not 'str'" == resp.reason
-            assert 1 == patch_logger.call_count
+            assert patch_logger.called
+


### PR DESCRIPTION
Below is one of the example; On audit entry failure

Python traceback with multilines
```
Apr 13 13:35:51 aj-ThinkPad-E450 Fledge[16823] ERROR: audit: fledge.services.core.api.audit: Failed to fetch log audit entry.
Apr 13 13:35:51 aj-ThinkPad-E450 Fledge[16823] ERROR: audit: fledge.services.core.api.audit: Traceback (most recent call last):
Apr 13 13:35:51 aj-ThinkPad-E450 Fledge[16823] ERROR: audit: fledge.services.core.api.audit:   File "/home/aj/fledge/python/fledge/services/core/api/audit.py", line 252, in get_audit_entries#012    rows = results['rows1']
Apr 13 13:35:51 aj-ThinkPad-E450 Fledge[16823] ERROR: audit: fledge.services.core.api.audit: KeyError: 'rows1'
```