### PR TITLE
FOGL-7526A: Adjust product version check for changes in EDS 2023

### DIFF
--- a/C/plugins/north/OMF/plugin.cpp
+++ b/C/plugins/north/OMF/plugin.cpp
@@ -1580,7 +1580,8 @@ static void ParseProductVersion(std::string &versionString, int *major, int *min
 }
 
 /**
- * Parses the Edge Data Store version string from the /productinformation REST response
+ * Parses the Edge Data Store version string from the /productinformation REST response.
+ * Note that the response format differs between EDS 2020 and EDS 2023.
  * 
  * @param    json		REST response from /api/v1/diagnostics/productinformation
  * @return   version	Edge Data Store version string
@@ -1595,9 +1596,14 @@ static std::string ParseEDSProductInformation(std::string json)
 	{
 		try
 		{
-			if (doc.HasMember("Edge Data Store"))
+			if (doc.HasMember("Edge Data Store"))	// EDS 2020 response
 			{
 				const rapidjson::Value &EDS = doc["Edge Data Store"];
+				version = EDS.GetString();
+			}
+			else if (doc.HasMember("Product Version"))	// EDS 2023 response
+			{
+				const rapidjson::Value &EDS = doc["Product Version"];
 				version = EDS.GetString();
 			}
 		}


### PR DESCRIPTION
This work item has been completed and closed before ([FOGL-7526](https://scaledb.atlassian.net/browse/[FOGL-7526](https://scaledb.atlassian.net/browse/FOGL-7526))). However, during testing of AVEVA's latest release of the Edge Data Store (EDS 2023 Patch 1) with the OMF North plugin, it was discovered that the REST endpoint that returns the product version has been changed. The product version string is in a different position in the JSON response document which caused the parsing code to miss it. This Pull Request fixes the version string parsing so it will properly detect both EDS 2020 and EDS 2023 versions.