### PR TITLE
FOGL-7685 args fixes in logger and other fixes

### DIFF
--- a/python/fledge/common/logger.py
+++ b/python/fledge/common/logger.py
@@ -128,7 +128,13 @@ def setup(logger_name: str = None,
                 trace_msg[:0] = ["{}\n".format(args[0])]
             [__logging_error(line.strip('\n')) for line in trace_msg]
         else:
-            [__logging_error(m) for m in msg.splitlines()]
+            if isinstance(msg, str):
+                if args:
+                    msg = msg % args
+                [__logging_error(m) for m in msg.splitlines()]
+            else:
+                # Default logging error
+                __logging_error(msg)
 
     # overwrite the default logging.error
     logger.error = error
@@ -223,13 +229,21 @@ class FLCoreLogger:
                     trace_msg[:0] = ["{}\n".format(args[0])]
                 [__logging_error(line.strip('\n')) for line in trace_msg]
             else:
-                """Case: When we pass string in error
-                For example:  
-                a) _logger.error(str(ex))
-                b) _logger.error("Failed to log audit trail entry")
-                c) _logger.error("Failed to log audit trail entry '{}' \n{}".format(code, str(ex))) 
-                """
-                [__logging_error(m) for m in msg.splitlines()]
+                if isinstance(msg, str):
+                    """For example:
+                        a) _logger.error(str(ex))
+                        b) _logger.error("Failed to log audit trail entry")
+                        c) _logger.error('Failed to log audit trail entry for code: %s', "CONCH")
+                        d) _logger.error('Failed to log audit trail entry for code: {log_code}'.format(log_code="CONAD"))
+                        e) _logger.error('Failed to log audit trail entry for code: {0}'.format("CONAD"))
+                        f) _logger.error("Failed to log audit trail entry for code '{}' \n{}".format("CONCH", "Next line"))
+                    """
+                    if args:
+                        msg = msg % args
+                    [__logging_error(m) for m in msg.splitlines()]
+                else:
+                    # Default logging error
+                    __logging_error(msg)
 
         # overwrite the default logging.error
         _logger.error = error


### PR DESCRIPTION
This primarily has the fix of below cases:

a) string format when having with %s as it prints as is
```
For example:
_logger.error('Failed to log audit trail entry for code: %s', "CONCH")
O/P
Failed to log audit trail entry for code: %s
```
b) non-Exception cases 
For example:
```
color_list = ['Orange', 'White', 'Green']
i) _logger.error(color_list)
color_dict = {'colors': {'Orange', 'White', 'Green'}}
ii) _logger.error(color_dict)
iii) _logger.error(type(request))

O/p
 i) 'list' object has no attribute 'splitlines'
ii) 'dict' object has no attribute 'splitlines'
iii) type object 'Request' has no attribute 'splitlines'
```

This needs to get merged ASAP to block others
