### PR TITLE
FOGL-5409 error handling added in create user

### DIFF
--- a/python/fledge/services/core/user_model.py
+++ b/python/fledge/services/core/user_model.py
@@ -216,9 +216,7 @@ class User:
         @classmethod
         async def all(cls):
             storage_client = connect.get_storage_async()
-            payload = PayloadBuilder().SELECT("id", "uname", "role_id", "access_method", "real_name",
-                                              "description").WHERE(['enabled', '=', 't']).payload()
-            result = await storage_client.query_tbl_with_payload('users', payload)
+            result = await storage_client.query_tbl('users')
             return result['rows']
 
         @classmethod

--- a/tests/unit/python/fledge/services/core/api/test_auth_optional.py
+++ b/tests/unit/python/fledge/services/core/api/test_auth_optional.py
@@ -63,11 +63,19 @@ class TestAuthOptional:
 
     @pytest.mark.parametrize("ret_val, exp_result", [
         ([], []),
-        ([{'uname': 'admin', 'role_id': '1', 'access_method': 'any', 'id': '1', 'real_name': 'Admin', 'description': 'Admin user'}, {'uname': 'user', 'role_id': '2', 'access_method': 'any', 'id': '2', 'real_name': 'Non-admin', 'description': 'Normal user'}],
-         [{"userId": "1", "userName": "admin", "roleId": "1", "accessMethod": "any", "realName": "Admin", "description": "Admin user"}, {"userId": "2", "userName": "user", "roleId": "2", "accessMethod": "any", "realName": "Non-admin", "description": "Normal user"}])
+        ([{'uname': 'admin', 'role_id': '1', 'access_method': 'any', 'id': '1', 'real_name': 'Admin',
+           'description': 'Admin user', 'enabled': 't'},
+          {'uname': 'user', 'role_id': '2', 'access_method': 'any', 'id': '2', 'real_name': 'Non-admin',
+           'description': 'Normal user', 'enabled': 't'},
+          {'uname': 'dviewer', 'role_id': '3', 'access_method': 'any', 'id': '3', 'real_name': 'Data-Viewer',
+           'description': 'Data user', 'enabled': 'f'}
+          ],
+         [{"userId": "1", "userName": "admin", "roleId": "1", "accessMethod": "any", "realName": "Admin",
+           "description": "Admin user"},
+          {"userId": "2", "userName": "user", "roleId": "2", "accessMethod": "any", "realName": "Non-admin",
+           "description": "Normal user"}])
     ])
     async def test_get_all_users(self, client, ret_val, exp_result):
-        
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
             _rv = await mock_coro(ret_val)

--- a/tests/unit/python/fledge/services/core/test_user_model.py
+++ b/tests/unit/python/fledge/services/core/test_user_model.py
@@ -87,7 +87,6 @@ class TestUserModel:
 
     async def test_get_all(self):
         expected = {'rows': [], 'count': 0}
-        payload = '{"return": ["id", "uname", "role_id", "access_method", "real_name", "description"], "where": {"column": "enabled", "condition": "=", "value": "t"}}'
         storage_client_mock = MagicMock(StorageClientAsync)
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
@@ -97,10 +96,10 @@ class TestUserModel:
             _rv = asyncio.ensure_future(mock_coro(expected))
         
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
-            with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv) as query_tbl_patch:
+            with patch.object(storage_client_mock, 'query_tbl', return_value=_rv) as query_tbl_patch:
                 actual = await User.Objects.all()
                 assert actual == expected['rows']
-            query_tbl_patch.assert_called_once_with('users', payload)
+            query_tbl_patch.assert_called_once_with('users')
 
     @pytest.mark.parametrize("kwargs, payload", [
         ({'username': None, 'uid': None}, '{"return": ["id", "uname", "role_id", "access_method", "real_name", "description"], "where": {"column": "enabled", "condition": "=", "value": "t"}}'),


### PR DESCRIPTION
Return early when user sent bad request.

This PR only to handle the storage exception that was occurred and DB errors in syslog on ADD user when attempt with deactivated user. 

Also new audit log codes step and handling to override the values in separate PR as new enhancement.