### PR TITLE
Readthedocs build failure fixes as latest urllib3 version is not compatible

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 Sphinx==3.5.4
 docutils<0.18
+urllib3==1.26.15


### PR DESCRIPTION
Now, RTD build passed...