### PR TITLE
Sql query syntax fixes

### DIFF
--- a/C/plugins/storage/sqlite/common/readings.cpp
+++ b/C/plugins/storage/sqlite/common/readings.cpp
@@ -1659,13 +1659,11 @@ vector<string>  asset_codes;
 					sql.append(' ');
 				}
 
-				sql.append("id, asset_code, reading, strftime(')" F_DATEH24_SEC);
-				sql.append("(', user_ts, '");
+				sql.append("id, asset_code, reading, strftime('" F_DATEH24_SEC "', user_ts, '");
 				sql.append(timezone);
-				sql.append("')  || substr(user_ts, instr(user_ts, '.'), 7) AS user_ts, strftime(')" F_DATEH24_MS);
-			       	sql.append("(', ts, '");
+				sql.append("')  || substr(user_ts, instr(user_ts, '.'), 7) AS user_ts, strftime('" F_DATEH24_MS "', ts, '");
 				sql.append(timezone);
-				sql.append("') AS ts FROM  )");
+				sql.append("') AS ts FROM  ");
 			}
 			{
 


### PR DESCRIPTION
On calling below
```
curl -sX PUT localhost:34259/storage/reading/query -d '{"sort": {"column": "asset_code", "direction": "asc"}}'
```
Though it returns 200 http status code. But there is a syntax error on Sql query

Error:

```
Jul 20 19:09:05 AJ Fledge Storage[32692]: ERROR: SQLite3 storage plugin raising error: near ")": syntax error
```