### PR TITLE
FOGL-7994.patch

### DIFF
--- a/scripts/plugins/storage/postgres/downgrade/61.sql
+++ b/scripts/plugins/storage/postgres/downgrade/61.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS fledge.monitors;
+DROP INDEX IF EXISTS fledge.monitors_ix1;

--- a/scripts/plugins/storage/postgres/init.sql
+++ b/scripts/plugins/storage/postgres/init.sql
@@ -905,6 +905,19 @@ CREATE TABLE fledge.control_filters (
              CONSTRAINT       control_filters_fk1              FOREIGN KEY (cpid) REFERENCES fledge.control_pipelines (cpid)  MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
              );
 
+CREATE TABLE fledge.monitors (
+	service		character varying(255) NOT NULL,
+	monitor 	character varying(80) NOT NULL,
+	minimum		bigint,
+	maximum		bigint,
+	average		bigint,
+	samples		bigint,
+	timestamp   timestamp(6) with time zone NOT NULL DEFAULT now());
+
+CREATE INDEX monitors_ix1
+    ON fledge.monitors(service, monitor);
+
+
 -- Grants to fledge schema
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA fledge TO PUBLIC;
 
@@ -1160,17 +1173,3 @@ INSERT INTO fledge.control_destination ( name, description )
             ('Asset', 'A name of asset that is being controlled.'),
             ('Script', 'A name of script that will be executed.'),
             ('Broadcast', 'No name is applied and pipeline will be considered for any control writes or operations to broadcast destinations.');
-
-
-CREATE TABLE fledge.monitors (
-	service		character varying(255) NOT NULL,   -- 
-	monitor 	character varying(80) NOT NULL,
-	minimum		bigint,
-	maximum		bigint,
-	average		bigint,
-	samples		bigint,
-	timestamp    	timestamp(6) with time zone NOT NULL DEFAULT now()
-
--- Index: log_ix1 - For queries by code
-CREATE INDEX monitor_ix1
-    ON fledge.monitors(service, monitor);

--- a/scripts/plugins/storage/postgres/init.sql
+++ b/scripts/plugins/storage/postgres/init.sql
@@ -906,13 +906,14 @@ CREATE TABLE fledge.control_filters (
              );
 
 CREATE TABLE fledge.monitors (
-	service		character varying(255) NOT NULL,
-	monitor 	character varying(80) NOT NULL,
-	minimum		bigint,
-	maximum		bigint,
-	average		bigint,
-	samples		bigint,
-	timestamp   timestamp(6) with time zone NOT NULL DEFAULT now());
+             service		character varying(255) NOT NULL,
+             monitor 	    character varying(80) NOT NULL,
+             minimum		bigint,
+             maximum		bigint,
+             average		bigint,
+             samples		bigint,
+             ts             timestamp(6) with time zone NOT NULL DEFAULT now()
+             );
 
 CREATE INDEX monitors_ix1
     ON fledge.monitors(service, monitor);

--- a/scripts/plugins/storage/postgres/init.sql
+++ b/scripts/plugins/storage/postgres/init.sql
@@ -906,12 +906,12 @@ CREATE TABLE fledge.control_filters (
              );
 
 CREATE TABLE fledge.monitors (
-             service		character varying(255) NOT NULL,
-             monitor 	    character varying(80) NOT NULL,
-             minimum		bigint,
-             maximum		bigint,
-             average		bigint,
-             samples		bigint,
+             service        character varying(255) NOT NULL,
+             monitor        character varying(80) NOT NULL,
+             minimum        bigint,
+             maximum        bigint,
+             average        bigint,
+             samples        bigint,
              ts             timestamp(6) with time zone NOT NULL DEFAULT now()
              );
 

--- a/scripts/plugins/storage/postgres/upgrade/62.sql
+++ b/scripts/plugins/storage/postgres/upgrade/62.sql
@@ -1,11 +1,12 @@
 CREATE TABLE fledge.monitors (
-	service		character varying(255) NOT NULL,
-	monitor 	character varying(80) NOT NULL,
-	minimum		bigint,
-	maximum		bigint,
-	average		bigint,
-	samples		bigint,
-	timestamp   timestamp(6) with time zone NOT NULL DEFAULT now());
+             service		character varying(255) NOT NULL,
+             monitor 	    character varying(80) NOT NULL,
+             minimum		bigint,
+             maximum		bigint,
+             average		bigint,
+             samples		bigint,
+             ts             timestamp(6) with time zone NOT NULL DEFAULT now()
+);
 
 CREATE INDEX monitors_ix1
     ON fledge.monitors(service, monitor);

--- a/scripts/plugins/storage/postgres/upgrade/62.sql
+++ b/scripts/plugins/storage/postgres/upgrade/62.sql
@@ -1,10 +1,10 @@
 CREATE TABLE fledge.monitors (
-             service		character varying(255) NOT NULL,
-             monitor 	    character varying(80) NOT NULL,
-             minimum		bigint,
-             maximum		bigint,
-             average		bigint,
-             samples		bigint,
+             service        character varying(255) NOT NULL,
+             monitor        character varying(80) NOT NULL,
+             minimum        bigint,
+             maximum        bigint,
+             average        bigint,
+             samples        bigint,
              ts             timestamp(6) with time zone NOT NULL DEFAULT now()
 );
 

--- a/scripts/plugins/storage/postgres/upgrade/62.sql
+++ b/scripts/plugins/storage/postgres/upgrade/62.sql
@@ -1,11 +1,11 @@
 CREATE TABLE fledge.monitors (
-	service		character varying(80) NOT NULL,   -- 
+	service		character varying(255) NOT NULL,
 	monitor 	character varying(80) NOT NULL,
 	minimum		bigint,
 	maximum		bigint,
 	average		bigint,
 	samples		bigint,
-	timestamp    	timestamp(6) with time zone NOT NULL DEFAULT now()
+	timestamp   timestamp(6) with time zone NOT NULL DEFAULT now());
 
-CREATE INDEX fledge.monitor_ix1
+CREATE INDEX monitors_ix1
     ON fledge.monitors(service, monitor);

--- a/scripts/plugins/storage/sqlite/downgrade/61.sql
+++ b/scripts/plugins/storage/sqlite/downgrade/61.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS fledge.monitors;
+DROP INDEX IF EXISTS fledge.monitors_ix1;

--- a/scripts/plugins/storage/sqlite/init.sql
+++ b/scripts/plugins/storage/sqlite/init.sql
@@ -668,13 +668,13 @@ CREATE TABLE fledge.control_filters (
 
 -- Create monitors table
 CREATE TABLE fledge.monitors (
-             service		character varying(255) NOT NULL,
-             monitor 	character varying(80) NOT NULL,
-             minimum		integer,
-             maximum		integer,
-             average		integer,
-             samples		integer,
-             ts    	    DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))
+             service       character varying(255) NOT NULL,
+             monitor       character varying(80) NOT NULL,
+             minimum       integer,
+             maximum       integer,
+             average       integer,
+             samples       integer,
+             ts            DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))
              );
 
 CREATE INDEX monitors_ix1

--- a/scripts/plugins/storage/sqlite/init.sql
+++ b/scripts/plugins/storage/sqlite/init.sql
@@ -668,13 +668,14 @@ CREATE TABLE fledge.control_filters (
 
 -- Create monitors table
 CREATE TABLE fledge.monitors (
-	service		character varying(255) NOT NULL,
-	monitor 	character varying(80) NOT NULL,
-	minimum		integer,
-	maximum		integer,
-	average		integer,
-	samples		integer,
-	timestamp    	DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')));
+             service		character varying(255) NOT NULL,
+             monitor 	character varying(80) NOT NULL,
+             minimum		integer,
+             maximum		integer,
+             average		integer,
+             samples		integer,
+             ts    	    DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))
+             );
 
 CREATE INDEX monitors_ix1
     ON monitors(service, monitor);

--- a/scripts/plugins/storage/sqlite/init.sql
+++ b/scripts/plugins/storage/sqlite/init.sql
@@ -666,6 +666,19 @@ CREATE TABLE fledge.control_filters (
              REFERENCES       control_pipelines (cpid)    MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
              );
 
+-- Create monitors table
+CREATE TABLE fledge.monitors (
+	service		character varying(255) NOT NULL,
+	monitor 	character varying(80) NOT NULL,
+	minimum		integer,
+	maximum		integer,
+	average		integer,
+	samples		integer,
+	timestamp    	DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')));
+
+CREATE INDEX monitors_ix1
+    ON monitors(service, monitor);
+
 ----------------------------------------------------------------------
 -- Initialization phase - DML
 ----------------------------------------------------------------------
@@ -917,14 +930,3 @@ INSERT INTO fledge.control_destination ( name, description )
             ('Script', 'A name of script that will be executed.'),
             ('Broadcast', 'No name is applied and pipeline will be considered for any control writes or operations to broadcast destinations.');
 
-CREATE TABLE fledge.monitors (
-	service		character varying(255) NOT NULL,   -- 
-	monitor 	character varying(80) NOT NULL,
-	minimum		integer,
-	maximum		integer,
-	average		integer,
-	samples		integer,
-	timestamp    	DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')));
-
-CREATE INDEX monitor_ix1
-    ON fledge.monitors(service, monitor);

--- a/scripts/plugins/storage/sqlite/upgrade/62.sql
+++ b/scripts/plugins/storage/sqlite/upgrade/62.sql
@@ -1,12 +1,12 @@
 
 CREATE TABLE fledge.monitors (
-             service		character varying(255) NOT NULL,
-             monitor 	    character varying(80) NOT NULL,
-             minimum		integer,
-             maximum		integer,
-             average		integer,
-             samples		integer,
-             ts    	        DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))
+             service       character varying(255) NOT NULL,
+             monitor       character varying(80) NOT NULL,
+             minimum       integer,
+             maximum       integer,
+             average       integer,
+             samples       integer,
+             ts            DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))
 );
 
 

--- a/scripts/plugins/storage/sqlite/upgrade/62.sql
+++ b/scripts/plugins/storage/sqlite/upgrade/62.sql
@@ -9,5 +9,5 @@ CREATE TABLE fledge.monitors (
 	timestamp    	DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')));
 
 
-CREATE INDEX monitor_ix1
-    ON fledge.monitors(service, monitor);
+CREATE INDEX monitors_ix1
+    ON monitors(service, monitor);

--- a/scripts/plugins/storage/sqlite/upgrade/62.sql
+++ b/scripts/plugins/storage/sqlite/upgrade/62.sql
@@ -1,12 +1,13 @@
 
 CREATE TABLE fledge.monitors (
-	service		character varying(255) NOT NULL,
-	monitor 	character varying(80) NOT NULL,
-	minimum		integer,
-	maximum		integer,
-	average		integer,
-	samples		integer,
-	timestamp    	DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')));
+             service		character varying(255) NOT NULL,
+             monitor 	    character varying(80) NOT NULL,
+             minimum		integer,
+             maximum		integer,
+             average		integer,
+             samples		integer,
+             ts    	        DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))
+);
 
 
 CREATE INDEX monitors_ix1

--- a/scripts/plugins/storage/sqlitelb/downgrade/61.sql
+++ b/scripts/plugins/storage/sqlitelb/downgrade/61.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS fledge.monitors;
+DROP INDEX IF EXISTS fledge.monitors_ix1;

--- a/scripts/plugins/storage/sqlitelb/init.sql
+++ b/scripts/plugins/storage/sqlitelb/init.sql
@@ -668,13 +668,13 @@ CREATE TABLE fledge.control_filters (
 
 -- Create monitors table
 CREATE TABLE fledge.monitors (
-             service		character varying(255) NOT NULL,
-             monitor 	    character varying(80) NOT NULL,
-             minimum		integer,
-             maximum		integer,
-             average		integer,
-             samples		integer,
-             ts    	        DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))
+             service       character varying(255) NOT NULL,
+             monitor       character varying(80) NOT NULL,
+             minimum       integer,
+             maximum       integer,
+             average       integer,
+             samples       integer,
+             ts            DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))
              );
 
 CREATE INDEX monitors_ix1

--- a/scripts/plugins/storage/sqlitelb/init.sql
+++ b/scripts/plugins/storage/sqlitelb/init.sql
@@ -668,14 +668,14 @@ CREATE TABLE fledge.control_filters (
 
 -- Create monitors table
 CREATE TABLE fledge.monitors (
-	service		character varying(255) NOT NULL,
-	monitor 	character varying(80) NOT NULL,
-	minimum		integer,
-	maximum		integer,
-	average		integer,
-	samples		integer,
-	timestamp    	DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW'))
-);
+             service		character varying(255) NOT NULL,
+             monitor 	    character varying(80) NOT NULL,
+             minimum		integer,
+             maximum		integer,
+             average		integer,
+             samples		integer,
+             ts    	        DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))
+             );
 
 CREATE INDEX monitors_ix1
     ON monitors(service, monitor);

--- a/scripts/plugins/storage/sqlitelb/init.sql
+++ b/scripts/plugins/storage/sqlitelb/init.sql
@@ -666,6 +666,20 @@ CREATE TABLE fledge.control_filters (
              REFERENCES       control_pipelines (cpid)    MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
              );
 
+-- Create monitors table
+CREATE TABLE fledge.monitors (
+	service		character varying(255) NOT NULL,
+	monitor 	character varying(80) NOT NULL,
+	minimum		integer,
+	maximum		integer,
+	average		integer,
+	samples		integer,
+	timestamp    	DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW'))
+);
+
+CREATE INDEX monitors_ix1
+    ON monitors(service, monitor);
+
 ----------------------------------------------------------------------
 -- Initialization phase - DML
 ----------------------------------------------------------------------
@@ -916,15 +930,3 @@ INSERT INTO fledge.control_destination ( name, description )
             ('Script', 'A name of script that will be executed.'),
             ('Broadcast', 'No name is applied and pipeline will be considered for any control writes or operations to broadcast destinations.');
 
-CREATE TABLE fledge.monitors (
-	service		character varying(255) NOT NULL,   -- 
-	monitor 	character varying(80) NOT NULL,
-	minimum		integer,
-	maximum		integer,
-	average		integer,
-	samples		integer,
-	timestamp    	DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW'))
-);
-
-CREATE INDEX monitor_ix1
-    ON log(service, monitor);

--- a/scripts/plugins/storage/sqlitelb/upgrade/62.sql
+++ b/scripts/plugins/storage/sqlitelb/upgrade/62.sql
@@ -9,5 +9,5 @@ CREATE TABLE fledge.monitors (
 	timestamp    	DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW'))
 );
 
-CREATE INDEX monitor_ix1
-    ON fledge.monitors(service, monitor);
+CREATE INDEX monitors_ix1
+    ON monitors(service, monitor);

--- a/scripts/plugins/storage/sqlitelb/upgrade/62.sql
+++ b/scripts/plugins/storage/sqlitelb/upgrade/62.sql
@@ -1,12 +1,12 @@
 
 CREATE TABLE fledge.monitors (
-	service		character varying(255) NOT NULL, 
-	monitor 	character varying(80) NOT NULL,
-	minimum		integer,
-	maximum		integer,
-	average		integer,
-	samples		integer,
-	timestamp    	DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW'))
+             service		character varying(255) NOT NULL,
+             monitor 	    character varying(80) NOT NULL,
+             minimum		integer,
+             maximum		integer,
+             average		integer,
+             samples		integer,
+             ts    	        DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))
 );
 
 CREATE INDEX monitors_ix1

--- a/scripts/plugins/storage/sqlitelb/upgrade/62.sql
+++ b/scripts/plugins/storage/sqlitelb/upgrade/62.sql
@@ -1,12 +1,12 @@
 
 CREATE TABLE fledge.monitors (
-             service		character varying(255) NOT NULL,
-             monitor 	    character varying(80) NOT NULL,
-             minimum		integer,
-             maximum		integer,
-             average		integer,
-             samples		integer,
-             ts    	        DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))
+             service       character varying(255) NOT NULL,
+             monitor       character varying(80) NOT NULL,
+             minimum       integer,
+             maximum       integer,
+             average       integer,
+             samples       integer,
+             ts            DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))
 );
 
 CREATE INDEX monitors_ix1


### PR DESCRIPTION
Fixed items

- [x] Grouping of table creation fixes; as these were written under DML section
- [x] Downgrade scripts added with 61.sql for all engines
- [x] Sytnax fixes in CREATE TABLE for PostgreSQL
- [x] service character limit is fixed in PostgreSQL
- [x] INDEX name with table name; consistency wise across all tables
- [x] INDEX is wrong in sqlitelb; It was used with log

NOTE: We should not use `timestamp` (reserved) name column . As in fledge schema we usually with `ts` column. 

- [x] ts column and also fix the UTC in Sqlite and Sqlitelb engines.