### PR TITLE
FOGL-8113 PURGE JSON response fixes when nothing to removed & more exception handling added in Python purge along with unit tests

### DIFF
--- a/C/plugins/storage/sqlitelb/common/readings.cpp
+++ b/C/plugins/storage/sqlitelb/common/readings.cpp
@@ -1634,7 +1634,7 @@ unsigned int  Connection::purgeReadings(unsigned long age,
 	result = "{ \"removed\" : 0, ";
 	result += " \"unsentPurged\" : 0, ";
 	result += " \"unsentRetained\" : 0, ";
-	result += " \"readings\" : 0 }";
+	result += " \"readings\" : 0, ";
 	result += " \"method\" : \"time\", ";
 	result += " \"duration\" : 0 }";
 

--- a/python/fledge/common/storage_client/storage_client.py
+++ b/python/fledge/common/storage_client/storage_client.py
@@ -587,10 +587,16 @@ class ReadingsStorageClientAsync(StorageClientAsync):
         async with aiohttp.ClientSession() as session:
             async with session.put(url, data=None) as resp:
                 status_code = resp.status
-                jdoc = await resp.json()
-                if status_code not in range(200, 209):
-                    _LOGGER.error("PUT url %s, Error code: %d, reason: %s, details: %s", put_url, resp.status,
-                                  resp.reason, jdoc)
-                    raise StorageServerError(code=resp.status, reason=resp.reason, error=jdoc)
-
+                try:
+                    jdoc = await resp.json()
+                    if status_code not in range(200, 209):
+                        _LOGGER.error("PUT url %s, Error code: %d, reason: %s, details: %s", put_url, resp.status,
+                                      resp.reason, jdoc)
+                        raise StorageServerError(code=resp.status, reason=resp.reason, error=jdoc)
+                except ValueError as err:
+                    jdoc = None
+                    _LOGGER.error(err, "Failed to parse JSON data returned of purge from the storage reading plugin.")
+                except Exception as ex:
+                    jdoc = None
+                    _LOGGER.error(ex, "Purge readings is failed.")
         return jdoc


### PR DESCRIPTION
OLD

```
 $ curl -sX PUT "http://localhost:42703/storage/reading/purge?age=72&sent=0&flags=purge"
{ "removed" : 0,  "unsentPurged" : 0,  "unsentRetained" : 0,  "readings" : 0 } "method" : "time",  "duration" : 0 }
```

With the given change

```
$ curl -sX PUT "http://localhost:42703/storage/reading/purge?age=72&sent=0&flags=purge" | jq
{
  "removed": 0,
  "unsentPurged": 0,
  "unsentRetained": 0,
  "readings": 0,
  "method": "time",
  "duration": 0
}

```