### PR TITLE
FOGL-8220: Assign ADH credentials to OMFInformation member variables

### DIFF
--- a/C/plugins/north/OMF/omfinfo.cpp
+++ b/C/plugins/north/OMF/omfinfo.cpp
@@ -159,10 +159,10 @@ OMFInformation::OMFInformation(ConfigCategory *config) : m_sender(NULL), m_omf(N
 	m_AFMap = AFMap;
 
 	// OCS configurations
-	OCSNamespace    = OCSNamespace;
-	OCSTenantId     = OCSTenantId;
-	OCSClientId     = OCSClientId;
-	OCSClientSecret = OCSClientSecret;
+	m_OCSNamespace    = OCSNamespace;
+	m_OCSTenantId     = OCSTenantId;
+	m_OCSClientId     = OCSClientId;
+	m_OCSClientSecret = OCSClientSecret;
 
 	// PI Web API end-point - evaluates the authentication method requested
 	if (m_PIServerEndpoint == ENDPOINT_PIWEB_API)


### PR DESCRIPTION
The constructor of the new OMFInformation class read the AVEVA Data Hub (ADH) credentials from the plugin configuration but did not properly assign them to the OMFInformation member variables leaving them empty. All OMF calls would fail. The first REST call to fail was the authentication call which sent an empty Client Id and and empty Client Secret to ADH. This has been fixed.
