### PR TITLE
FOGL-8236 bucket type and properties optional attribute support added in configuration manager

### DIFF
--- a/python/fledge/common/configuration_manager.py
+++ b/python/fledge/common/configuration_manager.py
@@ -277,7 +277,6 @@ class ConfigurationManager(ConfigurationManagerSingleton):
             def get_entry_val(k):
                 v = [val for name, val in item_val.items() if name == k]
                 return v[0]
-
             for entry_name, entry_val in item_val.copy().items():
                 if type(entry_name) is not str:
                     raise TypeError('For {} category, entry name {} must be a string for item name {}; got {}'
@@ -309,6 +308,10 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                             raise TypeError('For {} category, entry value must be a string for item name {} and '
                                             'entry name {}; got {}'.format(category_name, item_name, entry_name,
                                                                            type(entry_val)))
+                elif 'type' in item_val and entry_val == 'bucket':
+                    if 'properties' not in item_val:
+                        raise KeyError('For {} category, properties KV pair must be required '
+                                       'for item name {}.'.format(category_name, item_name))
                 else:
                     if type(entry_val) is not str:
                         raise TypeError('For {} category, entry value must be a string for item name {} and '

--- a/python/fledge/common/configuration_manager.py
+++ b/python/fledge/common/configuration_manager.py
@@ -35,7 +35,7 @@ _logger = FLCoreLogger().get_logger(__name__)
 
 # MAKE UPPER_CASE
 _valid_type_strings = sorted(['boolean', 'integer', 'float', 'string', 'IPv4', 'IPv6', 'X509 certificate', 'password',
-                              'JSON', 'URL', 'enumeration', 'script', 'code', 'northTask', 'ACL'])
+                              'JSON', 'URL', 'enumeration', 'script', 'code', 'northTask', 'ACL', 'bucket'])
 _optional_items = sorted(['readonly', 'order', 'length', 'maximum', 'minimum', 'rule', 'deprecated', 'displayName',
                           'validity', 'mandatory', 'group'])
 RESERVED_CATG = ['South', 'North', 'General', 'Advanced', 'Utilities', 'rest_api', 'Security', 'service', 'SCHEDULER',
@@ -268,7 +268,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
 
             optional_item_entries = {'readonly': 0, 'order': 0, 'length': 0, 'maximum': 0, 'minimum': 0,
                                      'deprecated': 0, 'displayName': 0, 'rule': 0, 'validity': 0, 'mandatory': 0,
-                                     'group': 0}
+                                     'group': 0, 'properties': 0}
             expected_item_entries = {'description': 0, 'default': 0, 'type': 0}
 
             if require_entry_value:
@@ -332,7 +332,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                                                                                                          entry_val)) is False:
                             raise ValueError('For {} category, entry value must be an integer or float for item name '
                                              '{}; got {}'.format(category_name, entry_name, type(entry_val)))
-                    elif entry_name in ('displayName', 'group', 'rule', 'validity'):
+                    elif entry_name in ('displayName', 'group', 'rule', 'validity', 'properties'):
                         if not isinstance(entry_val, str):
                             raise ValueError('For {} category, entry value must be string for item name {}; got {}'
                                              .format(category_name, entry_name, type(entry_val)))

--- a/python/fledge/common/configuration_manager.py
+++ b/python/fledge/common/configuration_manager.py
@@ -968,14 +968,17 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                     return
             # Validate optional types only when new_value_entry not empty; otherwise set empty value
             if new_value_entry:
-                if optional_entry_name == 'readonly' or optional_entry_name == 'deprecated' or optional_entry_name == 'mandatory':
+                if optional_entry_name == "properties":
+                    raise ValueError('For {} category, optional item name properties cannot be updated.'.format(
+                        category_name))
+                elif optional_entry_name in ('readonly', 'deprecated', 'mandatory'):
                     if self._validate_type_value('boolean', new_value_entry) is False:
                         raise ValueError(
                             'For {} category, entry value must be boolean for optional item name {}; got {}'
                             .format(category_name, optional_entry_name, type(new_value_entry)))
-                elif optional_entry_name == 'minimum' or optional_entry_name == 'maximum':
-                    if (self._validate_type_value('integer', new_value_entry) or self._validate_type_value('float',
-                                                                                                           new_value_entry)) is False:
+                elif optional_entry_name in ('minimum', 'maximum'):
+                    if (self._validate_type_value('integer', new_value_entry) or self._validate_type_value(
+                            'float', new_value_entry)) is False:
                         raise ValueError('For {} category, entry value must be an integer or float for optional item '
                                          '{}; got {}'.format(category_name, optional_entry_name, type(new_value_entry)))
                 elif optional_entry_name in ('displayName', 'group', 'rule', 'validity'):

--- a/tests/unit/python/fledge/common/test_configuration_manager.py
+++ b/tests/unit/python/fledge/common/test_configuration_manager.py
@@ -35,7 +35,7 @@ class TestConfigurationManager:
 
     def test_supported_validate_type_strings(self):
         expected_types = ['IPv4', 'IPv6', 'JSON', 'URL', 'X509 certificate', 'boolean', 'code', 'enumeration', 'float', 'integer',
-                'northTask', 'password', 'script', 'string', 'ACL']
+                'northTask', 'password', 'script', 'string', 'ACL', 'bucket']
         assert len(expected_types) == len(_valid_type_strings)
         assert sorted(expected_types) == _valid_type_strings
 

--- a/tests/unit/python/fledge/common/test_configuration_manager.py
+++ b/tests/unit/python/fledge/common/test_configuration_manager.py
@@ -539,11 +539,15 @@ class TestConfigurationManager:
         ("string", " ", False),
         ("JSON", "", False),
         ("JSON", " ", False),
+        ("bucket", "", False),
+        ("bucket", " ", False),
         ("integer", " ", True),
         ("string", "", True),
         ("string", " ", True),
         ("JSON", "", True),
-        ("JSON", " ", True)
+        ("JSON", " ", True),
+        ("bucket", "", True),
+        ("bucket", " ", True)
     ])
     async def test__validate_category_val_with_optional_mandatory(self, _type, value, from_default_val):
         storage_client_mock = MagicMock(spec=StorageClientAsync)
@@ -554,7 +558,8 @@ class TestConfigurationManager:
             await c_mgr._validate_category_val(category_name=CAT_NAME, category_val=test_config,
                                                set_value_val_from_default_val=from_default_val)
         assert excinfo.type is ValueError
-        assert "For {} category, A default value must be given for {}".format(CAT_NAME, ITEM_NAME) == str(excinfo.value)
+        assert ("For {} category, A default value must be given for {}"
+                "").format(CAT_NAME, ITEM_NAME) == str(excinfo.value)
 
     async def test__validate_category_val_with_enum_type(self, reset_singleton):
         storage_client_mock = MagicMock(spec=StorageClientAsync)
@@ -3476,7 +3481,8 @@ class TestConfigurationManager:
         (None, 'group', 5,
          "For catname category, entry value must be string for optional item group; got <class 'int'>"),
         (None, 'group', True,
-         "For catname category, entry value must be string for optional item group; got <class 'bool'>")
+         "For catname category, entry value must be string for optional item group; got <class 'bool'>"),
+        (None, 'properties', '{"foo": "bar"}', 'For catname category, optional item name properties cannot be updated.')
     ])
     async def test_set_optional_value_entry_bad_update(self, reset_singleton, _type, optional_key_name,
                                                        new_value_entry, exc_msg):
@@ -3497,7 +3503,8 @@ class TestConfigurationManager:
         storage_value_entry = {'length': '255', 'displayName': category_name, 'rule': 'value * 3 == 6',
                                'deprecated': 'false', 'readonly': 'true', 'type': 'string', 'order': '4',
                                'description': 'Test Optional', 'minimum': minimum, 'value': '13', 'maximum': maximum,
-                               'default': '13', 'validity': 'field X is set', 'mandatory': 'false', 'group': 'Security'}
+                               'default': '13', 'validity': 'field X is set', 'mandatory': 'false', 'group': 'Security',
+                               'properties': "{}"}
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:


### PR DESCRIPTION
[bucket_payload.json](https://github.com/fledge-iot/fledge/files/13437341/bucket_payload.json)


**Curl Examples**

- Create
```
$ curl -sX POST http://localhost:8081/fledge/category -d @bucket_payload.json 

{"key": "bucket", "description": "description", "value": {"model": {"description": "The machine learning model to use inspect the captured image for defects", "displayName": "QA Model", "order": "2", "type": "bucket", "properties": "{\"constant\": {\"type\": \"MLModel\",\"name\": \"BadBottle\"}, \"key\": {\"product\": {\"description\": \"The bottle type being produced\", \"displayName\": \"Bottle Type\",\"type\": \"enumeration\",\"options\": [\"Wine Bottle\",\"Bear Bottle\",\"Whiskey Bottle\",\"Milk Bottle\"],\"default\": \"Milk Bottle\"}},\"properties\": {\"version\": {\"description\": \"The model version to use, 0 represents the latest version\",\"displayName\": \"Version\",\"type\": \"string\",\"default\": \"\"}}", "default": "{\"type\" : \"MLModel\", \"name\" : \"BadBottle\", \"product\" : \"Wine Bottle\", \"version\" : \"0\"}", "value": "{\"type\" : \"MLModel\", \"name\" : \"BadBottle\", \"product\" : \"Wine Bottle\", \"version\" : \"0\"}"}}, "displayName": "bucket"}aj@aj-Thi
```
- GET

```
$ curl -sX GET http://localhost:8081/fledge/category/bucket | jq
{
  "model": {
    "description": "The machine learning model to use inspect the captured image for defects",
    "displayName": "QA Model",
    "order": "2",
    "type": "bucket",
    "properties": "{\"constant\": {\"type\": \"MLModel\",\"name\": \"BadBottle\"}, \"key\": {\"product\": {\"description\": \"The bottle type being produced\", \"displayName\": \"Bottle Type\",\"type\": \"enumeration\",\"options\": [\"Wine Bottle\",\"Bear Bottle\",\"Whiskey Bottle\",\"Milk Bottle\"],\"default\": \"Milk Bottle\"}},\"properties\": {\"version\": {\"description\": \"The model version to use, 0 represents the latest version\",\"displayName\": \"Version\",\"type\": \"string\",\"default\": \"\"}}",
    "default": "{\"type\" : \"MLModel\", \"name\" : \"BadBottle\", \"product\" : \"Wine Bottle\", \"version\" : \"0\"}",
    "value": "{\"type\" : \"MLModel\", \"name\" : \"BadBottle\", \"product\" : \"Wine Bottle\", \"version\" : \"0\"}"
  }
}

```
- Update

```
$ curl -sX PUT http://localhost:8081/fledge/category/bucket -d '{"model":"{\"type\" : \"MLModel\", \"name\" : \"BadBottle\", \"product\" : \"Bear Bottle\", \"version\" : \"0\"}"}' | jq
{
  "model": {
    "description": "The machine learning model to use inspect the captured image for defects",
    "displayName": "QA Model",
    "order": "2",
    "type": "bucket",
    "properties": "{\"constant\": {\"type\": \"MLModel\",\"name\": \"BadBottle\"}, \"key\": {\"product\": {\"description\": \"The bottle type being produced\", \"displayName\": \"Bottle Type\",\"type\": \"enumeration\",\"options\": [\"Wine Bottle\",\"Bear Bottle\",\"Whiskey Bottle\",\"Milk Bottle\"],\"default\": \"Milk Bottle\"}},\"properties\": {\"version\": {\"description\": \"The model version to use, 0 represents the latest version\",\"displayName\": \"Version\",\"type\": \"string\",\"default\": \"\"}}",
    "default": "{\"type\" : \"MLModel\", \"name\" : \"BadBottle\", \"product\" : \"Wine Bottle\", \"version\" : \"0\"}",
    "value": "{\"type\" : \"MLModel\", \"name\" : \"BadBottle\", \"product\" : \"Bear Bottle\", \"version\" : \"0\"}"
  }
}

```
- GET

```
$ curl -sX GET http://localhost:8081/fledge/category/bucket | jq
{
  "model": {
    "description": "The machine learning model to use inspect the captured image for defects",
    "displayName": "QA Model",
    "order": "2",
    "type": "bucket",
    "properties": "{\"constant\": {\"type\": \"MLModel\",\"name\": \"BadBottle\"}, \"key\": {\"product\": {\"description\": \"The bottle type being produced\", \"displayName\": \"Bottle Type\",\"type\": \"enumeration\",\"options\": [\"Wine Bottle\",\"Bear Bottle\",\"Whiskey Bottle\",\"Milk Bottle\"],\"default\": \"Milk Bottle\"}},\"properties\": {\"version\": {\"description\": \"The model version to use, 0 represents the latest version\",\"displayName\": \"Version\",\"type\": \"string\",\"default\": \"\"}}",
    "default": "{\"type\" : \"MLModel\", \"name\" : \"BadBottle\", \"product\" : \"Wine Bottle\", \"version\" : \"0\"}",
    "value": "{\"type\" : \"MLModel\", \"name\" : \"BadBottle\", \"product\" : \"Bear Bottle\", \"version\" : \"0\"}"
  }
}

```

**Scenario2**

Add service with dummy bucket type in sinusoid plugin (For test purpose)

```
curl -sX POST http://localhost:8081/fledge/service -d '{"name":"Test-bucket-type","type":"south","plugin":"sinusoid","config":{"assetName":{"description":"Name of Asset","type":"string","default":"sinusoid","displayName":"Asset name","mandatory":"true","key":"assetName","value":"sinusoid"},"model":{"description":"The machine learning model to use inspect the captured image for defects","displayName":"QA Model","order":"3","type":"bucket","properties":"{\"constant\": {\"type\": \"MLModel\",\"name\": \"BadBottle\"}, \"key\": {\"product\": {\"description\": \"The bottle type being produced\", \"displayName\": \"Bottle Type\",\"type\": \"enumeration\",\"options\": [\"Wine Bottle\",\"Bear Bottle\",\"Whiskey Bottle\",\"Milk Bottle\"],\"default\": \"Milk Bottle\"}},\"properties\": {\"version\": {\"description\": \"The model version to use, 0 represents the latest version\",\"displayName\": \"Version\",\"type\": \"string\",\"default\": \"\"}}}","default":"{\"type\": \"MLModel\",\"name\": \"BadBottle\",\"product\": \"Wine Bottle\",\"version\": \"0\" }","key":"model","value":"{\"type\": \"MLModel\",\"name\": \"BadBottle\",\"product\": \"Wine Bottle\",\"version\": \"0\" }"}},"enabled":true}'
```

**NOTE**
You may have noticed some of the errors logs are coming in syslog

```
ERROR: logger: fledge.common.configuration_manager: Unable to create new category based on category_name Test-bucket-type and category_description Test-bucket-type and category_json_schema
Nov 22 15:00:56 aj-ThinkPad-E450 Fledge Test-bucket-type[31822]: ERROR: Failed to parse result of adding a category: 400: 'For Test-bucket-type category, properties KV pair must be required for item name model.'
```
Reason is  from the merge category value scenario which will be called by the microservice. I have raised a JIRA FOGL-8281. Once we will have this support available in C side, these logs will not appear