### PR TITLE
FOGL-8354 bucket properties converted to JSON object rather a string type in configuration manager

### DIFF
--- a/C/common/include/service_record.h
+++ b/C/common/include/service_record.h
@@ -45,6 +45,10 @@ class ServiceRecord : public JSONProvider {
 					{
 						m_protocol = protocol;
 					}
+		const std::string&	getProtocol() const
+					{
+						return m_protocol;
+					}
 		void			setManagementPort(const unsigned short managementPort)
 					{
 						m_managementPort = managementPort;

--- a/python/fledge/common/configuration_manager.py
+++ b/python/fledge/common/configuration_manager.py
@@ -268,7 +268,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
 
             optional_item_entries = {'readonly': 0, 'order': 0, 'length': 0, 'maximum': 0, 'minimum': 0,
                                      'deprecated': 0, 'displayName': 0, 'rule': 0, 'validity': 0, 'mandatory': 0,
-                                     'group': 0, 'properties': 0}
+                                     'group': 0}
             expected_item_entries = {'description': 0, 'default': 0, 'type': 0}
 
             if require_entry_value:
@@ -308,10 +308,24 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                             raise TypeError('For {} category, entry value must be a string for item name {} and '
                                             'entry name {}; got {}'.format(category_name, item_name, entry_name,
                                                                            type(entry_val)))
-                elif 'type' in item_val and entry_val == 'bucket':
+                # Validate bucket type and mandatory properties item_name
+                elif 'type' in item_val and get_entry_val("type") == 'bucket':
                     if 'properties' not in item_val:
                         raise KeyError('For {} category, properties KV pair must be required '
                                        'for item name {}.'.format(category_name, item_name))
+                    if entry_name == 'properties':
+                        prop_val = get_entry_val('properties')
+                        if not isinstance(prop_val, dict):
+                            raise ValueError('For {} category, properties must be JSON object for item name {}; got {}'
+                                             .format(category_name, item_name, type(entry_val)))
+                        if not prop_val:
+                            raise ValueError('For {} category, properties JSON object cannot be empty for item name {}'
+                                             ''.format(category_name, item_name))
+                        if 'key' not in prop_val:
+                            raise ValueError('For {} category, key KV pair must exist in properties for item name {}'
+                                             ''.format(category_name, item_name))
+                        d = {entry_name: entry_val}
+                        expected_item_entries.update(d)
                 else:
                     if type(entry_val) is not str:
                         raise TypeError('For {} category, entry value must be a string for item name {} and '
@@ -335,7 +349,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                                                                                                          entry_val)) is False:
                             raise ValueError('For {} category, entry value must be an integer or float for item name '
                                              '{}; got {}'.format(category_name, entry_name, type(entry_val)))
-                    elif entry_name in ('displayName', 'group', 'rule', 'validity', 'properties'):
+                    elif entry_name in ('displayName', 'group', 'rule', 'validity'):
                         if not isinstance(entry_val, str):
                             raise ValueError('For {} category, entry value must be string for item name {}; got {}'
                                              .format(category_name, entry_name, type(entry_val)))

--- a/python/fledge/common/configuration_manager.py
+++ b/python/fledge/common/configuration_manager.py
@@ -326,6 +326,11 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                                              ''.format(category_name, item_name))
                         d = {entry_name: entry_val}
                         expected_item_entries.update(d)
+                    else:
+                        if type(entry_val) is not str:
+                            raise TypeError('For {} category, entry value must be a string for item name {} and '
+                                            'entry name {}; got {}'.format(category_name, item_name, entry_name,
+                                                                           type(entry_val)))
                 else:
                     if type(entry_val) is not str:
                         raise TypeError('For {} category, entry value must be a string for item name {} and '

--- a/tests/unit/python/fledge/common/test_configuration_manager.py
+++ b/tests/unit/python/fledge/common/test_configuration_manager.py
@@ -565,6 +565,9 @@ class TestConfigurationManager:
         ({ITEM_NAME: {"description": "test description", "type": "bucket", "default": "A", "properties": {"k": "v"}}},
          ValueError, "For {} category, key KV pair must exist in properties for item name {}".format(
             CAT_NAME, ITEM_NAME)),
+        ({ITEM_NAME: {"description": "test description", "type": "bucket", "default": {}, "properties": {"key": "v"}}},
+         TypeError, "For {} category, entry value must be a string for item name {} and entry name default; "
+                    "got <class 'dict'>".format(CAT_NAME, ITEM_NAME))
     ])
     async def test__validate_category_val_bucket_type_bad(self, config, exc_name, reason):
         storage_client_mock = MagicMock(spec=StorageClientAsync)

--- a/tests/unit/python/fledge/common/test_configuration_manager.py
+++ b/tests/unit/python/fledge/common/test_configuration_manager.py
@@ -547,21 +547,33 @@ class TestConfigurationManager:
                                                set_value_val_from_default_val=True)
         assert isinstance(c_return_value, dict)
 
-    @pytest.mark.parametrize("config", [
-        ({ITEM_NAME: {"description": "test description", "type": "bucket", "default": "A"}}),
-        ({ITEM_NAME: {"description": "test description", "type": "bucket", "default": "A", "property": '{"a": 1}'}}),
+    @pytest.mark.parametrize("config, exc_name, reason", [
+        ({ITEM_NAME: {"description": "test description", "type": "bucket", "default": "A"}}, KeyError,
+         "'For {} category, properties KV pair must be required for item name {}.'".format(CAT_NAME, ITEM_NAME)),
+        ({ITEM_NAME: {"description": "test description", "type": "bucket", "default": "A", "property": '{"a": 1}'}},
+         KeyError, "'For {} category, properties KV pair must be required for item name {}.'".format(
+            CAT_NAME, ITEM_NAME)),
         ({"item": {"description": "test description", "type": "string", "default": "A", "value": "B"},
-          ITEM_NAME: {"description": "test description", "type": "bucket", "default": "A"}})
+          ITEM_NAME: {"description": "test description", "type": "bucket", "default": "A"}}, KeyError,
+         "'For {} category, properties KV pair must be required for item name {}.'".format(CAT_NAME, ITEM_NAME)),
+        ({ITEM_NAME: {"description": "test description", "type": "bucket", "default": "A", "properties": '{"a": 1}'}},
+         ValueError, "For {} category, properties must be JSON object for item name {}; got <class 'str'>".format(
+            CAT_NAME, ITEM_NAME)),
+        ({ITEM_NAME: {"description": "test description", "type": "bucket", "default": "A", "properties": {}}},
+         ValueError, "For {} category, properties JSON object cannot be empty for item name {}".format(
+            CAT_NAME, ITEM_NAME)),
+        ({ITEM_NAME: {"description": "test description", "type": "bucket", "default": "A", "properties": {"k": "v"}}},
+         ValueError, "For {} category, key KV pair must exist in properties for item name {}".format(
+            CAT_NAME, ITEM_NAME)),
     ])
-    async def test__validate_category_val_bucket_type_bad(self, config):
+    async def test__validate_category_val_bucket_type_bad(self, config, exc_name, reason):
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        msg = "'For test category, properties KV pair must be required for item name {}.'".format(ITEM_NAME)
         with pytest.raises(Exception) as excinfo:
             await c_mgr._validate_category_val(category_name=CAT_NAME, category_val=config,
                                                set_value_val_from_default_val=False)
-        assert excinfo.type is KeyError
-        assert msg == str(excinfo.value)
+        assert excinfo.type is exc_name
+        assert reason == str(excinfo.value)
         
     @pytest.mark.parametrize("_type, value, from_default_val", [
         ("integer", " ", False),
@@ -585,7 +597,7 @@ class TestConfigurationManager:
         test_config = {ITEM_NAME: {"description": "test description", "type": _type, "default": value,
                                    "mandatory": "true"}}
         if _type == "bucket":
-            test_config[ITEM_NAME]['properties'] = '{"foo": "bar"}'
+            test_config[ITEM_NAME]['properties'] = {"key": "foo"}
         with pytest.raises(Exception) as excinfo:
             await c_mgr._validate_category_val(category_name=CAT_NAME, category_val=test_config,
                                                set_value_val_from_default_val=from_default_val)
@@ -3514,7 +3526,7 @@ class TestConfigurationManager:
          "For catname category, entry value must be string for optional item group; got <class 'int'>"),
         (None, 'group', True,
          "For catname category, entry value must be string for optional item group; got <class 'bool'>"),
-        (None, 'properties', '{"foo": "bar"}', 'For catname category, optional item name properties cannot be updated.')
+        (None, 'properties', {"key": "Bot"}, 'For catname category, optional item name properties cannot be updated.')
     ])
     async def test_set_optional_value_entry_bad_update(self, reset_singleton, _type, optional_key_name,
                                                        new_value_entry, exc_msg):
@@ -3536,7 +3548,7 @@ class TestConfigurationManager:
                                'deprecated': 'false', 'readonly': 'true', 'type': 'string', 'order': '4',
                                'description': 'Test Optional', 'minimum': minimum, 'value': '13', 'maximum': maximum,
                                'default': '13', 'validity': 'field X is set', 'mandatory': 'false', 'group': 'Security',
-                               'properties': "{}"}
+                               'properties': {"key": "model"}}
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
@@ -3548,6 +3560,7 @@ class TestConfigurationManager:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
                 with pytest.raises(Exception) as excinfo:
                     await c_mgr.set_optional_value_entry(category_name, item_name, optional_key_name, new_value_entry)
+
                 assert excinfo.type is ValueError
                 assert exc_msg == str(excinfo.value)
             readpatch.assert_called_once_with(category_name, item_name)


### PR DESCRIPTION
**Tested With below samples**

[bucket_payload.json](https://github.com/fledge-iot/fledge/files/13741532/bucket_payload.json)
[FOGL-8349.json](https://github.com/fledge-iot/fledge/files/13741577/FOGL-8349.json)


Run the below script for POST, PUT, GET operations with above examples

[FOGL-8354.zip](https://github.com/fledge-iot/fledge/files/13741628/FOGL-8354.zip)

`sh FOGL-8354.sh`


**GET Response**
```
With Sample1:
{
  "model": {
    "description": "The machine learning model to use inspect the captured image for defects",
    "displayName": "QA Model",
    "order": "2",
    "type": "bucket",
    "properties": {
      "constant": {
        "type": "MLModel",
        "name": "BadBottle"
      },
      "key": {
        "product": {
          "description": "The bottle type being produced",
          "displayName": "Bottle Type",
          "type": "enumeration",
          "options": [
            "Wine Bottle",
            "Beer Bottle",
            "Whiskey Bottle",
            "Milk Bottle"
          ],
          "default": "Milk Bottle"
        }
      },
      "properties": {
        "version": {
          "description": "The model version to use, 0 represents the latest version",
          "displayName": "Version",
          "type": "string",
          "default": ""
        }
      }
    },
    "default": "{\"type\" : \"MLModel\", \"name\" : \"BadBottle\", \"product\" : \"Wine Bottle\", \"version\" : \"0\"}",
    "value": "{\"type\" : \"MLModel\", \"name\" : \"GoodBottle\", \"product\" : \"Beer Bottle\", \"version\" : \"0\"}"
  }
}


With Sample2:

{
  "model": {
    "description": "The model to execute",
    "type": "bucket",
    "properties": {
      "constant": {
        "type": "umetrics"
      },
      "key": {
        "name": {
          "description": "Model name",
          "displayName": "Name",
          "type": "string",
          "default": ""
        }
      },
      "properties": {
        "measurement": {
          "description": "Measurement instrument",
          "displayName": "Measurement",
          "type": "string",
          "default": "NIR"
        }
      }
    },
    "default": "{\"name\": \"Beer\", \"type\": \"umetrics\", \"measurement\": \"NIR\"}",
    "order": "1",
    "displayName": "Model",
    "value": "{\"type\" : \"umetrics\", \"name\": \"Whiskey\", \"measurement\": \"NIR\"}"
  }
}

```