### PR TITLE
FOGL-7649A: Fix documentation of OMF version for PI Web API 2019

### DIFF
--- a/docs/OMF.rst
+++ b/docs/OMF.rst
@@ -684,10 +684,10 @@ These are the OMF versions the plugin will use to post data:
 |           |- 2021 SP3|                     |
 |           |- 2023    |                     |
 +-----------+----------+---------------------+
-|        1.1|- 2019    |                     |
-|           |- 2019 SP1|                     |
+|        1.1|          |                     |
 +-----------+----------+---------------------+
-|        1.0|          |- 2020               |
+|        1.0|- 2019    |- 2020               |
+|           |- 2019 SP1|                     |
 +-----------+----------+---------------------+
 
 The AVEVA Data Hub (ADH) is cloud-deployed and is always at the latest version of OMF support which is 1.2.


### PR DESCRIPTION
There is an error in the OMF North documentation that lists the OMF versions that align with AVEVA product versions ([FOGL-7649](https://scaledb.atlassian.net/browse/FOGL-7649))([Pull Request 1256](https://github.com/fledge-iot/fledge/pull/1256)). The error is in the OMF version applied to PI Web API 2019 (and all SPs): documentation said OMF 1.1; correct version is OMF 1.0.

We could also address this by changing the OMF North code so that we apply OMF 1.1 to the PI Web API 2019 releases. This would be a problem because we would have to retest OMF North with PI Web API 2019 if we do that.

This means that we never use OMF 1.1 to communicate with anything. I left the OMF 1.1 line in the table but it aligns with no AVEVA product versions. I could remove the line.