### PR TITLE
FOGL-8388: Fix endless connection loss log messages and deprecate OMFHint LegacyType

### DIFF
--- a/C/plugins/north/OMF/include/omf.h
+++ b/C/plugins/north/OMF/include/omf.h
@@ -146,7 +146,7 @@ class OMF
 
 		// Method with vector (by reference) of readings
 		uint32_t sendToServer(const std::vector<Reading>& readings,
-				      bool skipSentDataTypes = true);
+				      bool skipSentDataTypes = true); // never called
 
 		// Method with vector (by reference) of reading pointers
 		uint32_t sendToServer(const std::vector<Reading *>& readings,
@@ -154,11 +154,11 @@ class OMF
 
 		// Send a single reading (by reference)
 		uint32_t sendToServer(const Reading& reading,
-				      bool skipSentDataTypes = true);
+				      bool skipSentDataTypes = true); // never called
 
 		// Send a single reading pointer
 		uint32_t sendToServer(const Reading* reading,
-				      bool skipSentDataTypes = true);
+				      bool skipSentDataTypes = true); // never called
 
 		// Set saved OMF formats
 		void setFormatType(const std::string &key, std::string &value);
@@ -230,9 +230,6 @@ class OMF
 
 		bool getAFMapEmptyNames() const { return m_AFMapEmptyNames; };
 		bool getAFMapEmptyMetadata() const { return m_AFMapEmptyMetadata; };
-
-		bool getConnected() const { return m_connected; };
-		void setConnected(const bool connectionStatus);
 
 		void setLegacyMode(bool legacy) { m_legacy = legacy; };
 
@@ -395,7 +392,6 @@ private:
 		bool            m_AFMapEmptyMetadata;
 		std::string		m_AFHierarchyLevel;
 		std::string		m_prefixAFAsset;
-		bool            m_connected;  // true if calls to PI Web API are working 
 
 		vector<std::string>  m_afhHierarchyAlreadyCreated={
 

--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -1095,10 +1095,6 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 	string AFHierarchyLevel;
 	string measurementId;
 
-	string varValue;
-	string varDefault;
-	bool variablePresent;
-
 #if INSTRUMENT
 	ostringstream threadId;
 	threadId << std::this_thread::get_id();
@@ -1160,8 +1156,6 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 	string OMFHintAFHierarchyTmp;
 	string OMFHintAFHierarchy;
 
-	bool legacyType = m_legacy;
-
 	// Create the class that deals with the linked data generation
 	OMFLinkedData linkedData(&m_linkedAssetState, m_PIServerEndpoint);
 	linkedData.setSendFullStructure(m_sendFullStructure);
@@ -1197,14 +1191,8 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 					Logger::getLogger()->info("Using OMF Tag hint: %s", (*it)->getHint().c_str());
 					keyComplete.append("_" + (*it)->getHint());
 					usingTagHint = true;
-					break;
 				}
-
-				varValue="";
-				varDefault="";
-				variablePresent=false;
-
-				if (typeid(**it) == typeid(OMFAFLocationHint))
+				else if (typeid(**it) == typeid(OMFAFLocationHint))
 				{
 					OMFHintAFHierarchyTmp = (*it)->getHint();
 					OMFHintAFHierarchy = variableValueHandle(*reading, OMFHintAFHierarchyTmp);
@@ -1214,14 +1202,9 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 						,OMFHintAFHierarchyTmp.c_str()
 						,OMFHintAFHierarchy.c_str() );
 				}
-			}
-			for (auto it = omfHints.cbegin(); it != omfHints.cend(); it++)
-			{
-				if (typeid(**it) == typeid(OMFLegacyTypeHint))
+				else if (typeid(**it) == typeid(OMFLegacyTypeHint))
 				{
-					Logger::getLogger()->info("Using OMF Legacy Type hint: %s", (*it)->getHint().c_str());
-					legacyType = true;
-					break;
+					Logger::getLogger()->warn("OMFHint LegacyType has been deprecated. The hint value '%s' will be ignored.", (*it)->getHint().c_str());
 				}
 			}
 		}
@@ -1279,7 +1262,7 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 		// Use old style complex types if the user has forced it via configuration,
 		// we are running against an EDS endpoint or Connector Relay or we have types defined for this
 		// asset already
-		if (legacyType || m_PIServerEndpoint == ENDPOINT_EDS || 
+		if (m_legacy || m_PIServerEndpoint == ENDPOINT_EDS || 
 		        m_PIServerEndpoint == ENDPOINT_CR ||
 				m_OMFDataTypes->find(keyComplete) != m_OMFDataTypes->end())
 		{

--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -244,7 +244,6 @@ OMF::OMF(const string& name,
 	m_changeTypeId = false;
 	m_OMFDataTypes = NULL;
 	m_OMFVersion = "1.0";
-	m_connected = false;
 }
 
 /**
@@ -272,7 +271,6 @@ OMF::OMF(const string& name,
 
 	m_lastError = false;
 	m_changeTypeId = false;
-	m_connected = false;
 }
 
 // Destructor
@@ -421,7 +419,6 @@ bool OMF::sendDataTypes(const Reading& row, OMFHints *hints)
 		string msg = "An error occurred sending the dataType message for the asset " + assetName
 				+ ". " + errorMsg;
 		reportAsset(assetName, "error", msg);
-		m_connected = false;
 		return false;
 	}
 
@@ -488,10 +485,9 @@ bool OMF::sendDataTypes(const Reading& row, OMFHints *hints)
 	{
 		string errorMsg = errorMessageHandler(e.what());
 
-		string msg = "An error occurred sending the dataType message for the asset " + assetName
+		string msg = "An error occurred sending the dataType container message for the asset " + assetName
 				+ ". " + errorMsg;
 		reportAsset(assetName, "error", msg);
-		m_connected = false;
 		return false;
 	}
 
@@ -519,7 +515,7 @@ bool OMF::sendDataTypes(const Reading& row, OMFHints *hints)
 				return false;
 			}
 		}
-		// Exception raised fof HTTP 400 Bad Request
+		// Exception raised for HTTP 400 Bad Request
 		catch (const BadRequest& e)
 		{
 			OMFError error(m_sender.getHTTPResponse());
@@ -558,7 +554,6 @@ bool OMF::sendDataTypes(const Reading& row, OMFHints *hints)
 			string msg = "An error occurred sending the dataType staticData message for the asset " + assetName
 					+ ". " + errorMsg;
 			reportAsset(assetName, "debug", msg);
-			m_connected = false;
 			return false;
 		}
 
@@ -650,7 +645,7 @@ bool OMF::sendDataTypes(const Reading& row, OMFHints *hints)
 				{
 					string errorMsg = errorMessageHandler(e.what());
 
-					string msg = "An error occurred sending the dataType staticData message for the asset " + assetName
+					string msg = "An error occurred sending the dataType link message for the asset " + assetName
 							+ ". " + errorMsg;
 					reportAsset(assetName, "debug", msg);
 					return false;
@@ -711,7 +706,6 @@ bool OMF::AFHierarchySendMessage(const string& msgType, string& jsonData, const 
 	{
 		success = false;
 		errorMessage = ex.what();
-		m_connected = false;
 	}
 
 	if (! success)
@@ -957,7 +951,7 @@ bool OMF::sendAFHierarchy(string AFHierarchy)
  */
 bool OMF::sendAFHierarchyLevels(string parentPath, string path, std::string &lastLevel) {
 
-	bool success;
+	bool success = true;
 	std::string level;
 	std::string previousLevel;
 
@@ -1001,10 +995,14 @@ bool OMF::sendAFHierarchyLevels(string parentPath, string path, std::string &las
 			levelPath = StringSlashFix(levelPath);
 			prefixId = generateUniquePrefixId(levelPath);
 
-			success = sendAFHierarchyTypes(level, prefixId);
-			if (success)
+			if (!sendAFHierarchyTypes(level, prefixId))
 			{
-				success = sendAFHierarchyStatic(level, prefixId);
+				return false;
+			}
+
+			if (!sendAFHierarchyStatic(level, prefixId))
+			{
+				return false;
 			}
 
 			// Creates the link between the AF level
@@ -1013,7 +1011,10 @@ bool OMF::sendAFHierarchyLevels(string parentPath, string path, std::string &las
 				parentPathFixed = StringSlashFix(previousLevelPath);
 				prefixIdParent = generateUniquePrefixId(parentPathFixed);
 
-				sendAFHierarchyLink(previousLevel, level, prefixIdParent, prefixId);
+				if (!sendAFHierarchyLink(previousLevel, level, prefixIdParent, prefixId))
+				{
+					return false;
+				}
 			}
 			previousLevelPath = levelPath;
 			previousLevel = level;
@@ -1243,15 +1244,7 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 		// hint is present it will override any default AFLocation or AF Location rules defined in the north plugin configuration.
 		if ( ! createAFHierarchyOmfHint(m_assetName, OMFHintAFHierarchy) )
 		{
-			if (m_connected)
-			{
-				if (!evaluateAFHierarchyRules(m_assetName, *reading))
-				{
-					m_lastError = true;
-					return 0;
-				}
-			}
-			else
+			if (!evaluateAFHierarchyRules(m_assetName, *reading))
 			{
 				m_lastError = true;
 				return 0;
@@ -1643,7 +1636,6 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 
 		// Failure
 		m_lastError = true;
-		m_connected = false;
 		return 0;
 	}
 }
@@ -1761,7 +1753,6 @@ uint32_t OMF::sendToServer(const vector<Reading>& readings,
 					   m_path.c_str(),
 					   jsonData.str().c_str() );
 
-		m_connected = false;
 		return false;
 	}
 
@@ -1853,7 +1844,6 @@ uint32_t OMF::sendToServer(const Reading* reading,
 					   m_sender.getHostPort().c_str(),
 					   m_path.c_str() );
 
-		m_connected = false;
 		return false;
 	}
 
@@ -2806,6 +2796,10 @@ bool OMF::evaluateAFHierarchyRules(const string& assetName, const Reading& readi
 								,path.c_str()
 								,it->second.c_str());
 					}
+					else
+					{
+						return false;
+					}
 				} else {
 					Logger::getLogger()->debug(
 						"%s - m_NamesRules skipped pathInitial :%s: path :%s: stored :%s:"
@@ -2857,6 +2851,10 @@ bool OMF::evaluateAFHierarchyRules(const string& assetName, const Reading& readi
 						{
 							m_AssetNamePrefix[assetName].push_back(item);
 							Logger::getLogger()->debug("%s - m_MetadataRulesExist asset :%s: path added :%s: :%s:" , __FUNCTION__, assetName.c_str(), pathInitial.c_str()  , path.c_str() );
+						}
+						else
+						{
+							return false;
 						}
 					} else {
 						Logger::getLogger()->debug("%s - m_MetadataRulesExist already created asset :%s: path added :%s: :%s:" , __FUNCTION__, assetName.c_str(), pathInitial.c_str()  , path.c_str() );
@@ -2910,6 +2908,10 @@ bool OMF::evaluateAFHierarchyRules(const string& assetName, const Reading& readi
 						{
 							m_AssetNamePrefix[assetName].push_back(item);
 							Logger::getLogger()->debug("%s - m_MetadataRulesNonExist - asset :%s: path added :%s: :%s:" , __FUNCTION__, assetName.c_str(), pathInitial.c_str()  , path.c_str() );
+						}
+						else
+						{
+							return false;
 						}
 					} else {
 						Logger::getLogger()->debug("%s - m_MetadataRulesNonExist -  already created asset :%s: path added :%s: :%s:" , __FUNCTION__, assetName.c_str(), pathInitial.c_str()  , path.c_str() );
@@ -2975,6 +2977,10 @@ bool OMF::evaluateAFHierarchyRules(const string& assetName, const Reading& readi
 						{
 							m_AssetNamePrefix[assetName].push_back(item);
 							Logger::getLogger()->debug("%s - m_MetadataRulesEqual asset :%s: path added :%s: :%s:" , __FUNCTION__, assetName.c_str(), pathInitial.c_str()  , path.c_str() );
+						}
+						else
+						{
+							return false;
 						}
 					} else {
 						Logger::getLogger()->debug("%s - m_MetadataRulesEqual already created asset :%s: path added :%s: :%s:" , __FUNCTION__, assetName.c_str(), pathInitial.c_str()  , path.c_str() );
@@ -3043,6 +3049,10 @@ bool OMF::evaluateAFHierarchyRules(const string& assetName, const Reading& readi
 						{
 							m_AssetNamePrefix[assetName].push_back(item);
 							Logger::getLogger()->debug("%s - m_MetadataRulesNotEqual asset :%s: path added :%s: :%s:" , __FUNCTION__, assetName.c_str(), pathInitial.c_str()  , path.c_str() );
+						}
+						else
+						{
+							return false;
 						}
 					} else {
 						Logger::getLogger()->debug("%s - m_MetadataRulesNotEqual already created asset :%s: path added :%s: :%s:" , __FUNCTION__, assetName.c_str(), pathInitial.c_str()  , path.c_str() );
@@ -4813,7 +4823,6 @@ bool OMF::sendBaseTypes()
 									errorMsg.c_str(),
 									m_sender.getHostPort().c_str(),
 									m_path.c_str());
-		m_connected = false;
 		return false;
 	}
 	Logger::getLogger()->debug("Base types successfully sent");
@@ -4901,27 +4910,4 @@ void OMF::reportAsset(const string& asset, const string& level, const string& ms
 		else
 			Logger::getLogger()->debug(msg);
 	}
-}
-
-/**
- * Set the connection state
- *
- * @param connectionStatus	The target connection status
- */
-void OMF::setConnected(const bool connectionStatus)
-{
-	if (connectionStatus != m_connected)
-	{
-		// Send an audit event for the change of state
-		string data = "{ \"plugin\" : \"OMF\", \"service\" : \"" + m_name + "\" }";
-		if (!connectionStatus)
-		{
-			AuditLogger::auditLog("NHDWN", "ERROR", data);
-		}
-		else
-		{
-			AuditLogger::auditLog("NHAVL", "INFORMATION", data);
-		}
-	}
-	m_connected = connectionStatus;
 }

--- a/C/plugins/north/OMF/omfinfo.cpp
+++ b/C/plugins/north/OMF/omfinfo.cpp
@@ -461,7 +461,6 @@ uint32_t OMFInformation::send(const vector<Reading *>& readings)
 		{
 			// Created a new sender after a connection failure
 			m_omf->setSender(*m_sender);
-			m_omf->setConnected(false);
 		}
 	}
 
@@ -479,7 +478,6 @@ uint32_t OMFInformation::send(const vector<Reading *>& readings)
 		m_omf = new OMF(m_name, *m_sender, m_path, m_assetsDataTypes,
 				m_producerToken);
 
-		m_omf->setConnected(m_connected);
 		m_omf->setSendFullStructure(m_sendFullStructure);
 
 		// Set PIServerEndpoint configuration
@@ -529,15 +527,6 @@ uint32_t OMFInformation::send(const vector<Reading *>& readings)
 					  TYPE_ID_KEY,
 					  m_typeId);
 	}
-
-	// Write a warning if the connection to PI Web API has been lost
-	bool updatedConnected = m_omf->getConnected();
-	if (m_PIServerEndpoint == ENDPOINT_PIWEB_API && m_connected && !updatedConnected)
-	{
-		Logger::getLogger()->warn("Connection to PI Web API at %s has been lost", m_hostAndPort.c_str());
-	}
-	m_connected = updatedConnected;
-
 	
 #if INSTRUMENT
 	Logger::getLogger()->debug("plugin_send elapsed time: %6.3f seconds, NumValues: %u", GetElapsedTime(&startTime), ret);
@@ -1339,51 +1328,52 @@ double OMFInformation::GetElapsedTime(struct timeval *startTime)
 }
 
 /**
- * Check if the PI Web API server is available by reading the product version
+ * Check if the PI Web API server is available by reading the product version every 60 seconds.
+ * Log a message if the connection state changes.
  *
  * @return           Connection status
  */
 bool OMFInformation::IsPIWebAPIConnected()
 {
-	static std::chrono::steady_clock::time_point nextCheck;
-	static bool reported = false;	// Has the state been reported yet
-	static bool reportedState;	// What was the last reported state
+	static std::chrono::steady_clock::time_point nextCheck(std::chrono::steady_clock::time_point::duration::zero());
+	static bool lastConnected = m_connected;	// Previous value of m_connected
 
-	if (!m_connected && m_PIServerEndpoint == ENDPOINT_PIWEB_API)
+	if (m_PIServerEndpoint == ENDPOINT_PIWEB_API)
 	{
 		std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
 
 		if (now >= nextCheck)
 		{
 			int httpCode = PIWebAPIGetVersion(false);
-			if (httpCode >= 400)
+			Logger::getLogger()->debug("PIWebAPIGetVersion: %s HTTP Code: %d Connected: %s LastConnected: %s",
+				m_hostAndPort.c_str(),
+				httpCode,
+				m_connected ? "true" : "false",
+				lastConnected ? "true" : "false");
+
+			if ((httpCode < 200) || (httpCode >= 400))
 			{
 				m_connected = false;
-				now = std::chrono::steady_clock::now();
-				nextCheck = now + std::chrono::seconds(60);
-				Logger::getLogger()->debug("PI Web API %s is not available. HTTP Code: %d", m_hostAndPort.c_str(), httpCode);
-				if (reported == false || reportedState == true)
-				{
-					reportedState = false;
-					reported = true;
-					Logger::getLogger()->error("The PI Web API service %s is not available",
-							m_hostAndPort.c_str());
+				if (lastConnected == true)
+				{		
+					Logger::getLogger()->error("The PI Web API service %s is not available. HTTP Code: %d",
+							m_hostAndPort.c_str(), httpCode);
+					lastConnected = false;
 				}
 			}
 			else
 			{
 				m_connected = true;
 				SetOMFVersion();
-				Logger::getLogger()->info("%s reconnected to %s OMF Version: %s",
-					m_RestServerVersion.c_str(), m_hostAndPort.c_str(), m_omfversion.c_str());
-				if (reported == true || reportedState == false)
+				if (lastConnected == false)
 				{
-					reportedState = true;
-					reported = true;
-					Logger::getLogger()->warn("The PI Web API service %s has become available",
-							m_hostAndPort.c_str());
+					Logger::getLogger()->warn("%s reconnected to %s OMF Version: %s",
+						m_RestServerVersion.c_str(), m_hostAndPort.c_str(), m_omfversion.c_str());
+					lastConnected = true;
 				}
 			}
+
+			nextCheck = now + std::chrono::seconds(60);
 		}
 	}
 	else

--- a/docs/OMF.rst
+++ b/docs/OMF.rst
@@ -522,17 +522,6 @@ Specifies that a specific tag name should be used when storing data in the PI Se
 
    "OMFHint"  : { "tagName" : "AC1246" }
 
-Legacy Type Hint
-~~~~~~~~~~~~~~~~
-
-Use legacy style complex types for this reading rather that the newer linked data types.
-
-.. code-block:: console
-
-   "OMFHint" : { "LegacyType" : "true" }
-
-The allows the older mechanism to be forced for a single asset. See :ref:`Linked_Types`.
-
 Source Hint
 ~~~~~~~~~~~
 


### PR DESCRIPTION
If the OMF North plugin gets an exception when POSTing data to the PI Web API, the plugin would declare the connection to PI broken when it wasn't. This would result in endless connection loss and reconnection messages. This has been fixed. The plugin will now ping the PI Web API every 60 seconds and will determine that connection has been lost if this ping fails.

The _OMFHint LegacyType_ has been deprecated. After a Container has been created in the PI System, it is not possible to change it. This means there is no way to process the _LegacyType_ hint when readings are processed. The only time it is possible to configure the plugin for legacy types is when a plugin instance is created. This is done by checking the _Complex Types_ box in the Fledge GUI. The LegacyType entry in the OMF North documentation page has been removed.

If the _LegacyType_ hint appears in any reading, a warning message will be written saying that this hint type has been deprecated.