### PR TITLE
FOGL-8462 Control Pipeline filter order fixes 

### DIFF
--- a/python/fledge/services/core/api/control_service/pipeline.py
+++ b/python/fledge/services/core/api/control_service/pipeline.py
@@ -593,11 +593,9 @@ async def _update_filters(storage, cp_id, cp_name, cp_filters, db_filters=None):
     cf_mgr = ConfigurationManager(storage)
     new_filters = []
     children = []
-
-    insert_filters = set(cp_filters) - set(db_filters)
-    update_filters = set(cp_filters) & set(db_filters)
-    delete_filters = set(db_filters) - set(cp_filters)
-
+    insert_filters = list(filter(lambda x: x not in db_filters, cp_filters))
+    update_filters = list(filter(lambda x: x in cp_filters, db_filters))
+    delete_filters = list(filter(lambda x: x not in cp_filters, db_filters))
     if insert_filters:
         for fid, fname in enumerate(insert_filters, start=1):
             # get plugin config of filter

--- a/tests/system/python/api/test_service.py
+++ b/tests/system/python/api/test_service.py
@@ -234,7 +234,7 @@ class TestService:
         assert len(jdoc), "No data found"
         assert 'Fledge restart has been scheduled.' == jdoc['message']
 
-        time.sleep(wait_time * 4)
+        time.sleep(wait_time * 7)
         jdoc = get_service(fledge_url, '/fledge/service')
         assert len(jdoc), "No data found"
         assert 4 == len(jdoc['services'])


### PR DESCRIPTION
Previously we calculate the difference of filters between lists with an unordered way. 
In the given fix, list order preserved for filters on CRUD's.

Also fixed one of the service based API tests which _sometimes_ fails on RPi boards. Therefore increased the wait time to avoid red flag in the test report.