### PR TITLE
FOGL-8459 Performance monitors and user alerts endpoint verification in API tests with different users

### DIFF
--- a/tests/system/python/api/test_endpoints_with_different_user_types.py
+++ b/tests/system/python/api/test_endpoints_with_different_user_types.py
@@ -222,7 +222,9 @@ class TestAPIEndpointsWithViewUserType:
         ("POST", "/fledge/notification", 403), ("PUT", "/fledge/notification/N1", 403),
         ("DELETE", "/fledge/notification/N1", 403), ("GET", "/fledge/notification/N1/delivery", 404),
         ("POST", "/fledge/notification/N1/delivery", 403), ("GET", "/fledge/notification/N1/delivery/C1", 404),
-        ("DELETE", "/fledge/notification/N1/delivery/C1", 403)
+        ("DELETE", "/fledge/notification/N1/delivery/C1", 403),
+        # alerts
+        ("GET", "/fledge/alert", 200), ("DELETE", "/fledge/alert", 403), ("DELETE", "/fledge/alert/blah", 403)
     ])
     def test_endpoints(self, fledge_url, method, route_path, http_status_code, storage_plugin):
         conn = http.client.HTTPConnection(fledge_url)
@@ -372,7 +374,9 @@ class TestAPIEndpointsWithDataViewUserType:
         ("POST", "/fledge/notification", 403), ("PUT", "/fledge/notification/N1", 403),
         ("DELETE", "/fledge/notification/N1", 403), ("GET", "/fledge/notification/N1/delivery", 403),
         ("POST", "/fledge/notification/N1/delivery", 403), ("GET", "/fledge/notification/N1/delivery/C1", 403),
-        ("DELETE", "/fledge/notification/N1/delivery/C1", 403)
+        ("DELETE", "/fledge/notification/N1/delivery/C1", 403),
+        # alerts
+        ("GET", "/fledge/alert", 403), ("DELETE", "/fledge/alert", 403), ("DELETE", "/fledge/alert/blah", 403)
     ])
     def test_endpoints(self, fledge_url, method, route_path, http_status_code, storage_plugin):
         conn = http.client.HTTPConnection(fledge_url)
@@ -527,7 +531,9 @@ class TestAPIEndpointsWithControlUserType:
         ("POST", "/fledge/notification", 404), ("PUT", "/fledge/notification/N1", 404),
         ("DELETE", "/fledge/notification/N1", 404), ("GET", "/fledge/notification/N1/delivery", 404),
         ("POST", "/fledge/notification/N1/delivery", 400), ("GET", "/fledge/notification/N1/delivery/C1", 404),
-        ("DELETE", "/fledge/notification/N1/delivery/C1", 404)
+        ("DELETE", "/fledge/notification/N1/delivery/C1", 404),
+        # alerts
+        ("GET", "/fledge/alert", 200), ("DELETE", "/fledge/alert", 200), ("DELETE", "/fledge/alert/blah", 404)
     ])
     def test_endpoints(self, fledge_url, method, route_path, http_status_code, storage_plugin):
         conn = http.client.HTTPConnection(fledge_url)

--- a/tests/system/python/api/test_endpoints_with_different_user_types.py
+++ b/tests/system/python/api/test_endpoints_with_different_user_types.py
@@ -223,6 +223,10 @@ class TestAPIEndpointsWithViewUserType:
         ("DELETE", "/fledge/notification/N1", 403), ("GET", "/fledge/notification/N1/delivery", 404),
         ("POST", "/fledge/notification/N1/delivery", 403), ("GET", "/fledge/notification/N1/delivery/C1", 404),
         ("DELETE", "/fledge/notification/N1/delivery/C1", 403),
+        # performance monitors
+        ("GET", "/fledge/monitors", 200), ("GET", "/fledge/monitors/SVC", 200),
+        ("GET", "/fledge/monitors/Svc/Counter", 200), ("DELETE", "/fledge/monitors", 403),
+        ("DELETE", "/fledge/monitors/SVC", 403), ("DELETE", "/fledge/monitors/Svc/Counter", 403),
         # alerts
         ("GET", "/fledge/alert", 200), ("DELETE", "/fledge/alert", 403), ("DELETE", "/fledge/alert/blah", 403)
     ])
@@ -375,6 +379,10 @@ class TestAPIEndpointsWithDataViewUserType:
         ("DELETE", "/fledge/notification/N1", 403), ("GET", "/fledge/notification/N1/delivery", 403),
         ("POST", "/fledge/notification/N1/delivery", 403), ("GET", "/fledge/notification/N1/delivery/C1", 403),
         ("DELETE", "/fledge/notification/N1/delivery/C1", 403),
+        # performance monitors
+        ("GET", "/fledge/monitors", 403), ("GET", "/fledge/monitors/SVC", 403),
+        ("GET", "/fledge/monitors/Svc/Counter", 403), ("DELETE", "/fledge/monitors", 403),
+        ("DELETE", "/fledge/monitors/SVC", 403), ("DELETE", "/fledge/monitors/Svc/Counter", 403),
         # alerts
         ("GET", "/fledge/alert", 403), ("DELETE", "/fledge/alert", 403), ("DELETE", "/fledge/alert/blah", 403)
     ])
@@ -532,6 +540,10 @@ class TestAPIEndpointsWithControlUserType:
         ("DELETE", "/fledge/notification/N1", 404), ("GET", "/fledge/notification/N1/delivery", 404),
         ("POST", "/fledge/notification/N1/delivery", 400), ("GET", "/fledge/notification/N1/delivery/C1", 404),
         ("DELETE", "/fledge/notification/N1/delivery/C1", 404),
+        # performance monitors
+        ("GET", "/fledge/monitors", 200), ("GET", "/fledge/monitors/SVC", 200),
+        ("GET", "/fledge/monitors/Svc/Counter", 200), ("DELETE", "/fledge/monitors", 200),
+        ("DELETE", "/fledge/monitors/SVC", 200), ("DELETE", "/fledge/monitors/Svc/Counter", 200),
         # alerts
         ("GET", "/fledge/alert", 200), ("DELETE", "/fledge/alert", 200), ("DELETE", "/fledge/alert/blah", 404)
     ])


### PR DESCRIPTION


| User Type  | HTTP VERB | API ENDPOINT | Action
| ------------- | ------------- |------------- |-------------------------|
| Admin  | GET  | <ul><li>/fledge/alert</li><li>/fledge/monitors</li></ul>       |  <ul><li>[x]  Allowed </li> |
| Admin  | DELETE  | <ul><li>/fledge/alert</li><li>/fledge/monitors</li></ul>       | <ul><li>[x]  Allowed </li> |
| Normal  | GET  | <ul><li>/fledge/alert</li><li>/fledge/monitors</li></ul>       |  <ul><li>[x]  Allowed </li> |
| Normal  | DELETE  | <ul><li>/fledge/alert</li><li>/fledge/monitors</li></ul>       | <ul><li>[x]  Allowed </li> |
| Control  | GET  | <ul><li>/fledge/alert</li><li>/fledge/monitors</li></ul>       |  <ul><li>[x]  Allowed </li> |
| Control  | DELETE  | <ul><li>/fledge/alert</li><li>/fledge/monitors</li></ul>       | <ul><li>[x]  Allowed </li> |
| View  | GET  | <ul><li>/fledge/alert</li><li>/fledge/monitors</li></ul>       |  <ul><li>[x]  Allowed </li> |
| View  | DELETE  | <ul><li>/fledge/alert</li><li>/fledge/monitors</li></ul>       | <ul><li>[ ]  Not Allowed </li> |
| Data View  | GET  | <ul><li>/fledge/alert</li><li>/fledge/monitors</li></ul>       |  <ul><li>[ ]  Not Allowed </li> |
| Data View  | DELETE  | <ul><li>/fledge/alert</li><li>/fledge/monitors</li></ul>       | <ul><li>[ ]  Not Allowed </li> |
