### PR TITLE
FOGL-8389: Problem changing data type formats

### DIFF
--- a/docs/OMF.rst
+++ b/docs/OMF.rst
@@ -235,7 +235,7 @@ Formats & Types
 ~~~~~~~~~~~~~~~
 
 The *Formats & Types* tab provides a means to specify the detail types that will be used and the way complex assets are mapped to OMF types to also be configured.
-See the section *Numeric Data Types* below for more information on configuring data types.
+See the section :ref:`Numeric Data Types` for more information on configuring data types.
 
 +--------------+
 | |OMF_Format| |
@@ -465,7 +465,7 @@ Number Format Hints
 A number format hint tells the plugin what number format to use when inserting data
 into the PI Server. The following will cause all numeric data within
 the asset to be written using the format *float32*.
-See the section *Numeric Data Types* below.
+See the section :ref:`Numeric Data Types`.
 
 .. code-block:: console
 
@@ -479,7 +479,7 @@ Integer Format Hints
 An integer format hint tells the plugin what integer format to use when inserting
 data into the PI Server. The following will cause all integer data
 within the asset to be written using the format *integer32*.
-See the section *Numeric Data Types* below.
+See the section :ref:`Numeric Data Types`.
 
 .. code-block:: console
 


### PR DESCRIPTION
The original bug report ([FOGL-8389](https://scaledb.atlassian.net/browse/FOGL-8389)) noted that disabling an _integer_ OMFHint generated errors and caused data to stop flowing to the PI Server. It turns out that OMF causes the PI Server to create AF Attributes and PI Points based on the original data type information. OMF cannot change these data types after the PI entities are created. The only change in this Pull Request is documentation to this effect. A procedure for detecting the problem and repairing the PI Server is included.