### PR TITLE
alert count fixes in both normal and safe mode; as used in Ping response

### DIFF
--- a/python/fledge/services/core/api/common.py
+++ b/python/fledge/services/core/api/common.py
@@ -93,7 +93,11 @@ async def ping(request):
         return 'green'
 
     status_color = services_health_litmus_test()
-    safe_mode = True if server.Server.running_in_safe_mode else False
+    safe_mode = True
+    alert_count = 0
+    if not server.Server.running_in_safe_mode:
+        safe_mode = False
+        alert_count = len(server.Server._alert_manager.alerts)
     version = get_version()
     return web.json_response({'uptime': int(since_started),
                               'dataRead': data_read,
@@ -106,7 +110,7 @@ async def ping(request):
                               'health': status_color,
                               'safeMode': safe_mode,
                               'version': version,
-                              'alerts': len(server.Server._alert_manager.alerts)
+                              'alerts': alert_count
                               })
 
 


### PR DESCRIPTION
```
:~/fledge$ ./scripts/fledge kill; ./scripts/fledge start --safe-mode
Fledge killed.
Starting Fledge v2.3.0 in safe mode........
Fledge started.

~/fledge$ ./scripts/fledge status
Fledge v2.3.0 running in safe mode.
Fledge Uptime:  13 seconds.
Fledge records: 0 read, 0 sent, 0 purged.
Fledge does not require authentication.
=== Fledge services:
fledge.services.core
fledge.services.storage --address=0.0.0.0 --port=46103
=== Fledge tasks:

~/fledge$ curl -sX GET localhost:8081/fledge/ping
{"uptime": 20, "dataRead": 0, "dataSent": 0, "dataPurged": 0, "authenticationOptional": true, "serviceName": "Fledge", "hostName": "ip-10-0-0-163", "ipAddresses": ["10.0.0.163"], "health": "green", "safeMode": true, "version": "2.3.0", "alerts": 0}
```