### PR TITLE
Fix JSON unescaping performance issue

### DIFF
--- a/C/common/json_utils.cpp
+++ b/C/common/json_utils.cpp
@@ -83,44 +83,45 @@ string escaped = subject;
         }
         return escaped;
 }
+
 /**
  * Return unescaped version of a JSON string
  *
  * Routine removes \" inside the string
  * and leading and trailing "
  *
- * @param subject       Input string
+ * @param input         Input string
  * @return              Unescaped string
  */
-std::string JSONunescape(const std::string& subject)
+std::string JSONunescape(const std::string& input)
 {
-        size_t pos = 0;
-        string replace("");
-        string json = subject;
+	std::string output;
+	output.reserve(input.size());
 
-        // Replace '\"' with '"'
-        while ((pos = json.find("\\\"", pos)) != std::string::npos)
-        {
-                json.replace(pos, 1, "");
-        }
-        // Remove leading '"'
-        if (json[0] == '\"')
-        {
-                json.erase(0, 1);
-        }
-        // Remove trailing '"'
-        if (json[json.length() - 1] == '\"')
-        {
-                json.erase(json.length() - 1, 1);
-        }
+	for (size_t i = 0; i < input.size(); ++i)
+	{
+		// skip leading or trailing "
+		if ((i == 0 || i == input.size() -1) && input[i] == '"')
+		{
+		}
+		// \\" -> \"
+		else if (input[i] == '\\' && i + 2 < input.size() && input[i + 1] == '\\' && input[i + 2] == '"')
+		{
+			output.push_back('\\');
+			output.push_back('"');
+			i += 2;
+		}
+		// \" -> "
+		else if (input[i] == '\\' && i + 1 < input.size() && input[i + 1] == '"')
+		{
+			output.push_back('"');
+			++i;
+		}
+		else
+		{
+			output.push_back(input[i]);
+		}
+	}
 
-	// Where we had escaped " characters we now have \\"
-	// replace this with \"
-	pos = 0;
-        while ((pos = json.find("\\\\\"", pos)) != std::string::npos)
-        {
-                json.replace(pos, 3, "\\\"");
-        }
-        return json;
+	return output;
 }
-

--- a/C/common/json_utils.cpp
+++ b/C/common/json_utils.cpp
@@ -103,9 +103,11 @@ std::string JSONunescape(const std::string& input)
 		// skip leading or trailing "
 		if ((i == 0 || i == input.size() -1) && input[i] == '"')
 		{
+			continue;
 		}
+
 		// \\" -> \"
-		else if (input[i] == '\\' && i + 2 < input.size() && input[i + 1] == '\\' && input[i + 2] == '"')
+		if (input[i] == '\\' && i + 2 < input.size() && input[i + 1] == '\\' && input[i + 2] == '"')
 		{
 			output.push_back('\\');
 			output.push_back('"');

--- a/tests/unit/C/common/test_json_utils.cpp
+++ b/tests/unit/C/common/test_json_utils.cpp
@@ -73,3 +73,21 @@ TEST(JsonToVectorString, JSONbad)
 
 	ASSERT_EQ(result, false);
 }
+
+TEST(JsonStringUnescape, LeadingAndTrailingDoubleQuote)
+{
+	string json = R"("value")";
+	ASSERT_EQ("value", JSONunescape(json));
+}
+
+TEST(JsonStringUnescape, UnescapedDoubleQuote)
+{
+	string json = R"({\"key\":\"value\"})";
+	ASSERT_EQ(R"({"key":"value"})", JSONunescape(json));
+}
+
+TEST(JsonStringUnescape, TwoTimesUnescapedDoubleQuote)
+{
+	string json = R"({\\"key\\":\\"value\\"})";
+	ASSERT_EQ(R"({\"key\":\"value\"})", JSONunescape(json));
+}


### PR DESCRIPTION
When escaping a large json string, we get a performance issue. 
I tested with a 30000 assets data exchange json and unescaping last around 20s while with new code only 20ms (1000 times faster).