### PR TITLE
FOGL-8608: New 'Profiling' build type to CMake.

### DIFF
--- a/C/services/north/CMakeLists.txt
+++ b/C/services/north/CMakeLists.txt
@@ -3,6 +3,7 @@ project (North)
 
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb -DPy_DEBUG")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wsign-conversion")
+set(CMAKE_CXX_FLAGS_PROFILING "-O2 -pg")
 set(DLLIB -ldl)
 set(UUIDLIB -luuid)
 set(COMMON_LIB common-lib)
@@ -48,3 +49,15 @@ if(MSYS) #TODO: Is MSYS true when MSVC is true?
         target_link_libraries(${EXEC} ws2_32 wsock32)
     endif()
 endif()
+
+# Set profiling flags if 'Profiling' build
+if(CMAKE_BUILD_TYPE STREQUAL "Profiling")
+    message("Building in Profiling mode")
+    set_target_properties(${EXEC} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS_PROFILING}")
+    # define 'PROFILING' flag used by service to change directory
+    target_compile_definitions(${EXEC} PRIVATE PROFILING=1)
+    set(CMAKE_SHARED_LINKED_FLAGS "${CMAKE_SHARED_LINKED_FLAGS} -O2 -pg")
+    target_link_libraries(${EXEC} -O2 -pg)
+endif()
+
+    

--- a/C/services/north/north.cpp
+++ b/C/services/north/north.cpp
@@ -130,6 +130,13 @@ static int controlOperation(char *operation, int paramCount, char *names[], char
  */
 int main(int argc, char *argv[])
 {
+#ifdef PROFILING
+	char profilePath[200]{0};
+	snprintf(profilePath, sizeof(profilePath), "%s/services/%s_Profile", getenv("FLEDGE_ROOT"), SERVICE_TYPE);
+	mkdir(profilePath, 0777);
+	chdir(profilePath);
+#endif
+
 unsigned short	corePort = 8082;
 string		coreAddress = "localhost";
 bool		daemonMode = true;

--- a/C/services/south/CMakeLists.txt
+++ b/C/services/south/CMakeLists.txt
@@ -4,6 +4,7 @@ project (South)
 
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb -DPy_DEBUG")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wsign-conversion")
+set(CMAKE_CXX_FLAGS_PROFILING "-O2 -pg")
 set(DLLIB -ldl)
 set(UUIDLIB -luuid)
 set(COMMON_LIB common-lib)
@@ -81,3 +82,14 @@ if(MSYS) #TODO: Is MSYS true when MSVC is true?
         target_link_libraries(${EXEC} ws2_32 wsock32)
     endif()
 endif()
+
+# Set profiling flags if 'Profiling' build
+if(CMAKE_BUILD_TYPE STREQUAL "Profiling")
+    message("Building in Profiling mode")
+    set_target_properties(${EXEC} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS_PROFILING}")
+    # define 'PROFILING' flag used by service to change directory
+    target_compile_definitions(${EXEC} PRIVATE PROFILING=1)
+    set(CMAKE_SHARED_LINKED_FLAGS "${CMAKE_SHARED_LINKED_FLAGS} -O2 -pg")
+    target_link_libraries(${EXEC} -O2 -pg)
+endif()
+

--- a/C/services/south/south.cpp
+++ b/C/services/south/south.cpp
@@ -49,6 +49,13 @@ using namespace std;
  */
 int main(int argc, char *argv[])
 {
+#ifdef PROFILING
+	char profilePath[200]{0};
+	snprintf(profilePath, sizeof(profilePath), "%s/services/%s_Profile", getenv("FLEDGE_ROOT"), SERVICE_TYPE);
+	mkdir(profilePath, 0777);
+	chdir(profilePath);
+#endif
+
 unsigned short corePort = 8082;
 string	       coreAddress = "localhost";
 bool	       daemonMode = true;

--- a/C/services/storage/CMakeLists.txt
+++ b/C/services/storage/CMakeLists.txt
@@ -3,6 +3,7 @@ project (Storage)
 
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wsign-conversion")
+set(CMAKE_CXX_FLAGS_PROFILING "-O2 -pg")
 set(DLLIB -ldl)
 set(UUIDLIB -luuid)
 set(COMMON_LIB common-lib)
@@ -47,4 +48,14 @@ if(MSYS) #TODO: Is MSYS true when MSVC is true?
     if(OPENSSL_FOUND)
         target_link_libraries(${EXEC} ws2_32 wsock32)
     endif()
+endif()
+
+# Set profiling flags if 'Profiling' build
+if(CMAKE_BUILD_TYPE STREQUAL "Profiling")
+    message("Building in Profiling mode")
+    set_target_properties(${EXEC} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS_PROFILING}")
+    # define 'PROFILING' flag used by service to change directory
+    target_compile_definitions(${EXEC} PRIVATE PROFILING=1)
+    set(CMAKE_SHARED_LINKED_FLAGS "${CMAKE_SHARED_LINKED_FLAGS} -O2 -pg")
+    target_link_libraries(${EXEC} -O2 -pg)
 endif()

--- a/C/services/storage/storage.cpp
+++ b/C/services/storage/storage.cpp
@@ -88,6 +88,13 @@ int	size;
  */
 int main(int argc, char *argv[])
 {
+#ifdef PROFILING
+	char profilePath[200]{0};
+	snprintf(profilePath, sizeof(profilePath), "%s/services/Storage_Profile", getenv("FLEDGE_ROOT"));
+	mkdir(profilePath, 0777);
+	chdir(profilePath);
+#endif
+
 unsigned short corePort = 8082;
 string	       coreAddress = "localhost";
 bool	       daemonMode = true;


### PR DESCRIPTION
- Added Profiling option to CMake for south/north/storage services.
* Use option  -DCMAKE_BUILD_TYPE=Profiling in Makefile to enable profiling build. Profiling information for each service will be created in seperate folders namely 'Southbound_Profile', 'Northbound_Profile' and 'Storage_Profile', each of these folders will be located in FLEDGE_ROOT/services.