### PR TITLE
FOGL-8899: Fix for double free

### DIFF
--- a/C/plugins/storage/sqlite/common/connection.cpp
+++ b/C/plugins/storage/sqlite/common/connection.cpp
@@ -3037,9 +3037,9 @@ char	tmpbuf[512];
 	va_start(ap, reason);
 	vsnprintf(tmpbuf, sizeof(tmpbuf), reason, ap);
 	va_end(ap);
-	Logger::getLogger()->error("%s storage plugin raising error: %s",
+	Logger::getLogger()->error("%s storage plugin raising error: %s: %s",
 				   PLUGIN_LOG_NAME,
-				   tmpbuf);
+				   operation, tmpbuf);
 	manager->setError(operation, tmpbuf, false);
 }
 

--- a/C/plugins/storage/sqlite/common/readings.cpp
+++ b/C/plugins/storage/sqlite/common/readings.cpp
@@ -2246,16 +2246,16 @@ vector<string>  assetCodes;
 
 		totTime += usecs;
 
-		if(usecs>150000)
+		if(usecs > 150000)
 		{
-			std::this_thread::sleep_for(std::chrono::milliseconds(100+usecs/10000));
+			std::this_thread::sleep_for(std::chrono::milliseconds(100 + usecs/1000));
 		}
 		}
 
 		if (rc != SQLITE_OK)
 		{
 			raiseError("purge - phase 3", zErrMsg);
-			// sqlite3_free(zErrMsg); // already freed inside purgeAllReadings, in case of error
+			sqlite3_free(zErrMsg);
 			return 0;
 		}
 
@@ -2572,6 +2572,8 @@ struct timeval startTv, endTv;
 			numReadings -= rowsAffected;
 			rowcount    -= rowsAffected;
 
+			sqlite3_free(zErrMsg);
+
 			// Release memory for 'query' var
 			delete[] query;
 			logger->debug(" Deleted :%lu: rows", rowsAffected);
@@ -2712,6 +2714,7 @@ sqlite3_stmt *stmt;
 		if (rc != SQLITE_OK)
 		{
 			raiseError("ReadingsAssetPurge", sqlite3_errmsg(dbHandle));
+			sqlite3_free(zErrMsg);
 			return 0;
 		}
 

--- a/C/plugins/storage/sqlite/common/readings.cpp
+++ b/C/plugins/storage/sqlite/common/readings.cpp
@@ -2255,7 +2255,7 @@ vector<string>  assetCodes;
 		if (rc != SQLITE_OK)
 		{
 			raiseError("purge - phase 3", zErrMsg);
-			sqlite3_free(zErrMsg);
+			// sqlite3_free(zErrMsg); // already freed inside purgeAllReadings, in case of error
 			return 0;
 		}
 

--- a/C/plugins/storage/sqlite/common/readings_catalogue.cpp
+++ b/C/plugins/storage/sqlite/common/readings_catalogue.cpp
@@ -2437,7 +2437,7 @@ int  ReadingsCatalogue::purgeAllReadings(sqlite3 *dbHandle, const char *sqlCmdBa
 
 			rc = SQLExec(dbHandle, sqlCmdTmp.c_str(), zErrMsg);
 
-			Logger::getLogger()->debug("purgeAllReadings:  rc %d cmd '%s'", rc ,sqlCmdTmp.c_str() );
+			Logger::getLogger()->debug("purgeAllReadings:  rc %d  errorMsg '%s'   cmd '%s'", rc , (*zErrMsg) ? (*zErrMsg) : "", sqlCmdTmp.c_str() );
 
 			if (rc != SQLITE_OK)
 			{

--- a/C/plugins/storage/sqlite/common/readings_catalogue.cpp
+++ b/C/plugins/storage/sqlite/common/readings_catalogue.cpp
@@ -2437,11 +2437,11 @@ int  ReadingsCatalogue::purgeAllReadings(sqlite3 *dbHandle, const char *sqlCmdBa
 
 			rc = SQLExec(dbHandle, sqlCmdTmp.c_str(), zErrMsg);
 
-			Logger::getLogger()->debug("purgeAllReadings:  rc %d  errorMsg '%s'   cmd '%s'", rc , (*zErrMsg) ? (*zErrMsg) : "", sqlCmdTmp.c_str() );
+			Logger::getLogger()->debug("purgeAllReadings:  rc:%d, errorMsg:'%s', cmd:'%s'", rc , (*zErrMsg) ? (*zErrMsg) : "", sqlCmdTmp.c_str() );
 
 			if (rc != SQLITE_OK)
 			{
-				sqlite3_free(*zErrMsg);
+				// sqlite3_free(*zErrMsg); // needed by calling method
 				break;
 			}
 			if  (rowsAffected != nullptr) {


### PR DESCRIPTION
Crash was due to double free for a sqlite's error msg buffer. That is fixed. But DB file is corrupted:

```
Jul 10 12:45:06 193PRC-EGD0001 FogLAMP Storage[834311]: ERROR: SQL statement DELETE FROM foglamp.statistics_history WHERE history_ts <= '2024-06-10 12:45:04.778127'; failed after maximum retries
Jul 10 12:45:06 193PRC-EGD0001 FogLAMP Storage[834311]: ERROR: Database error after maximum retries, executing DELETE operation on statistics_history
Jul 10 12:45:06 193PRC-EGD0001 FogLAMP Storage[834311]: ERROR: SQLite3 storage plugin raising error: delete: database disk image is malformed
Jul 10 12:45:06 193PRC-EGD0001 FogLAMP Storage[834311]: ERROR: SQL statement: DELETE FROM foglamp.statistics_history WHERE history_ts <= '2024-06-10 12:45:04.778127';
Jul 10 12:45:06 193PRC-EGD0001 FogLAMP purge[835279] ERROR: logger: foglamp.common.storage_client.storage_client: Error code: 400, reason: Bad Request, details: {'entryPoint': 'delete', 'message': 'database disk image is malformed', 'retryable': False}
```

Will investigate that further.