### PR TITLE
FOGL-8901: Updated requirement.txt file to install aiohttp of v3.9.4 for Platforms having Python version 3.8 or +

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,6 @@
 # Common - REST interface
-aiohttp==3.8.1
+aiohttp==3.8.1;python_version<"3.8"
+aiohttp==3.9.4;python_version>="3.8"
 aiohttp_cors==0.7.0
 cchardet==2.1.4;python_version<"3.9"
 cchardet==2.1.7;python_version>="3.9"


### PR DESCRIPTION
…sion>=3.8