### PR TITLE
FOGL-8917 setuptools pip dep fixes when python version is greater than 3.8

### DIFF
--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -15,3 +15,7 @@ pyserial==3.4
 # keep this in sync with requirement.txt, as otherwise pytest-aiohttp always pulls the latest
 aiohttp==3.8.1
 yarl==1.7.2
+
+# specific version for setuptools as per pytest version
+setuptools==70.3.0;python_version>="3.8"
+


### PR DESCRIPTION
Ran below CI builds

- Both PR tester is fine
- Nightly is fine - `fledge_nightly_build_ub2004/1400/`
- One custom bucket API tests - `fledge_wl_bucket_service_api/244/`

And now python tests are running fine

Note: Removed temporary fix at Ub20 PR tester; 