### PR TITLE
FOGL-9163 API statistics schedule wait time fixes in tests

### DIFF
--- a/tests/system/python/api/test_statistics.py
+++ b/tests/system/python/api/test_statistics.py
@@ -150,7 +150,7 @@ class TestStatistics:
         assert 1 == stats['READINGS']
 
         # Allow stats collector schedule to run i.e. by default 15s
-        time.sleep(wait_time * 2 + 1)
+        time.sleep(wait_time * 3)
 
         # check stats history
         conn.request("GET", '/fledge/statistics/history')


### PR DESCRIPTION
The test scenario has been failing intermittently on platforms since the FOGL-8788 merge. Instead of adding an extra wait after the stats history request call to check the READINGS stats count, implemented a consistent 15-second wait for the schedule to ensure it runs before the stats history call.

ran custom Ci Jobs:

```
ub18 + postgres - Build 850 - **PASSED**
ub20 + sqlite - Build 71 -  **PASSED**
centos stream9 + sqlite - Build 729 - **PASSED**
```