### PR TITLE
FOGL-9265 - Debug trace logs directory added to support bundle

### DIFF
--- a/python/fledge/services/core/api/package_log.py
+++ b/python/fledge/services/core/api/package_log.py
@@ -43,9 +43,10 @@ async def get_logs(request: web.Request) -> web.Response:
     logs_root_dir = _get_logs_dir()
     found_files = []
 
-    for root, dirs, files in os.walk(logs_root_dir):
-        found_files = [f for f in files if f.endswith(valid_extension)]
-
+    for root, dirs, files in os.walk(logs_root_dir, topdown=True):
+        # Only process files in the root directory and filter for .log files
+        if root == logs_root_dir:
+            found_files = [f for f in files if f.endswith(valid_extension)]
     result = []
     for f in found_files:
         if f.endswith(valid_extension):
@@ -86,9 +87,11 @@ async def get_log_by_name(request: web.Request) -> web.FileResponse:
         raise web.HTTPBadRequest(reason="Accepted file extension is {}".format(valid_extension))
 
     logs_root_dir = _get_logs_dir()
-    for root, dirs, files in os.walk(logs_root_dir):
-        if str(file_name) not in files:
-            raise web.HTTPNotFound(reason='{} file not found'.format(file_name))
+    for root, dirs, files in os.walk(logs_root_dir, topdown=True):
+        # Only process files in the root directory
+        if root == logs_root_dir:
+            if str(file_name) not in files:
+                raise web.HTTPNotFound(reason='{} file not found'.format(file_name))
 
     fp = Path(logs_root_dir + "/" + str(file_name))
     return web.FileResponse(path=fp)

--- a/python/fledge/services/core/support.py
+++ b/python/fledge/services/core/support.py
@@ -109,6 +109,7 @@ class SupportBuilder:
                 self.add_psinfo(pyz, file_spec)
                 self.add_script_dir_content(pyz)
                 self.add_package_log_dir_content(pyz)
+                self.add_debug_trace_log_dir_content(pyz)
                 self.add_software_list(pyz, file_spec)
                 self.add_python_packages_list(pyz, file_spec)
             finally:
@@ -281,11 +282,29 @@ class SupportBuilder:
             # recursively 'true' by default and __pycache__ dir excluded
             pyz.add(script_file_path, arcname='scripts', filter=self.exclude_pycache)
 
-    def add_package_log_dir_content(self, pyz):
-        script_package_logs_path = _PATH + '/logs'
-        if os.path.exists(script_package_logs_path):
-            # recursively 'true' by default and __pycache__ dir excluded
-            pyz.add(script_package_logs_path, arcname='logs/package', filter=self.exclude_pycache)
+    def add_package_log_dir_content(self, pyz) -> None:
+        package_logs_path = _PATH + '/logs'
+        if os.path.exists(package_logs_path):
+            for filename in os.listdir(package_logs_path):
+                if filename.endswith('.log'):
+                    file_path = os.path.join(package_logs_path, filename)
+                    # recursively 'true' by default and __pycache__ dir excluded
+                    pyz.add(file_path, arcname='logs/package/{}'.format(basename(file_path)),
+                            filter=self.exclude_pycache)
+
+    def add_debug_trace_log_dir_content(self, pyz) -> None:
+        debug_trace_logs_path = _PATH + '/logs/debug-trace'
+        if os.path.exists(debug_trace_logs_path):
+            for filename in os.listdir(debug_trace_logs_path):
+                # Check if the file has a .log extension
+                if filename.endswith('.log'):
+                    file_path = os.path.join(debug_trace_logs_path, filename)
+                    # recursively 'true' by default and __pycache__ dir excluded
+                    pyz.add(file_path, arcname='logs/debug-trace/{}'.format(basename(file_path)),
+                            filter=self.exclude_pycache)
+                    # Open the file in write mode ('w'), which will truncate it to zero length
+                    with open(file_path, 'w') as file:
+                        file.truncate(0)
 
     def add_software_list(self, pyz, file_spec) -> None:
         data = {

--- a/tests/unit/python/fledge/services/core/api/test_package_log.py
+++ b/tests/unit/python/fledge/services/core/api/test_package_log.py
@@ -95,7 +95,7 @@ class TestPackageLog:
                 assert files[7] == obj['filename']
                 assert len(obj['timestamp']) > 0
                 assert "20230609_093006_Trace_00000" == obj['name']
-            mockwalk.assert_called_once_with(logs_path)
+            mockwalk.assert_called_once_with(logs_path, topdown=True)
 
     async def test_get_log_by_name_with_invalid_extension(self, client):
         resp = await client.get('/fledge/package/log/blah.txt')


### PR DESCRIPTION
**Sample content of logs directory inside support bundle**


```
$ tree logs/
logs/
├── debug-trace
│   ├── omf.log
│   └── s2opcua.log
├── package
│   ├── 241122-05-58-14-list.log
│   ├── 241122-05-58-20-list.log
│   ├── 241122-05-58-21-fledge-south-s2opcua-install.log
│   ├── 241122-05-58-42-list.log
│   ├── 241122-05-58-49-list.log
│   ├── 241122-05-58-51-fledge-north-opcuaclient-install.log
│   ├── 241122-06-09-47-list.log
│   ├── 241122-06-10-05-list.log
│   └── 241122-06-10-06-fledge-filter-python35-install.log
└── sys
    ├── fl_syslog.log
    ├── fl_syslog_factor
    ├── fl_syslog_script_runs
    ├── syslog-241122-08-12-26
    ├── syslog-S2-241122-08-12-26
    └── syslogStorage-241122-08-12-26

3 directories, 27 files

```

As per **FLEDGE_DATA**:

debug-trace - All log files will be listed as is
package - All log files will be listed as is
sys - Syslogs related files include services/tasks individual log files and other syslog utility files

Note - If any other files are present outside the listed directories, they will be ignored, except for those with the `.log` extension, which will be included under the package.