### PR TITLE
FOGL-4015 individual external services logs added in support bundle

### DIFF
--- a/python/fledge/services/core/support.py
+++ b/python/fledge/services/core/support.py
@@ -87,13 +87,11 @@ class SupportBuilder:
                             self.add_syslog_service(pyz, file_spec, task)
                 except:
                     pass
-                # TODO: FOGL-4015 - other external services
                 try:
                     schedule_list = await server.Server.scheduler.get_schedules()
-                    for sch in schedule_list:
-                        if sch.process_name == 'management':
-                            self.add_syslog_service(pyz, file_spec, sch.name)
-                            break
+                    external_svc_processes = ('bucket_storage_c', 'dispatcher_c', 'management', 'notification_c')
+                    for sch in filter(lambda obj: obj.process_name in external_svc_processes, schedule_list):
+                        self.add_syslog_service(pyz, file_spec, sch.name)
                 except:
                     pass
                 db_tables = {"configuration": "category", "log": "audit", "schedules": "schedule",


### PR DESCRIPTION
**Sample content**

```
$ ls support-241125-07-13-56/logs/sys
fl_syslog.log			fl_syslog_script_runs		syslog-OMF-241125-07-13-56 syslog-SP-241125-07-13-56     syslog-KP-241125-07-13-56	syslog-RW-241125-07-13-56
fl_syslog_factor		syslog-241125-07-13-56	syslog-NS-241125-07-13-56	syslogStorage-241125-07-13-56
```
where,
prefix fl meant related for => utility logs
syslog -KP => dispatcher Service
syslog -NS => notification Service
syslog -SP => North Service
syslog-OMF => North Task
syslog -RW => South Service
syslogStorage => Storage Service
syslog => combined logs
