### PR TITLE
FOGL-9297 - Configuration Manager fixes for optional attribute when cleaning up the values

### DIFF
--- a/python/fledge/common/configuration_manager.py
+++ b/python/fledge/common/configuration_manager.py
@@ -619,11 +619,11 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 raise ValueError(
                     'For {} category, unrecognized value for item name {}'.format(category_name, item_name))
             if 'readonly' in item_val:
-                item_val['readonly'] = self._clean(item_val, item_val['readonly'])
+                item_val['readonly'] = self._clean('boolean', item_val['readonly'])
             if 'deprecated' in item_val:
-                item_val['deprecated'] = self._clean(item_val, item_val['deprecated'])
+                item_val['deprecated'] = self._clean('boolean', item_val['deprecated'])
             if 'mandatory' in item_val:
-                item_val['mandatory'] = self._clean(item_val, item_val['mandatory'])
+                item_val['mandatory'] = self._clean('boolean', item_val['mandatory'])
             if set_value_val_from_default_val:
                 item_val['default'] = self._clean(item_val, item_val['default'])
                 item_val['value'] = item_val['default']
@@ -1904,6 +1904,10 @@ class ConfigurationManager(ConfigurationManagerSingleton):
             return isinstance(_value, str)
 
     def _clean(self, storage_val, item_val) -> str:
+        # For optional attributes
+        if isinstance(storage_val, str):
+            return item_val.lower() if storage_val == 'boolean' else item_val
+        # For required attributes
         if storage_val['type'] == 'boolean':
             return item_val.lower()
         elif storage_val['type'] == 'float':

--- a/tests/unit/python/fledge/common/test_configuration_manager.py
+++ b/tests/unit/python/fledge/common/test_configuration_manager.py
@@ -3573,6 +3573,8 @@ class TestConfigurationManager:
             assert str(msg) == str(excinfo.value)
 
     @pytest.mark.parametrize("item_type, item_val, result", [
+        ('boolean', "True", "true"),
+        ('string', "Plugin", "Plugin"),
         ({'description': 'Test', 'type': 'boolean', 'default': 'true'}, "True", "true"),
         ({'description': 'Test', 'type': 'boolean', 'default': 'true'}, "true", "true"),
         ({'description': 'Test', 'type': 'boolean', 'default': 'false'}, "false", "false"),
@@ -3591,7 +3593,8 @@ class TestConfigurationManager:
         ({'description': 'Datapoints', 'type': 'kvlist', 'items': 'object', 'default': '{"plc": {"register": "0"}}'},
          '{"plc": {"register": "0"}, "plc": {"type": "integer"}}', '{"plc": {"type": "integer"}}'),
         ({'description': 'Datapoints', 'type': 'kvlist', 'items': 'object', 'default': '{"plc": {"register": "0"}}'},
-         '{"plc": {"register": "0"}, "plc-2": {"type": "integer"}}', '{"plc": {"register": "0"}, "plc-2": {"type": "integer"}}')
+         '{"plc": {"register": "0"}, "plc-2": {"type": "integer"}}',
+         '{"plc": {"register": "0"}, "plc-2": {"type": "integer"}}')
     ])
     async def test__clean(self, item_type, item_val, result):
         storage_client_mock = MagicMock(spec=StorageClientAsync)


### PR DESCRIPTION
Here is the custom build run - `fledge_on_demand_code_coverage_ub2004/96/#showFailuresLink`

~`e2e.test_e2e_modbus_c_pi.TestE2EModbusCPI.test_end_to_end ` test failure due to some other reason which is a incomplete change made in [PR](https://github.com/fledge-iot/fledge/pull/1495/files#r1861987481)~ Now fixed

And other failures  seems to be flaky one's
Latest run - `fledge_on_demand_code_coverage_ub2004/100/#showFailuresLink`