### PR TITLE
FOGL-9252.patch task name fixes in modbus E2E tests

### DIFF
--- a/tests/system/python/e2e/test_e2e_modbus_c_pi.py
+++ b/tests/system/python/e2e/test_e2e_modbus_c_pi.py
@@ -93,7 +93,8 @@ class TestE2EModbusCPI:
         add_south(SOUTH_PLUGIN, south_branch, fledge_url, service_name=SVC_NAME, config=cfg,
                   plugin_lang="C", start_service=False, plugin_discovery_name=PLUGIN_NAME)
 
-        start_north_pi_server_c_web_api(fledge_url, pi_host, pi_port, pi_db=pi_db, pi_user=pi_admin, pi_pwd=pi_passwd)
+        start_north_pi_server_c_web_api(fledge_url, pi_host, pi_port, pi_db=pi_db, pi_user=pi_admin, pi_pwd=pi_passwd,
+                                        taskname="NorthReadingsToPI")
 
         yield self.start_south_north
 

--- a/tests/system/python/e2e/test_e2e_modbus_c_rtu_pi.py
+++ b/tests/system/python/e2e/test_e2e_modbus_c_rtu_pi.py
@@ -84,7 +84,8 @@ class TestE2EModbusC_RTU_PI:
                   plugin_lang="C", start_service=False, plugin_discovery_name=PLUGIN_NAME)
 
         if not skip_verify_north_interface:
-            start_north_pi_server_c_web_api(fledge_url, pi_host, pi_port, pi_db=pi_db, pi_user=pi_admin, pi_pwd=pi_passwd)
+            start_north_pi_server_c_web_api(fledge_url, pi_host, pi_port, pi_db=pi_db, pi_user=pi_admin,
+                                            pi_pwd=pi_passwd, taskname="NorthReadingsToPI")
 
         yield self.start_south_north
 


### PR DESCRIPTION
https://github.com/fledge-iot/fledge/pull/1495/files#r1861987481

Custom Job run available at - `fledge_on_demand_code_coverage_ub2004/97/` - now modbus pi one is now passing

TestE2eCsvMultiFltrPi setup will be fixed by FOGL-9297 changes
TestE2EKafka seems to be flaky one; most likely destination server is NOT responding/available