### PR TITLE
FOGL-9311 - Add  properties to key/value lists in C++

### DIFF
--- a/C/common/config_category.cpp
+++ b/C/common/config_category.cpp
@@ -611,6 +611,10 @@ string ConfigCategory::getItemAttribute(const string& itemName,
 					return m_items[i]->m_listItemType;
 				case LIST_NAME_ATTR:
 				    return m_items[i]->m_listName;
+				case KVLIST_KEY_NAME_ATTR:
+				    return m_items[i]->m_kvlistKeyName;
+				case KVLIST_KEY_DESCRIPTION_ATTR:
+				    return m_items[i]->m_kvlistKeyDescription;
 				default:
 					throw new ConfigItemAttributeNotFound();
 			}
@@ -687,6 +691,12 @@ bool ConfigCategory::setItemAttribute(const string& itemName,
 					return true;
 				case LIST_NAME_ATTR:
 					m_items[i]->m_listName = value;
+					return true;
+				case KVLIST_KEY_NAME_ATTR:
+					m_items[i]->m_kvlistKeyName = value;
+					return true;
+				case KVLIST_KEY_DESCRIPTION_ATTR:
+					m_items[i]->m_kvlistKeyDescription = value;
 					return true;
 				default:
 					return false;
@@ -1412,7 +1422,28 @@ ConfigCategory::CategoryItem::CategoryItem(const string& name,
 			throw new runtime_error("ListName configuration item property is not a string");
 		}
 	}
-
+	if (item.HasMember("keyName"))
+	{
+		if (item["keyName"].IsString())
+		{
+			m_kvlistKeyName = item["keyName"].GetString();
+		}
+		else
+		{
+			throw new runtime_error("keyName configuration item property is not a string");
+		}
+	}
+	if (item.HasMember("keyDescription"))
+	{
+		if (item["keyDescription"].IsString())
+		{
+			m_kvlistKeyDescription = item["keyDescription"].GetString();
+		}
+		else
+		{
+			throw new runtime_error("keyDescription configuration item property is not a string");
+		}
+	}
 	std::string m_typeUpperCase = m_type;
 	for (auto & c: m_typeUpperCase) c = toupper(c);
 
@@ -1701,6 +1732,8 @@ ConfigCategory::CategoryItem::CategoryItem(const CategoryItem& rhs)
 	m_listSize = rhs.m_listSize;
 	m_listItemType = rhs.m_listItemType;
 	m_listName = rhs.m_listName;
+	m_kvlistKeyName = rhs.m_kvlistKeyName;
+	m_kvlistKeyDescription = rhs.m_kvlistKeyDescription;
 	for (auto it = rhs.m_permissions.cbegin(); it != rhs.m_permissions.cend(); it++)
 	{
 		m_permissions.push_back(*it);
@@ -1841,6 +1874,14 @@ ostringstream convert;
 		{
 			convert << ", \"listName\" : \"" << m_listName << "\"";
 		}
+		if (!m_kvlistKeyName.empty())
+		{
+			convert << ", \"keyName\" : \"" << m_kvlistKeyName << "\"";
+		}
+		if (!m_kvlistKeyDescription.empty())
+		{
+			convert << ", \"keyDescription\" : \"" << m_kvlistKeyDescription << "\"";
+		}
 	}
 	convert << " }";
 
@@ -1951,7 +1992,14 @@ ostringstream convert;
 	{
 	    convert << ", \"listName\" : \"" << m_listName << "\"";
 	}
-
+	if (!m_kvlistKeyName.empty())
+	{
+	    convert << ", \"keyName\" : \"" << m_kvlistKeyName << "\"";
+	}
+	if (!m_kvlistKeyDescription.empty())
+	{
+	    convert << ", \"keyDescription\" : \"" << m_kvlistKeyDescription << "\"";
+	}
 
 	if (m_itemType == StringItem ||
 	    m_itemType == EnumerationItem ||

--- a/C/common/include/config_category.h
+++ b/C/common/include/config_category.h
@@ -145,7 +145,9 @@ class ConfigCategory {
 					BUCKET_PROPERTIES_ATTR,
 					LIST_SIZE_ATTR,
 					ITEM_TYPE_ATTR,
-					LIST_NAME_ATTR
+					LIST_NAME_ATTR,
+					KVLIST_KEY_NAME_ATTR,
+					KVLIST_KEY_DESCRIPTION_ATTR
 					};
 		std::string			getItemAttribute(const std::string& itemName,
 								 ItemAttribute itemAttribute) const;
@@ -197,6 +199,8 @@ class ConfigCategory {
 				std::string	m_listSize;
 				std::string	m_listItemType;
 				std::string	m_listName;
+				std::string	m_kvlistKeyName;
+				std::string	m_kvlistKeyDescription;
 				std::vector<std::string>
 						m_permissions;
 		};


### PR DESCRIPTION
Configuration support for optional attributes, such as keyName and keyDescription, in the kvlist for the C++