### PR TITLE
FOGL-9312 - Add properties to key/value list in Python

### DIFF
--- a/C/common/config_category.cpp
+++ b/C/common/config_category.cpp
@@ -611,6 +611,10 @@ string ConfigCategory::getItemAttribute(const string& itemName,
 					return m_items[i]->m_listItemType;
 				case LIST_NAME_ATTR:
 				    return m_items[i]->m_listName;
+				case KVLIST_KEY_NAME_ATTR:
+				    return m_items[i]->m_kvlistKeyName;
+				case KVLIST_KEY_DESCRIPTION_ATTR:
+				    return m_items[i]->m_kvlistKeyDescription;
 				default:
 					throw new ConfigItemAttributeNotFound();
 			}
@@ -687,6 +691,12 @@ bool ConfigCategory::setItemAttribute(const string& itemName,
 					return true;
 				case LIST_NAME_ATTR:
 					m_items[i]->m_listName = value;
+					return true;
+				case KVLIST_KEY_NAME_ATTR:
+					m_items[i]->m_kvlistKeyName = value;
+					return true;
+				case KVLIST_KEY_DESCRIPTION_ATTR:
+					m_items[i]->m_kvlistKeyDescription = value;
 					return true;
 				default:
 					return false;
@@ -1412,7 +1422,28 @@ ConfigCategory::CategoryItem::CategoryItem(const string& name,
 			throw new runtime_error("ListName configuration item property is not a string");
 		}
 	}
-
+	if (item.HasMember("keyName"))
+	{
+		if (item["keyName"].IsString())
+		{
+			m_kvlistKeyName = item["keyName"].GetString();
+		}
+		else
+		{
+			throw new runtime_error("keyName configuration item property is not a string");
+		}
+	}
+	if (item.HasMember("keyDescription"))
+	{
+		if (item["keyDescription"].IsString())
+		{
+			m_kvlistKeyDescription = item["keyDescription"].GetString();
+		}
+		else
+		{
+			throw new runtime_error("keyDescription configuration item property is not a string");
+		}
+	}
 	std::string m_typeUpperCase = m_type;
 	for (auto & c: m_typeUpperCase) c = toupper(c);
 
@@ -1701,6 +1732,8 @@ ConfigCategory::CategoryItem::CategoryItem(const CategoryItem& rhs)
 	m_listSize = rhs.m_listSize;
 	m_listItemType = rhs.m_listItemType;
 	m_listName = rhs.m_listName;
+	m_kvlistKeyName = rhs.m_kvlistKeyName;
+	m_kvlistKeyDescription = rhs.m_kvlistKeyDescription;
 	for (auto it = rhs.m_permissions.cbegin(); it != rhs.m_permissions.cend(); it++)
 	{
 		m_permissions.push_back(*it);
@@ -1841,6 +1874,14 @@ ostringstream convert;
 		{
 			convert << ", \"listName\" : \"" << m_listName << "\"";
 		}
+		if (!m_kvlistKeyName.empty())
+		{
+			convert << ", \"keyName\" : \"" << m_kvlistKeyName << "\"";
+		}
+		if (!m_kvlistKeyDescription.empty())
+		{
+			convert << ", \"keyDescription\" : \"" << m_kvlistKeyDescription << "\"";
+		}
 	}
 	convert << " }";
 
@@ -1951,7 +1992,14 @@ ostringstream convert;
 	{
 	    convert << ", \"listName\" : \"" << m_listName << "\"";
 	}
-
+	if (!m_kvlistKeyName.empty())
+	{
+	    convert << ", \"keyName\" : \"" << m_kvlistKeyName << "\"";
+	}
+	if (!m_kvlistKeyDescription.empty())
+	{
+	    convert << ", \"keyDescription\" : \"" << m_kvlistKeyDescription << "\"";
+	}
 
 	if (m_itemType == StringItem ||
 	    m_itemType == EnumerationItem ||

--- a/C/common/include/config_category.h
+++ b/C/common/include/config_category.h
@@ -145,7 +145,9 @@ class ConfigCategory {
 					BUCKET_PROPERTIES_ATTR,
 					LIST_SIZE_ATTR,
 					ITEM_TYPE_ATTR,
-					LIST_NAME_ATTR
+					LIST_NAME_ATTR,
+					KVLIST_KEY_NAME_ATTR,
+					KVLIST_KEY_DESCRIPTION_ATTR
 					};
 		std::string			getItemAttribute(const std::string& itemName,
 								 ItemAttribute itemAttribute) const;
@@ -197,6 +199,8 @@ class ConfigCategory {
 				std::string	m_listSize;
 				std::string	m_listItemType;
 				std::string	m_listName;
+				std::string	m_kvlistKeyName;
+				std::string	m_kvlistKeyDescription;
 				std::vector<std::string>
 						m_permissions;
 		};

--- a/docs/plugin_developers_guide/02_writing_plugins.rst
+++ b/docs/plugin_developers_guide/02_writing_plugins.rst
@@ -554,6 +554,8 @@ An alternative might be to use a key/value pair list, *kvlist* type, where the k
         "default": "{\"speed\" : {\"register\" : \"10\", \"width\" : \"1\", \"type\" : \"integer\"}}",
         "order" : "3",
         "displayName" : "PLC Map",
+        "keyName": "Datapoints",
+        "keyDescription": "A list of datapoints to read",
         "properties" : {
                 "register" : {
                         "description" : "The register number to read",
@@ -594,6 +596,8 @@ The *value* and *default* properties for a list of objects is returned as a JSON
                         "type" : "float"
                 }
   }
+
+The *keyName* and *keyDescription* will be used by the GUI client to display a name and description associated with an entry in the key/value list.
 
 Properties
 ~~~~~~~~~~
@@ -641,6 +645,10 @@ Properties
      - The current value of the configuration item. This is not included when defining a set of default configuration in, for example, a plugin.
    * - properties
      - A set of items that are used in list and kvlist type items to create a list of groups of configuration items.
+   * - keyName
+     - A display name to be used for entry and display of key in the key-value list type, with item being an object.
+   * - keyDescription
+     - A description of key value in the key-value list type, with item being an object.
    * - permissions
      - An array of user roles that are allowed to update this configuration item. If not given then the configuration item can be updated by any user. If the permissions property is included in a configuration item the array must have at least one entry.
 

--- a/python/fledge/common/configuration_manager.py
+++ b/python/fledge/common/configuration_manager.py
@@ -253,6 +253,17 @@ class ConfigurationManager(ConfigurationManagerSingleton):
         return category_val_new_copy
 
     async def _validate_category_val(self, category_name, category_val, set_value_val_from_default_val=True):
+
+        def _validate_optional_attribute_string_type(optional_key_name, optional_key_value, config_item_name):
+            if not isinstance(optional_key_value, str):
+                raise TypeError('For {} category, {} type must be a string for item name {}; got {}'.format(
+                    category_name, optional_key_name, config_item_name, type(optional_key_value)))
+            final_optional_key_value = optional_key_value.strip()
+            if not final_optional_key_value:
+                raise ValueError('For {} category, {} cannot be empty for item name {}'.format(
+                    category_name, optional_key_name, config_item_name))
+            return final_optional_key_value
+
         require_entry_value = not set_value_val_from_default_val
         if type(category_val) is not dict:
             raise TypeError('For {} category, category value must be a dictionary; got {}'
@@ -368,16 +379,18 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                     if 'items' not in item_val:
                         raise KeyError('For {} category, items KV pair must be required '
                                        'for item name {}.'.format(category_name, item_name))
+                    if item_val['type'] == 'kvlist' and item_val['items'] == 'object':
+                        if 'keyName' in item_val:
+                            item_val['keyName'] = _validate_optional_attribute_string_type('keyName',
+                                                                                           item_val['keyName'], item_name)
+                            expected_item_entries.update({entry_name: entry_val})
+                        if 'keyDescription' in item_val:
+                            item_val['keyDescription'] = _validate_optional_attribute_string_type(
+                                'keyDescription', item_val['keyDescription'], item_name)
+                            expected_item_entries.update({entry_name: entry_val})
                     if 'listName' in item_val:
-                        list_name = item_val['listName']
-                        if not isinstance(list_name, str):
-                            raise TypeError('For {} category, listName type must be a string for item name {}; '
-                                            'got {}'.format(category_name, item_name, type(list_name)))
-                        list_name = item_val['listName'].strip()
-                        if not list_name:
-                            raise ValueError('For {} category, listName cannot be empty for item name '
-                                             '{}'.format(category_name, item_name))
-                        item_val['listName'] = list_name
+                        item_val['listName'] = _validate_optional_attribute_string_type('listName',
+                                                                     item_val['listName'], item_name)
                     elif "permissions" in item_val:
                         permissions = item_val['permissions']
                         if not isinstance(permissions, list):

--- a/tests/unit/python/fledge/common/test_configuration_manager.py
+++ b/tests/unit/python/fledge/common/test_configuration_manager.py
@@ -868,6 +868,30 @@ class TestConfigurationManager:
             "object", "properties": {"width": {"description": "", "default": ""}}}}, ValueError,
          "For {} category, width properties must have type, description, default keys for item name {}".format(
              CAT_NAME, ITEM_NAME)),
+        ({ITEM_NAME: {"description": "expression", "type": "kvlist", "default": "{}", "items": "object", "keyName": 1,
+                      "properties": {"width": {"description": "Width", "default": "1", "type": "integer"}}}},
+         TypeError, "For {} category, keyName type must be a string for item name {}; got <class 'int'>".format(
+            CAT_NAME, ITEM_NAME)),
+        ({ITEM_NAME: {"description": "expression", "type": "kvlist", "default": "{}", "items": "object",
+                      "keyDescription": False, "properties": {"width": {"description": "Width", "default": "1", "type":
+                "integer"}}}}, TypeError, "For {} category, keyDescription type must be a string for item name {}; "
+                                          "got <class 'bool'>".format(CAT_NAME, ITEM_NAME)),
+        ({ITEM_NAME: {"description": "expression", "type": "kvlist", "default": "{}", "items": "object", "keyName":
+            "DP", "keyDescription": False, "properties": {"width": {"description": "Width", "default": "1", "type":
+                "integer"}}}}, TypeError, "For {} category, keyDescription type must be a string for item name {}; "
+                                          "got <class 'bool'>".format(CAT_NAME, ITEM_NAME)),
+        ({ITEM_NAME: {"description": "expression", "type": "kvlist", "default": "{}", "items": "object", "keyName":
+            4.5, "keyDescription": "", "properties": {"width": {"description": "Width", "default": "1", "type":
+            "integer"}}}}, TypeError, "For {} category, keyName type must be a string for item name {}; "
+                                      "got <class 'float'>".format(CAT_NAME, ITEM_NAME)),
+        ({ITEM_NAME: {"description": "expression", "type": "kvlist", "default": "{}", "items": "object", "keyName":
+            "", "keyDescription": "", "properties": {"width": {"description": "Width", "default": "1", "type":
+            "integer"}}}}, ValueError, "For {} category, keyName cannot be empty for item name {}".format(
+            CAT_NAME, ITEM_NAME)),
+        ({ITEM_NAME: {"description": "expression", "type": "kvlist", "default": "{}", "items": "object", "keyName":
+            "DP", "keyDescription": "", "properties": {"width": {"description": "Width", "default": "1", "type":
+            "integer"}}}}, ValueError, "For {} category, keyDescription cannot be empty for item name {}".format(
+            CAT_NAME, ITEM_NAME)),
         ({ITEM_NAME: {"description": "expression", "type": "kvlist", "default": "{\"key1\": \"integer\"}",
                       "items": "enumeration"}}, KeyError,
          "'For {} category, options required for item name {}'".format(CAT_NAME, ITEM_NAME)),
@@ -977,6 +1001,7 @@ class TestConfigurationManager:
         {"include": {"description": "A list of expressions and values", "type": "kvlist", "items": "float",
                      "default": "{}", "order": "1", "displayName": "labels", "listSize": "3"}},
         {"include": {"description": "A list of expressions and values", "type": "kvlist", "items": "object",
+                     "keyName": "Register", "keyDescription": "Register to read",
                      "default": "{\"register\": {\"width\": \"2\"}}", "order": "1", "displayName": "labels",
                      "properties": {"width": {"description": "Number of registers to read", "displayName": "Width",
                                               "type": "integer", "maximum": "4", "default": "1"}}}},


### PR DESCRIPTION
**The representation of a configuration item can be as follows**

```
{
  "description": "The datapoints that represent our modelled asset",
  "type": "kvlist",
  "order": "3",
  "displayName": "Datapoints",
  "properties": {
    "asset": {
      "description": "The asset name to fetch the data from",
      "displayName": "Source Asset",
      "type": "string",
      "default": ""
    },
    "datapoint": {
      "description": "The datapoint to fetch the data from within the asset",
      "displayName": "Source Datapoint",
      "type": "string",
      "default": ""
    },
    "type": {
      "description": "The type of the datapoint to create in the model asset",
      "displayName": "Type",
      "type": "enumeration",
      "options": [
        "float",
        "integer",
        "string"
      ],
      "default": "float"
    },
    "default": {
      "description": "Default value for the item in the model",
      "displayName": "Default",
      "type": "string",
      "default": ""
    }
  },
  "group": "Model",
  "items": "object",
  "keyName": "Datapoint",
  "keyDescription": "The datapoint name within the asset created by the filter",
  "default": "{}",
  "value": "{\"DP\": {\"asset\": \"\", \"datapoint\": \"\", \"type\": \"float\", \"default\": \"\"}}"
}
```