### PR TITLE
FOGL-9343 Inconsistent update of 'last_object' field of streams table

### DIFF
--- a/C/services/north/data_load.cpp
+++ b/C/services/north/data_load.cpp
@@ -237,7 +237,6 @@ void DataLoad::readBlock(unsigned int blockSize)
 			if (n_update_streamId > max_wait_count) {
 				// Update 'last_object_id' in 'streams' table when no readings to send
 				n_update_streamId = 0;
-				m_streamSent = getLastFetched();
 				flushLastSentId();
 			}
 		}


### PR DESCRIPTION
### Defect Explanation

The stack trace below shows the thread responsible for updating the `last_object` to an incorrect value:

```
0# DataLoad::flushLastSentId() at /usr/include/boost/stacktrace/stacktrace.hpp:213
1# DataLoad::readBlock(unsigned int) at /home/ashwini/WL-develop/FogLAMP/C/services/north/data_load.cpp:250
2# DataLoad::loadThread() at /home/ashwini/WL-develop/FogLAMP/C/services/north/data_load.cpp:133
3# 0x00007F515788BDF4 in /lib/x86_64-linux-gnu/libstdc++.so.6
4# 0x00007F5157EF7609 in /lib/x86_64-linux-gnu/libpthread.so.0
5# clone in /lib/x86_64-linux-gnu/libc.so.6
```

The function `DataLoad::readBlock()` sets the `last_object` marker of the stream to `lastFetchedId`. When the outbound connection for the north plugin is down, the readings remain in the stream. If we disable the plugin, the north interface queue is cleared. However, since `last_object` is set to `lastFetchedId`, the readings that are in the queue when the service is disabled are never sent.

### Proposed Fix:

We should avoid setting `m_streamSent` to `getLastFetched()`. The updated code should look like this:

```cpp
if (n_update_streamId > max_wait_count) {
    // Update 'last_object_id' in the 'streams' table when there are no readings to send
    n_update_streamId = 0;
    // m_streamSent = getLastFetched(); // This line should be removed
    flushLastSentId();
}
```
