### PR TITLE
FOGL-9553 Prevent crash when configuration categories for pipeline fi…

### DIFF
--- a/C/common/filter_pipeline.cpp
+++ b/C/common/filter_pipeline.cpp
@@ -185,12 +185,20 @@ void FilterPipeline::loadPipeline(const Value& filterList, vector<PipelineElemen
 			// Get "plugin" item from filterCategoryName
 			string filterCategoryName = itr->GetString();
 			Logger::getLogger()->info("Creating pipeline filter %s", filterCategoryName.c_str());
-			ConfigCategory filterDetails = mgtClient->getCategory(filterCategoryName);
+			try {
+				ConfigCategory filterDetails = mgtClient->getCategory(filterCategoryName);
 
-			PipelineFilter *element = new PipelineFilter(filterCategoryName, filterDetails);
-			element->setServiceName(serviceName);
-			element->setStorage(&storage);
-			pipeline.emplace_back(element);
+				PipelineFilter *element = new PipelineFilter(filterCategoryName, filterDetails);
+				element->setServiceName(serviceName);
+				element->setStorage(&storage);
+				pipeline.emplace_back(element);
+			} catch (exception& e) {
+				Logger::getLogger()->error("Failed to create filter %s: %s",
+						filterCategoryName.c_str(), e.what());
+			} catch (exception *e) {
+				Logger::getLogger()->error("Failed to create filter %s: %s",
+						filterCategoryName.c_str(), e->what());
+			}
 		}
 		else if (itr->IsArray())
 		{

--- a/C/common/pipeline_filter.cpp
+++ b/C/common/pipeline_filter.cpp
@@ -130,16 +130,21 @@ vector<string> children;
 
 	Logger::getLogger()->info("Load plugin categoryName %s for %s", m_categoryName.c_str(), m_name.c_str());
 	// Fetch up to date filter configuration
-	m_updatedCfg = mgmt->getCategory(m_categoryName);
+	try {
+		m_updatedCfg = mgmt->getCategory(m_categoryName);
 
-	// Pass Management client IP:Port to filter so that it may connect to bucket service
-	m_updatedCfg.addItem("mgmt_client_url_base", "Management client host and port",
+		// Pass Management client IP:Port to filter so that it may connect to bucket service
+		m_updatedCfg.addItem("mgmt_client_url_base", "Management client host and port",
 									"string", "127.0.0.1:0",
 									mgmt->getUrlbase());
 
-	// Add filter category name under service/process config name
-	children.push_back(m_categoryName);
-	mgmt->addChildCategories(m_serviceName, children);
+		// Add filter category name under service/process config name
+		children.push_back(m_categoryName);
+		mgmt->addChildCategories(m_serviceName, children);
+	} catch (...) {
+		Logger::getLogger()->error("Failed to fetch configuration %s for filter %s", m_categoryName.c_str(), m_name.c_str());
+		return false;
+	}
 		
 	ConfigHandler *configHandler = ConfigHandler::getInstance(mgmt);
 	configHandler->registerCategory((ServiceHandler *)ingest, m_categoryName);

--- a/C/services/south/south.cpp
+++ b/C/services/south/south.cpp
@@ -1102,42 +1102,28 @@ void SouthService::handlePendingReconf()
 		unique_lock<mutex> lck(mtx);
 		m_cvNewReconf.wait(lck);
 		Logger::getLogger()->debug("SouthService::handlePendingReconf: cv wait has completed; some reconf request(s) has/have been queued up");
-
-		while (isRunning())
+		unsigned int numPendingReconfs = 0;
 		{
-			unsigned int numPendingReconfs = 0;
+			lock_guard<mutex> guard(m_pendingNewConfigMutex);
+			numPendingReconfs = m_pendingNewConfig.size();
+		}
+		while (isRunning() && numPendingReconfs)
+		{
+			std::pair<std::string,std::string> reconfValue;
+			{
+				reconfValue = m_pendingNewConfig.front();
+				m_pendingNewConfig.pop_front();
+			}
+			{
+				string categoryName = reconfValue.first;
+				string category = reconfValue.second;
+				logger->info("Handle config change %s, %s",
+						categoryName.c_str(), category.c_str());
+				processConfigChange(categoryName, category);
+			}
 			{
 				lock_guard<mutex> guard(m_pendingNewConfigMutex);
 				numPendingReconfs = m_pendingNewConfig.size();
-				if (numPendingReconfs)
-					Logger::getLogger()->debug("SouthService::handlePendingReconf(): will process %d entries in m_pendingNewConfig", numPendingReconfs);
-				else
-				{
-					Logger::getLogger()->debug("SouthService::handlePendingReconf DONE");
-					break;
-				}
-			}
-
-			for (unsigned int i=0; i<numPendingReconfs; i++)
-			{
-				logger->debug("SouthService::handlePendingReconf(): Handling Configuration change #%d", i);
-				std::pair<std::string,std::string> *reconfValue = NULL;
-				{
-					lock_guard<mutex> guard(m_pendingNewConfigMutex);
-					reconfValue = &m_pendingNewConfig[i];
-				}
-				std::string categoryName = reconfValue->first;
-				std::string category = reconfValue->second;
-				processConfigChange(categoryName, category);
-
-				logger->debug("SouthService::handlePendingReconf(): Handling of configuration change #%d done", i);
-			}
-			
-			{
-				lock_guard<mutex> guard(m_pendingNewConfigMutex);
-				for (unsigned int i=0; i<numPendingReconfs; i++)
-					m_pendingNewConfig.pop_front();
-				logger->debug("SouthService::handlePendingReconf DONE: first %d entry(ies) removed, m_pendingNewConfig new size=%d", numPendingReconfs, m_pendingNewConfig.size());
 			}
 		}
 	}


### PR DESCRIPTION
…lters are missing

Note: This PR prevents the crash and reports an error, it does not make the filters added this way work. This will require a bigger effort to resolve the long standing issue of multiple configuration categories for filters.