### PR TITLE
FOGL-9529 - Fixes for Python unit and system tests to support a minimum version of 3.6 and a maximum of 3.11

### DIFF
--- a/extras/python/fogbench/__main__.py
+++ b/extras/python/fogbench/__main__.py
@@ -218,11 +218,8 @@ async def send_to_coap(payload):
 
     context = await Context.create_client_context()
 
-    request = Message(payload=dumps(payload), code=Code.POST)
-    request.opt.uri_host = arg_host
-    request.opt.uri_port = arg_port
-    request.opt.uri_path = ("other", "sensor-values")
-
+    uri = "coap://{}:{}/other/sensor-values".format(arg_host, arg_port)
+    request = Message(payload=dumps(payload), uri=uri, code=Code.POST)
     response = await context.request(request).response
     str_res = str(response.code)
     status_code = str_res[:4]  # or str_res.split()[0]

--- a/tests/system/memory_leak/scripts/setup
+++ b/tests/system/memory_leak/scripts/setup
@@ -7,6 +7,24 @@ BRANCH=${2:-develop}   # here Branch means branch of fledge repository that is n
 COLLECT_FILES=${3}
 PROJECT_ROOT=$(pwd)
 
+get_pip_break_system_flag() {
+    # Get Python version from python3 --version and parse it
+    PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
+    PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
+    PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
+
+    # Default to empty flag
+    FLAG=""
+
+    # Set the FLAG only for Python versions 3.11 or higher
+    if [ "$PYTHON_MAJOR" -gt 3 ] || { [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -ge 11 ]; }; then
+        FLAG="--break-system-packages"
+    fi
+
+    # Return the FLAG (via echo)
+    echo "$FLAG"
+}
+
 # Function to fetch OS information
 fetch_os_info() {
     OS_NAME=$(grep -o '^NAME=.*' /etc/os-release | cut -f2 -d\" | sed 's/"//g')
@@ -75,8 +93,9 @@ install_c_plugin() {
 # Function to install Python based plugin
 install_python_plugin() {
     local plugin_dir="${1}"
+    BREAK_PKG_FLAG=$(get_pip_break_system_flag)
     # Install dependencies if requirements.txt exists
-    [[ -f ${plugin_dir}/requirements.txt ]] && python3 -m pip install -r "${plugin_dir}/requirements.txt"
+    [[ -f ${plugin_dir}/requirements.txt ]] && python3 -m pip install -r "${plugin_dir}/requirements.txt" ${BREAK_PKG_FLAG:+$BREAK_PKG_FLAG}
     # Copy plugin
     echo 'Copying Plugin'
     sudo cp -r "${plugin_dir}/python" "${FLEDGE_ROOT}/"

--- a/tests/system/python/scripts/install_python_plugin
+++ b/tests/system/python/scripts/install_python_plugin
@@ -31,6 +31,24 @@ if [ "${PLUGIN_NAME}" == "http_south" ] || [ "${PLUGIN_NAME}" == "http_north" ] 
 fi
 
 
+get_pip_break_system_flag() {
+    # Get Python version from python3 --version and parse it
+    PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
+    PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
+    PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
+
+    # Default to empty flag
+    FLAG=""
+
+    # Set the FLAG only for Python versions 3.11 or higher
+    if [ "$PYTHON_MAJOR" -gt 3 ] || { [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -ge 11 ]; }; then
+        FLAG="--break-system-packages"
+    fi
+
+    # Return the FLAG (via echo)
+    echo "$FLAG"
+}
+
 clean () {
    rm -rf /tmp/${REPO_NAME}
    rm -rf ${FLEDGE_ROOT}/python/fledge/plugins/${PLUGIN_TYPE}/fledge-${PLUGIN_TYPE}-${PLUGIN_NAME}
@@ -47,7 +65,8 @@ copy_file_and_requirement () {
         cp -r /tmp/${REPO_NAME}/python/fledge/plugins/${PLUGIN_TYPE}/${PLUGIN_NAME} $FLEDGE_ROOT/python/fledge/plugins/${PLUGIN_TYPE}/
     fi
     req_file=$(find /tmp/${REPO_NAME} -name requirement*.txt)
-    [ ! -z "${req_file}" ] && python3 -m pip install --user -Ir ${req_file} ${USE_PIP_CACHE} || echo "No such external dependency needed for ${PLUGIN_NAME} plugin."
+    BREAK_PKG_FLAG=$(get_pip_break_system_flag)
+    [ ! -z "${req_file}" ] && python3 -m pip install --user -Ir ${req_file} ${USE_PIP_CACHE} ${BREAK_PKG_FLAG:+$BREAK_PKG_FLAG} || echo "No such external dependency needed for ${PLUGIN_NAME} plugin."
 }
 
 clean

--- a/tests/unit/python/fledge/common/test_audit_logger.py
+++ b/tests/unit/python/fledge/common/test_audit_logger.py
@@ -12,11 +12,11 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 
-@asyncio.coroutine
-def mock_coro():
+async def mock_coro():
     return None
 
-class TestAuditLogger():
+
+class TestAuditLogger:
 
     @pytest.mark.asyncio
     async def test_constructor_no_storage(self):

--- a/tests/unit/python/fledge/common/test_configuration_manager.py
+++ b/tests/unit/python/fledge/common/test_configuration_manager.py
@@ -2826,7 +2826,7 @@ class TestConfigurationManager:
             with patch.object(PayloadBuilder, 'SET', return_value=PayloadBuilder) as pbsetpatch:
                 with patch.object(PayloadBuilder, 'WHERE', return_value=PayloadBuilder) as pbwherepatch:
                     with patch.object(PayloadBuilder, 'payload', return_value=None) as pbpayloadpatch:
-                        with patch.object(c_mgr, '_read_category_val', return_value=_rv1()) as readpatch:
+                        with patch.object(c_mgr, '_read_category_val', return_value=_rv1) as readpatch:
                             await c_mgr._update_category(category_name, category_val, category_description)
                         readpatch.assert_called_once_with(category_name)
                     pbpayloadpatch.assert_called_once_with()

--- a/tests/unit/python/fledge/common/test_configuration_manager.py
+++ b/tests/unit/python/fledge/common/test_configuration_manager.py
@@ -24,6 +24,9 @@ ITEM_NAME = "test_item_name"
 
 
 class TestConfigurationManager:
+    async def async_mock(self, return_value):
+        return return_value
+
     @pytest.fixture()
     def reset_singleton(self):
         # executed before each test
@@ -1295,13 +1298,10 @@ class TestConfigurationManager:
         assert test_config_new is not test_config_storage
 
     async def test__merge_category_vals_deprecated(self, reset_singleton, mocker):
-        async def async_mock(return_value):
-            return return_value
-
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock('CONCH')
+            _rv = await self.async_mock('CONCH')
         else:
-            _rv = asyncio.ensure_future(async_mock('CONCH'))
+            _rv = asyncio.ensure_future(self.async_mock('CONCH'))
 
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -1702,19 +1702,15 @@ class TestConfigurationManager:
         'degrees(value) < 171'
     ])
     async def test_bad_rule_create_category(self, reset_singleton, rule):
-
-        async def async_mock(return_value):
-            return return_value
-
         d = {'info': {'rule': rule, 'default': '3', 'type': 'integer', 'description': 'Test', 'value': '3'}}
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _se = await async_mock(d)
+            _se = await self.async_mock(d)
         else:
-            _se = asyncio.ensure_future(async_mock(d))
+            _se = asyncio.ensure_future(self.async_mock(d))
         
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_validate_category_val', side_effect=[_se,
@@ -1727,22 +1723,18 @@ class TestConfigurationManager:
         assert 1 == log_exc.call_count
 
     async def test_create_category_good_newval_bad_storageval_good_update(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock({})
-            _se = await async_mock({})
-            _sr = await async_mock((False, None, None, None))
+            _rv = await self.async_mock({})
+            _se = await self.async_mock({})
+            _sr = await self.async_mock((False, None, None, None))
         else:
-            _rv = asyncio.ensure_future(async_mock({}))
-            _se = asyncio.ensure_future(async_mock({}))
-            _sr = asyncio.ensure_future(async_mock((False, None, None, None)))
+            _rv = asyncio.ensure_future(self.async_mock({}))
+            _se = asyncio.ensure_future(self.async_mock({}))
+            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
         
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_validate_category_val', side_effect=[_se, Exception()]) as valpatch:
@@ -1762,22 +1754,18 @@ class TestConfigurationManager:
         log_exc.assert_called_once_with('category_value for category_name %s from storage is corrupted; using category_value without merge', 'catname')
 
     async def test_create_category_good_newval_bad_storageval_bad_update(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock({})
-            _se = await async_mock({})
-            _sr = await async_mock((False, None, None, None))
+            _rv = await self.async_mock({})
+            _se = await self.async_mock({})
+            _sr = await self.async_mock((False, None, None, None))
         else:
-            _rv = asyncio.ensure_future(async_mock({}))
-            _se = asyncio.ensure_future(async_mock({}))
-            _sr = asyncio.ensure_future(async_mock((False, None, None, None)))
+            _rv = asyncio.ensure_future(self.async_mock({}))
+            _se = asyncio.ensure_future(self.async_mock({}))
+            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
                 
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_validate_category_val', side_effect=[_se, Exception]) as valpatch:
@@ -1799,23 +1787,19 @@ class TestConfigurationManager:
 
     # (merged_value)
     async def test_create_category_good_newval_good_storageval_nochange(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         all_cat_names = [('rest_api', 'Fledge Admin and User REST API', 'rest_api'), ('catname', 'catdesc', 'catname')]
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock({})
-            _rv2 = await async_mock(all_cat_names)
-            _se = await async_mock({})
+            _rv1 = await self.async_mock({})
+            _rv2 = await self.async_mock(all_cat_names)
+            _se = await self.async_mock({})
         else:
-            _rv1 = asyncio.ensure_future(async_mock({}))
-            _rv2 = asyncio.ensure_future(async_mock(all_cat_names))
-            _se = asyncio.ensure_future(async_mock({}))
+            _rv1 = asyncio.ensure_future(self.async_mock({}))
+            _rv2 = asyncio.ensure_future(self.async_mock(all_cat_names))
+            _se = asyncio.ensure_future(self.async_mock({}))
 
         with patch.object(ConfigurationManager, '_validate_category_val', side_effect=[_se, _se]) as valpatch:
             with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv1) as readpatch:
@@ -1833,29 +1817,25 @@ class TestConfigurationManager:
         valpatch.assert_has_calls([call('catname', 'catvalue', True), call('catname', {}, False)])
 
     async def test_create_category_good_newval_good_storageval_good_update(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         all_cat_names = [('rest_api', 'Fledge Admin and User REST API', 'rest_api'), ('catname', 'catdesc', 'catname')]
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock({})
-            _rv2 = await async_mock(all_cat_names)
-            _rv3 = await async_mock({'bla': 'bla'})
-            _rv4 = await async_mock(None)
-            _se = await async_mock({})
-            _sr = await async_mock((False, None, None, None))
+            _rv1 = await self.async_mock({})
+            _rv2 = await self.async_mock(all_cat_names)
+            _rv3 = await self.async_mock({'bla': 'bla'})
+            _rv4 = await self.async_mock(None)
+            _se = await self.async_mock({})
+            _sr = await self.async_mock((False, None, None, None))
         else:
-            _rv1 = asyncio.ensure_future(async_mock({}))
-            _rv2 = asyncio.ensure_future(async_mock(all_cat_names))
-            _rv3 = asyncio.ensure_future(async_mock({'bla': 'bla'}))
-            _rv4 = asyncio.ensure_future(async_mock(None))
-            _se = asyncio.ensure_future(async_mock({}))
-            _sr = asyncio.ensure_future(async_mock((False, None, None, None)))
+            _rv1 = asyncio.ensure_future(self.async_mock({}))
+            _rv2 = asyncio.ensure_future(self.async_mock(all_cat_names))
+            _rv3 = asyncio.ensure_future(self.async_mock({'bla': 'bla'}))
+            _rv4 = asyncio.ensure_future(self.async_mock(None))
+            _se = asyncio.ensure_future(self.async_mock({}))
+            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
 
         with patch.object(ConfigurationManager, '_validate_category_val', side_effect=[_se, _se]) as valpatch:
             with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv1) as readpatch:
@@ -1884,25 +1864,21 @@ class TestConfigurationManager:
         valpatch.assert_has_calls([call('catname', 'catvalue', True), call('catname', {}, False)])
 
     async def test_create_category_good_newval_good_storageval_bad_update(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         all_cat_names = [('rest_api', 'Fledge Admin and User REST API', 'rest_api'), ('catname', 'catdesc', 'catname')]
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock({})
-            _rv2 = await async_mock(all_cat_names)
-            _rv4 = await async_mock(None)
-            _se = await async_mock({})
+            _rv1 = await self.async_mock({})
+            _rv2 = await self.async_mock(all_cat_names)
+            _rv4 = await self.async_mock(None)
+            _se = await self.async_mock({})
         else:
-            _rv1 = asyncio.ensure_future(async_mock({}))
-            _rv2 = asyncio.ensure_future(async_mock(all_cat_names))
-            _rv4 = asyncio.ensure_future(async_mock(None))
-            _se = asyncio.ensure_future(async_mock({}))
+            _rv1 = asyncio.ensure_future(self.async_mock({}))
+            _rv2 = asyncio.ensure_future(self.async_mock(all_cat_names))
+            _rv4 = asyncio.ensure_future(self.async_mock(None))
+            _se = asyncio.ensure_future(self.async_mock({}))
         
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_validate_category_val', side_effect=[_se, _se]) as valpatch:
@@ -1923,22 +1899,18 @@ class TestConfigurationManager:
                                         'and category_json_schema %s', 'catname', 'catdesc', {})
 
     async def test_create_category_good_newval_no_storageval_good_create(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock({})
-            _rv2 = await async_mock(None)
-            _sr = await async_mock((False, None, None, None))
+            _rv1 = await self.async_mock({})
+            _rv2 = await self.async_mock(None)
+            _sr = await self.async_mock((False, None, None, None))
         else:
-            _rv1 = asyncio.ensure_future(async_mock({}))
-            _rv2 = asyncio.ensure_future(async_mock(None))
-            _sr = asyncio.ensure_future(async_mock((False, None, None, None)))
+            _rv1 = asyncio.ensure_future(self.async_mock({}))
+            _rv2 = asyncio.ensure_future(self.async_mock(None))
+            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
 
         with patch.object(ConfigurationManager, '_validate_category_val', return_value=_rv1) as valpatch:
             with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv2) as readpatch:
@@ -1954,20 +1926,16 @@ class TestConfigurationManager:
         valpatch.assert_called_once_with('catname', 'catvalue', True)
 
     async def test_create_category_good_newval_no_storageval_bad_create(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock({})
-            _rv2 = await async_mock(None)
+            _rv1 = await self.async_mock({})
+            _rv2 = await self.async_mock(None)
         else:
-            _rv1 = asyncio.ensure_future(async_mock({}))
-            _rv2 = asyncio.ensure_future(async_mock(None))
+            _rv1 = asyncio.ensure_future(self.async_mock({}))
+            _rv2 = asyncio.ensure_future(self.async_mock(None))
         
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_validate_category_val', return_value=_rv1) as valpatch:
@@ -1984,20 +1952,16 @@ class TestConfigurationManager:
         log_exc.assert_called_once_with('Unable to create new category based on category_name %s and category_description %s and category_json_schema %s', 'catname', 'catdesc', {})
 
     async def test_create_category_good_newval_keyerror_bad_create(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock({})
-            _rv2 = await async_mock(None)
+            _rv1 = await self.async_mock({})
+            _rv2 = await self.async_mock(None)
         else:
-            _rv1 = asyncio.ensure_future(async_mock({}))
-            _rv2 = asyncio.ensure_future(async_mock(None))
+            _rv1 = asyncio.ensure_future(self.async_mock({}))
+            _rv2 = asyncio.ensure_future(self.async_mock(None))
         
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_validate_category_val', return_value=_rv1) as valpatch:
@@ -2031,10 +1995,6 @@ class TestConfigurationManager:
         log_exc.assert_called_once_with('Unable to create new category based on category_name %s and category_description %s and category_json_schema %s', 'catname', 'catdesc', '')
 
     async def test_set_category_item_value_entry_good_update(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         category_name = 'catname'
@@ -2045,11 +2005,11 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(storage_value_entry)
-            _rv2 = await async_mock(None)
+            _rv1 = await self.async_mock(storage_value_entry)
+            _rv2 = await self.async_mock(None)
         else:
-            _rv1 = asyncio.ensure_future(async_mock(storage_value_entry))
-            _rv2 = asyncio.ensure_future(async_mock(None))
+            _rv1 = asyncio.ensure_future(self.async_mock(storage_value_entry))
+            _rv2 = asyncio.ensure_future(self.async_mock(None))
 
         with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv1) as readpatch:
             with patch.object(ConfigurationManager, '_update_value_val', return_value=_rv2) as updatepatch:
@@ -2079,9 +2039,6 @@ class TestConfigurationManager:
     ])
     async def test_set_category_item_value_entry_bad_update(self, reset_singleton, new_value_entry, storage_result,
                                                             exc_name, exc_msg):
-        async def async_mock():
-            return storage_result
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         category_name = 'catname'
@@ -2089,9 +2046,9 @@ class TestConfigurationManager:
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
+            _rv = await self.async_mock(storage_result)
         else:
-            _rv = asyncio.ensure_future(async_mock())
+            _rv = asyncio.ensure_future(self.async_mock(storage_result))
         
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
@@ -2106,10 +2063,6 @@ class TestConfigurationManager:
         log_exc.assert_called_once_with('Unable to set item value entry based on category_name %s and item_name %s and value_item_entry %s', category_name, item_name, new_value_entry)
 
     async def test_set_category_item_value_entry_bad_storage(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
@@ -2119,9 +2072,9 @@ class TestConfigurationManager:
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
+            _rv = await self.async_mock(None)
         else:
-            _rv = asyncio.ensure_future(async_mock(None))
+            _rv = asyncio.ensure_future(self.async_mock(None))
         
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
@@ -2137,10 +2090,6 @@ class TestConfigurationManager:
         log_exc.assert_called_once_with('Unable to set item value entry based on category_name %s and item_name %s and value_item_entry %s', 'catname', 'itemname', 'newvalentry')
 
     async def test_set_category_item_value_entry_no_change(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
@@ -2150,9 +2099,9 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(new_value_entry)
+            _rv = await self.async_mock(new_value_entry)
         else:
-            _rv = asyncio.ensure_future(async_mock(new_value_entry))
+            _rv = asyncio.ensure_future(self.async_mock(new_value_entry))
 
         with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
             with patch.object(ConfigurationManager, '_update_value_val') as updatepatch:
@@ -2163,9 +2112,6 @@ class TestConfigurationManager:
         readpatch.assert_called_once_with(category_name, item_name)
 
     async def test_set_category_item_invalid_type_value(self, reset_singleton):
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         category_name = 'catname'
@@ -2174,9 +2120,9 @@ class TestConfigurationManager:
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock({'value': 'test', 'description': 'Test desc', 'type': 'boolean', 'default': 'test'})
+            _rv = await self.async_mock({'value': 'test', 'description': 'Test desc', 'type': 'boolean', 'default': 'test'})
         else:
-            _rv = asyncio.ensure_future(async_mock({'value': 'test', 'description': 'Test desc', 'type': 'boolean', 'default': 'test'}))
+            _rv = asyncio.ensure_future(self.async_mock({'value': 'test', 'description': 'Test desc', 'type': 'boolean', 'default': 'test'}))
         
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
@@ -2188,9 +2134,6 @@ class TestConfigurationManager:
         assert 1 == log_exc.call_count
 
     async def test_set_category_item_value_entry_with_enum_type(self, reset_singleton):
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
@@ -2202,11 +2145,11 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(storage_value_entry)
-            _rv2 = await async_mock(None)
+            _rv1 = await self.async_mock(storage_value_entry)
+            _rv2 = await self.async_mock(None)
         else:
-            _rv1 = asyncio.ensure_future(async_mock(storage_value_entry))
-            _rv2 = asyncio.ensure_future(async_mock(None))
+            _rv1 = asyncio.ensure_future(self.async_mock(storage_value_entry))
+            _rv2 = asyncio.ensure_future(self.async_mock(None))
 
         with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv1) as readpatch:
             with patch.object(ConfigurationManager, '_update_value_val', return_value=_rv2) as updatepatch:
@@ -2221,10 +2164,7 @@ class TestConfigurationManager:
         ("blah", "new value does not exist in options enum")
     ])
     async def test_set_category_item_value_entry_with_enum_type_exceptions(self, new_value_entry, message):
-        async def async_mock():
-            return {"default": "woo", "description": "enum types", "type": "enumeration",
-                    "options": ["foo", "woo"]}
-
+        cat = {"default": "woo", "description": "enum types", "type": "enumeration", "options": ["foo", "woo"]}
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         category_name = 'catname'
@@ -2232,9 +2172,9 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
+            _rv = await self.async_mock(cat)
         else:
-            _rv = asyncio.ensure_future(async_mock())
+            _rv = asyncio.ensure_future(self.async_mock(cat))
         
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
@@ -2246,10 +2186,7 @@ class TestConfigurationManager:
         assert 1 == log_exc.call_count
 
     async def test_set_category_item_value_entry_with_rule_optional_attribute(self):
-
-        async def async_mock():
-            return {'rule': 'value*3==9', 'default': '3', 'description': 'Test', 'value': '3', 'type': 'integer'}
-
+        cat = {'rule': 'value*3==9', 'default': '3', 'description': 'Test', 'value': '3', 'type': 'integer'}
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         category_name = 'catname'
@@ -2258,9 +2195,9 @@ class TestConfigurationManager:
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
+            _rv = await self.async_mock(cat)
         else:
-            _rv = asyncio.ensure_future(async_mock())
+            _rv = asyncio.ensure_future(self.async_mock(cat))
         
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
@@ -2272,10 +2209,6 @@ class TestConfigurationManager:
         assert 1 == log_exc.call_count
 
     async def test_set_category_item_value_entry_with_list_name(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         category_name = 'catname'
@@ -2288,11 +2221,11 @@ class TestConfigurationManager:
         c_mgr._cacheManager.update(category_name, "desc", {item_name: storage_value_entry})
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(storage_value_entry)
-            _rv2 = await async_mock(None)
+            _rv1 = await self.async_mock(storage_value_entry)
+            _rv2 = await self.async_mock(None)
         else:
-            _rv1 = asyncio.ensure_future(async_mock(storage_value_entry))
-            _rv2 = asyncio.ensure_future(async_mock(None))
+            _rv1 = asyncio.ensure_future(self.async_mock(storage_value_entry))
+            _rv2 = asyncio.ensure_future(self.async_mock(None))
 
         with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv1) as patch_read:
             with patch.object(ConfigurationManager, '_update_value_val', return_value=_rv2) as patch_update:
@@ -2303,18 +2236,14 @@ class TestConfigurationManager:
         patch_read.assert_called_once_with(category_name, item_name)
 
     async def test_get_all_category_names_good(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock('bla')
+            _rv = await self.async_mock('bla')
         else:
-            _rv = asyncio.ensure_future(async_mock('bla'))
+            _rv = asyncio.ensure_future(self.async_mock('bla'))
 
         with patch.object(ConfigurationManager, '_read_all_category_names', return_value=_rv) as readpatch:
             ret_val = await c_mgr.get_all_category_names()
@@ -2325,18 +2254,14 @@ class TestConfigurationManager:
         "True", "False"
     ])
     async def test_get_all_category_names_with_root(self, reset_singleton, value):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock('bla')
+            _rv = await self.async_mock('bla')
         else:
-            _rv = asyncio.ensure_future(async_mock('bla'))
+            _rv = asyncio.ensure_future(self.async_mock('bla'))
 
         with patch.object(ConfigurationManager, '_read_all_groups', return_value=_rv) as readpatch:
             ret_val = await c_mgr.get_all_category_names(root=value)
@@ -2355,10 +2280,6 @@ class TestConfigurationManager:
         log_exc.assert_called_once_with('Unable to read all category names')
 
     async def test_get_category_all_items_good(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         category_name = 'catname'
         cat_value = {"config_item": {"type": "string", "default": "blah", "description": "Des", "value": "blah"}}
         cat_info = {'display_name': category_name, 'key': category_name, 'description': 'Test Des', "value": cat_value}
@@ -2367,9 +2288,9 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(cat_info)
+            _rv = await self.async_mock(cat_info)
         else:
-            _rv = asyncio.ensure_future(async_mock(cat_info))
+            _rv = asyncio.ensure_future(self.async_mock(cat_info))
 
         with patch.object(ConfigurationManager, '_read_category', return_value=_rv) as readpatch:
             ret_val = await c_mgr.get_category_all_items(category_name)
@@ -2389,10 +2310,6 @@ class TestConfigurationManager:
         log_exc.assert_called_once_with('Unable to get all category items of {} category.'.format(category_name))
 
     async def test_get_category_item_good(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         category_name = 'catname'
         item_name = 'item_name'
         storage_client_mock = MagicMock(spec=StorageClientAsync)
@@ -2400,11 +2317,11 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock('bla')
-            _rv2 = await async_mock(None)
+            _rv1 = await self.async_mock('bla')
+            _rv2 = await self.async_mock(None)
         else:
-            _rv1 = asyncio.ensure_future(async_mock('bla'))
-            _rv2 = asyncio.ensure_future(async_mock(None))        
+            _rv1 = asyncio.ensure_future(self.async_mock('bla'))
+            _rv2 = asyncio.ensure_future(self.async_mock(None))
 
         with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv1) as read_item_patch:
             with patch.object(ConfigurationManager, '_read_category', return_value=_rv2) as read_cat_patch:
@@ -2427,10 +2344,6 @@ class TestConfigurationManager:
         log_exc.assert_called_once_with('Unable to get category item based on category_name %s and item_name %s', 'catname', 'item_name')
 
     async def test_get_category_item_value_entry_good(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         category_name = 'catname'
         item_name = 'item_name'
         storage_client_mock = MagicMock(spec=StorageClientAsync)
@@ -2438,9 +2351,9 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock('bla')
+            _rv = await self.async_mock('bla')
         else:
-            _rv = asyncio.ensure_future(async_mock('bla'))        
+            _rv = asyncio.ensure_future(self.async_mock('bla'))
 
         with patch.object(ConfigurationManager, '_read_value_val', return_value=_rv) as readpatch:
             ret_val = await c_mgr.get_category_item_value_entry(category_name, item_name)
@@ -2461,24 +2374,18 @@ class TestConfigurationManager:
         log_exc.assert_called_once_with('Unable to get the "value" entry based on category_name %s and item_name %s', 'catname', 'item_name')
 
     async def test__create_new_category_good(self, reset_singleton):
-        async def mock_coro():
-            return {'response': [{'display_name': 'catname', 'category_name': 'catname', 'category_val': 'catval', 'description': 'catdesc'}]}
-
-        async def async_mock(return_value):
-            return return_value
-
         category_name = 'catname'
         category_val = 'catval'
         category_description = 'catdesc'
-
-
+        category_response = {'response': [{'display_name': 'catname', 'category_name': 'catname',
+                                           'category_val': 'catval', 'description': 'catdesc'}]}
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
-            _attr = await mock_coro()
+            _rv = await self.async_mock(None)
+            _attr = await self.async_mock(category_response)
         else:
-            _rv = asyncio.ensure_future(async_mock(None))
-            _attr = asyncio.ensure_future(mock_coro())
+            _rv = asyncio.ensure_future(self.async_mock(None))
+            _attr = asyncio.ensure_future(self.async_mock(category_response))
 
         attrs = {"insert_into_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2498,17 +2405,6 @@ class TestConfigurationManager:
             'configuration', None)
 
     async def test_create_new_category_deprecated(self, reset_singleton):
-        async def mock_coro():
-            return {'response': [{
-                'category_name': 'catname',
-                'category_val': 'catval',
-                'description': 'catdesc'
-            }]
-            }
-
-        async def async_mock(return_value):
-            return return_value
-
         category_name = 'catname'
         category_val = {
             "test_item_name1": {
@@ -2533,15 +2429,16 @@ class TestConfigurationManager:
         }
 
         category_description = 'catdesc'
+        category_response = {'response': [
+            {'category_name': 'catname', 'category_val': 'catval', 'description': 'catdesc'}]}
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
-            _attr = await mock_coro()
+            _rv = await self.async_mock(None)
+            _attr = await self.async_mock(category_response)
         else:
-            _rv = asyncio.ensure_future(async_mock(None))
-            _attr = asyncio.ensure_future(mock_coro())        
-
+            _rv = asyncio.ensure_future(self.async_mock(None))
+            _attr = asyncio.ensure_future(self.async_mock(category_response))
         attrs = {"insert_into_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2559,17 +2456,6 @@ class TestConfigurationManager:
         storage_client_mock.insert_into_tbl.assert_called_once_with('configuration', None)
 
     async def test_create_new_category_with_list_name(self, reset_singleton):
-        async def mock_coro():
-            return {'response': [{
-                'category_name': 'catname',
-                'category_val': 'catval',
-                'description': 'catdesc'
-            }]
-            }
-
-        async def async_mock(return_value):
-            return return_value
-
         category_name = 'catname'
         category_val = {
             "config_item": {
@@ -2582,13 +2468,15 @@ class TestConfigurationManager:
             }
         }
         category_description = 'catdesc'
+        category_response = {'response': [
+            {'category_name': 'catname', 'category_val': 'catval', 'description': 'catdesc'}]}
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
-            _attr = await mock_coro()
+            _rv = await self.async_mock(None)
+            _attr = await self.async_mock(category_response)
         else:
-            _rv = asyncio.ensure_future(async_mock(None))
-            _attr = asyncio.ensure_future(mock_coro())
+            _rv = asyncio.ensure_future(self.async_mock(None))
+            _attr = asyncio.ensure_future(self.async_mock(category_response))
 
         attrs = {"insert_into_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2608,14 +2496,12 @@ class TestConfigurationManager:
         storage_client_mock.insert_into_tbl.assert_called_once_with('configuration', None)
 
     async def test__read_all_category_names_1_row(self, reset_singleton):
-        async def mock_coro():
-            return {'rows': [{'key': 'key1', 'description': 'description1', 'display_name': 'display key'}]}
-
+        rows = {'rows': [{'key': 'key1', 'description': 'description1', 'display_name': 'display key'}]}
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2629,14 +2515,13 @@ class TestConfigurationManager:
         assert [('key1', 'description1', 'display key')] == ret_val
 
     async def test__read_all_category_names_2_row(self, reset_singleton):
-        async def mock_coro():
-            return {'rows': [{'key': 'key1', 'description': 'description1', 'display_name': 'display key1'}, {'key': 'key2', 'description': 'description2', 'display_name': 'display key2'}]}
-
+        rows = {'rows': [{'key': 'key1', 'description': 'description1', 'display_name': 'display key1'},
+                         {'key': 'key2', 'description': 'description2', 'display_name': 'display key2'}]}
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2649,14 +2534,12 @@ class TestConfigurationManager:
         assert [('key1', 'description1', 'display key1'), ('key2', 'description2', 'display key2')] == ret_val
 
     async def test__read_all_category_names_0_row(self, reset_singleton):
-        async def mock_coro():
-            return {'rows': []}
-
+        rows = {'rows': []}
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr }
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2669,14 +2552,12 @@ class TestConfigurationManager:
         assert [] == ret_val
 
     async def test__read_category_0_row(self, reset_singleton):
-        async def async_mock():
-            return {"rows": []}
-
+        rows = {"rows": []}
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await async_mock()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(async_mock())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2691,18 +2572,15 @@ class TestConfigurationManager:
                 "where": {"column": "key", "condition": "=", "value": CAT_NAME}, "limit": 1} == p
 
     async def test__read_category_1_row(self, reset_singleton):
-        async def async_mock():
-            return {"rows": storage_result, "count": 1}
-
         storage_result = [{'display_name': CAT_NAME, 'key': CAT_NAME, 'description': 'Test Des',
                            'value': {'config_item': {'default': 'blah', 'value': 'blah', 'description': 'Des',
                                                      'type': 'string'}}}]
-
+        rows = {"rows": storage_result, "count": 1}
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await async_mock()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(async_mock())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2721,7 +2599,6 @@ class TestConfigurationManager:
         (False, [('service', 'Fledge service', 'SERV'), ('rest_api', 'User REST API', 'API')])
     ])
     async def test__read_all_groups(self, reset_singleton, value, expected_result):
-        @asyncio.coroutine
         def q_result(*args):
             table = args[0]
             payload = json.loads(args[1])
@@ -2741,15 +2618,13 @@ class TestConfigurationManager:
         assert 2 == query_tbl_patch.call_count
 
     async def test__read_category_val_1_row(self, reset_singleton):
-        async def mock_coro():
-            return {'rows': [{'value': 'value1'}]}
+        rows = {'rows': [{'value': 'value1'}]}
         category_name = 'catname'
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2768,16 +2643,13 @@ class TestConfigurationManager:
             'configuration', None)
 
     async def test__read_category_val_0_row(self, reset_singleton):
-        async def mock_coro():
-            return {'rows': []}
-
+        rows = {'rows': []}
         category_name = 'catname'
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2796,18 +2668,14 @@ class TestConfigurationManager:
             'configuration', None)
 
     async def test__read_item_val_0_row(self, reset_singleton):
-        @asyncio.coroutine
-        def mock_coro():
-            return {'rows': []}
-
+        rows = {'rows': []}
         category_name = 'catname'
         item_name = 'itemname'
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2816,18 +2684,14 @@ class TestConfigurationManager:
         assert ret_val is None
 
     async def test__read_item_val_1_row(self, reset_singleton):
-        @asyncio.coroutine
-        def mock_coro():
-            return {'rows': [{'value': 'value1'}]}
-
+        rows = {'rows': [{'value': 'value1'}]}
         category_name = 'catname'
         item_name = 'itemname'
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2836,18 +2700,14 @@ class TestConfigurationManager:
         assert ret_val == 'value1'
 
     async def test__read_value_val_0_row(self, reset_singleton):
-        @asyncio.coroutine
-        def mock_coro():
-            return {'rows': []}
-
+        rows = {'rows': []}
         category_name = 'catname'
         item_name = 'itemname'
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2856,18 +2716,14 @@ class TestConfigurationManager:
         assert ret_val is None
 
     async def test__read_value_val_1_row(self, reset_singleton):
-        @asyncio.coroutine
-        def mock_coro():
-            return {'rows': [{'value': 'value1'}]}
-
+        rows = {'rows': [{'value': 'value1'}]}
         category_name = 'catname'
         item_name = 'itemname'
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2876,23 +2732,17 @@ class TestConfigurationManager:
         assert ret_val == 'value1'
 
     async def test__update_value_val(self, reset_singleton):
-        async def async_mock(return_value):
-            return return_value
-
-        async def mock_coro():
-            return {"rows": []}
-
+        rows = {"rows": []}
         category_name = 'catname'
         item_name = 'itemname'
         new_value_val = 'newval'
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
-            _rv = await async_mock(None)
+            _attr = await self.async_mock(rows)
+            _rv = await self.async_mock(None)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
-            _rv = asyncio.ensure_future(async_mock(None))      
+            _attr = asyncio.ensure_future(self.async_mock(rows))
+            _rv = asyncio.ensure_future(self.async_mock(None))
 
         attrs = {"query_tbl_with_payload.return_value": _attr, "update_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2906,18 +2756,15 @@ class TestConfigurationManager:
                 'category': category_name, 'item': item_name, 'oldValue': None, 'newValue': new_value_val})
 
     async def test__update_value_val_storageservererror(self, reset_singleton):
-        async def mock_coro():
-            return {"rows": []}
-
+        rows = {"rows": []}
         category_name = 'catname'
         item_name = 'itemname'
         new_value_val = 'newval'
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr, "update_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2934,18 +2781,15 @@ class TestConfigurationManager:
         assert 0 == auditinfopatch.call_count
 
     async def test__update_value_val_keyerror(self, reset_singleton):
-        async def mock_coro():
-            return {"rows": []}
-
+        rows = {"rows": []}
         category_name = 'catname'
         item_name = 'itemname'
         new_value_val = 'newval'
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr, "update_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2962,22 +2806,18 @@ class TestConfigurationManager:
         assert 0 == auditinfopatch.call_count
 
     async def test__update_category(self, reset_singleton):
-        async def mock_coro():
-            return {"response": "dummy"}
-
+        response = {"response": "dummy"}
         category_name = 'catname'
         category_description = 'catdesc'
         category_val = 'catval'
-
-        @asyncio.coroutine
         def mock_coro2():
             return category_val
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(response)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(response))
 
         attrs = {"update_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -2996,18 +2836,15 @@ class TestConfigurationManager:
         storage_client_mock.update_tbl.assert_called_once_with('configuration', None)
 
     async def test__update_category_storageservererror(self, reset_singleton):
-        async def mock_coro():
-            return {"response": "dummy"}
-
+        response = {"response": "dummy"}
         category_name = 'catname'
         category_description = 'catdesc'
         category_val = 'catval'
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(response)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(response))
 
         attrs = {"update_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -3028,18 +2865,15 @@ class TestConfigurationManager:
         assert 0 == storage_client_mock.update_tbl.call_count
 
     async def test__update_category_keyerror(self, reset_singleton):
-        async def mock_coro():
-            return {"noresponse": "dummy"}
-
+        response = {"noresponse": "dummy"}
         category_name = 'catname'
         category_description = 'catdesc'
         category_val = 'catval'
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(response)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(response))
 
         attrs = {"update_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -3057,9 +2891,6 @@ class TestConfigurationManager:
         storage_client_mock.update_tbl.assert_called_once_with('configuration', None)
 
     async def test_get_category_child(self):
-        async def async_mock(return_value):
-            return return_value
-
         category_name = 'HTTP SOUTH'
         all_child_ret_val = [{'parent': 'south', 'child': category_name}]
         child_info_ret_val = [{'key': category_name, 'description': 'HTTP South Plugin', 'display_name': category_name}]
@@ -3069,13 +2900,13 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock('bla')
-            _rv2 = await async_mock(all_child_ret_val)
-            _rv3 = await async_mock(child_info_ret_val)
+            _rv1 = await self.async_mock('bla')
+            _rv2 = await self.async_mock(all_child_ret_val)
+            _rv3 = await self.async_mock(child_info_ret_val)
         else:
-            _rv1 = asyncio.ensure_future(async_mock('bla'))
-            _rv2 = asyncio.ensure_future(async_mock(all_child_ret_val))
-            _rv3 = asyncio.ensure_future(async_mock(child_info_ret_val))
+            _rv1 = asyncio.ensure_future(self.async_mock('bla'))
+            _rv2 = asyncio.ensure_future(self.async_mock(all_child_ret_val))
+            _rv3 = asyncio.ensure_future(self.async_mock(child_info_ret_val))
 
         with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv1) as patch_read_cat_val:
             with patch.object(ConfigurationManager, '_read_all_child_category_names', return_value=_rv2) as patch_read_all_child:
@@ -3087,18 +2918,15 @@ class TestConfigurationManager:
         patch_read_cat_val.assert_called_once_with(category_name)
 
     async def test_get_category_child_no_exist(self):
-        async def async_mock(return_value):
-            return return_value
-
         category_name = 'HTTP SOUTH'
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
+            _rv = await self.async_mock(None)
         else:
-            _rv = asyncio.ensure_future(async_mock(None))
+            _rv = asyncio.ensure_future(self.async_mock(None))
 
         with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv) as patch_read_cat_val:
             with pytest.raises(ValueError) as excinfo:
@@ -3122,15 +2950,11 @@ class TestConfigurationManager:
         ("south", None, 'No such coap child exist')
     ])
     async def test_create_child_category_no_exists(self, ret_cat_name, ret_child_name, message):
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             if args[0] == cat_name:
-                return async_mock(ret_cat_name)
+                return ret_cat_name
             if args[0] == child_name:
-                return async_mock(ret_child_name)
-
-        async def async_mock(return_value):
-            return return_value
+                return ret_child_name
 
         cat_name = 'south'
         child_name = ["coap"]
@@ -3142,15 +2966,11 @@ class TestConfigurationManager:
             assert message == str(excinfo.value)
 
     async def test_create_child_category(self, reset_singleton):
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             if args[0] == cat_name:
-                return async_mock('blah1')
+                return 'blah1'
             if args[0] == child_name:
-                return async_mock('blah2')
-
-        async def async_mock(return_value):
-            return return_value
+                return 'blah2'
 
         cat_name = 'south'
         child_name = "coap"
@@ -3161,13 +2981,13 @@ class TestConfigurationManager:
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock('inserted')
-            _rv2 = await async_mock(all_child_ret_val)
-            _sr = await async_mock((False, None, None, None))
+            _rv1 = await self.async_mock('inserted')
+            _rv2 = await self.async_mock(all_child_ret_val)
+            _sr = await self.async_mock((False, None, None, None))
         else:
-            _rv1 = asyncio.ensure_future(async_mock('inserted'))
-            _rv2 = asyncio.ensure_future(async_mock(all_child_ret_val))
-            _sr = asyncio.ensure_future(async_mock((False, None, None, None)))
+            _rv1 = asyncio.ensure_future(self.async_mock('inserted'))
+            _rv2 = asyncio.ensure_future(self.async_mock(all_child_ret_val))
+            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
         
         with patch.object(ConfigurationManager, '_read_category_val', side_effect=q_result):
             with patch.object(ConfigurationManager, '_read_all_child_category_names',
@@ -3183,15 +3003,11 @@ class TestConfigurationManager:
         patch_create_child.assert_called_once_with(cat_name, child_name)
 
     async def test_create_child_category_if_exists(self, reset_singleton):
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             if args[0] == cat_name:
-                return async_mock('blah1')
+                return 'blah1'
             if args[0] == child_name:
-                return async_mock('blah2')
-
-        async def async_mock(return_value):
-            return return_value
+                return 'blah2'
 
         cat_name = 'south'
         child_name = "coap"
@@ -3202,11 +3018,11 @@ class TestConfigurationManager:
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(all_child_ret_val)
-            _sr = await async_mock((False, None, None, None))
+            _rv = await self.async_mock(all_child_ret_val)
+            _sr = await self.async_mock((False, None, None, None))
         else:
-            _rv = asyncio.ensure_future(async_mock(all_child_ret_val))
-            _sr = asyncio.ensure_future(async_mock((False, None, None, None)))
+            _rv = asyncio.ensure_future(self.async_mock(all_child_ret_val))
+            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
         
         with patch.object(ConfigurationManager, '_read_category_val', side_effect=q_result):
             with patch.object(ConfigurationManager, '_read_all_child_category_names',
@@ -3234,15 +3050,11 @@ class TestConfigurationManager:
         ("south", None, 'No such coap child exist')
     ])
     async def test_delete_child_category_no_exists(self, ret_cat_name, ret_child_name, message):
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             if args[0] == cat_name:
-                return async_mock(ret_cat_name)
+                return await self.async_mock(ret_cat_name)
             if args[0] == child_name:
-                return async_mock(ret_child_name)
-
-        async def async_mock(return_value):
-            return return_value
+                return await self.async_mock(ret_child_name)
 
         cat_name = 'south'
         child_name = 'coap'
@@ -3254,18 +3066,11 @@ class TestConfigurationManager:
             assert message == str(excinfo.value)
 
     async def test_delete_child_category(self, reset_singleton):
-        async def mock_coro():
-            return expected_result
-
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             if args[0] == cat_name:
-                return async_mock('blah1')
+                return await self.async_mock('blah1')
             if args[0] == child_name:
-                return async_mock('blah2')
-
-        async def async_mock(return_value):
-            return return_value
+                return await self.async_mock('blah2')
 
         expected_result = {"response": "deleted", "rows_affected": 1}
         cat_name = 'south'
@@ -3274,11 +3079,11 @@ class TestConfigurationManager:
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
-            _rv = await async_mock(all_child_ret_val)
+            _attr = await self.async_mock(expected_result)
+            _rv = await self.async_mock(all_child_ret_val)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
-            _rv = asyncio.ensure_future(async_mock(all_child_ret_val))
+            _attr = asyncio.ensure_future(self.async_mock(expected_result))
+            _rv = asyncio.ensure_future(self.async_mock(all_child_ret_val))
         
         attrs = {"delete_from_tbl.return_value": _attr}
         payload = {"where": {"column": "parent", "condition": "=", "value": "south", "and": {"column": "child", "condition": "=", "value": "coap"}}}
@@ -3295,26 +3100,18 @@ class TestConfigurationManager:
         assert payload == json.loads(del_args[1])
 
     async def test_delete_child_category_key_error(self, reset_singleton):
-        async def mock_coro():
-            return expected_result
-
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             if args[0] == cat_name:
-                return async_mock('blah1')
+                return await self.async_mock('blah1')
             if args[0] == child_name:
-                return async_mock('blah2')
-
-        async def async_mock(return_value):
-            return return_value
+                return await self.async_mock('blah2')
 
         expected_result = {"message": "blah"}
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(expected_result)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(expected_result))
 
         attrs = {"delete_from_tbl.return_value": _attr}
         cat_name = 'south'
@@ -3327,15 +3124,11 @@ class TestConfigurationManager:
             assert 'blah' == str(excinfo.value)
 
     async def test_delete_child_category_storage_exception(self, reset_singleton):
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             if args[0] == cat_name:
-                return async_mock('blah1')
+                return await self.async_mock('blah1')
             if args[0] == child_name:
-                return async_mock('blah2')
-
-        async def async_mock(return_value):
-            return return_value
+                return await self.async_mock('blah2')
 
         cat_name = 'south'
         child_name = 'coap'
@@ -3350,21 +3143,14 @@ class TestConfigurationManager:
                 assert str(msg) == str(excinfo.value)
 
     async def test_delete_parent_category(self, reset_singleton):
-        async def mock_coro():
-            return expected_result
-
-        async def async_mock(return_value):
-            return return_value
-
         expected_result = {"response": "deleted", "rows_affected": 1}
-
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
-            _rv = await async_mock('bla')
+            _attr = await self.async_mock(expected_result)
+            _rv = await self.async_mock('bla')
         else:
-            _attr = asyncio.ensure_future(mock_coro())
-            _rv = asyncio.ensure_future(async_mock('bla'))        
+            _attr = asyncio.ensure_future(self.async_mock(expected_result))
+            _rv = asyncio.ensure_future(self.async_mock('bla'))
 
         attrs = {"delete_from_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -3385,18 +3171,15 @@ class TestConfigurationManager:
         assert 'category_name must be a string' == str(excinfo.value)
 
     async def test_delete_parent_category_no_exists(self):
-        async def async_mock(return_value):
-            return return_value
-
         category_name = 'blah'
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
+            _rv = await self.async_mock(None)
         else:
-            _rv = asyncio.ensure_future(async_mock(None))
+            _rv = asyncio.ensure_future(self.async_mock(None))
 
         with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv) as patch_read_cat_val:
             with pytest.raises(ValueError) as excinfo:
@@ -3405,20 +3188,14 @@ class TestConfigurationManager:
         patch_read_cat_val.assert_called_once_with(category_name)
 
     async def test_delete_parent_category_key_error(self, reset_singleton):
-        @asyncio.coroutine
-        def mock_coro():
-            return {"message": "blah"}
-
-        async def async_mock(return_value):
-            return return_value
-
+        rows = {"message": "blah"}
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
-            _rv = await async_mock('blah')
+            _attr = await self.async_mock(rows)
+            _rv = await self.async_mock('blah')
         else:
-            _attr = asyncio.ensure_future(mock_coro())
-            _rv = asyncio.ensure_future(async_mock('blah')) 
+            _attr = asyncio.ensure_future(self.async_mock(rows))
+            _rv = asyncio.ensure_future(self.async_mock('blah'))
 
         attrs = {"delete_from_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -3431,34 +3208,27 @@ class TestConfigurationManager:
         patch_read_cat_val.assert_called_once_with("south")
 
     async def test_delete_parent_category_storage_exception(self, reset_singleton):
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         msg = {"entryPoint": "delete", "message": "failed"}
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock('blah')
+            _rv = await self.async_mock('blah')
         else:
-            _rv = asyncio.ensure_future(async_mock('blah'))
+            _rv = asyncio.ensure_future(self.async_mock('blah'))
 
         with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv) as patch_read_cat_val:
-            with patch.object(storage_client_mock, 'delete_from_tbl', side_effect=StorageServerError(code=400,
-                                                                                                     reason="blah", error=msg)):
+            with patch.object(storage_client_mock, 'delete_from_tbl', side_effect=
+            StorageServerError(code=400, reason="blah", error=msg)):
                 with pytest.raises(ValueError) as excinfo:
                     await c_mgr.delete_parent_category("south")
                 assert str(msg) == str(excinfo.value)
         patch_read_cat_val.assert_called_once_with("south")
 
     async def test_delete_category_and_children_recursively(self, mocker, reset_singleton):
-        @asyncio.coroutine
         def mock_coro(a, b):
             return expected_result
-
-        async def async_mock(return_value):
-            return return_value
 
         async def mock_read_all_child_category_names(cat):
             """
@@ -3517,11 +3287,11 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock('bla')
-            _sr = await async_mock((False, None, None, None))
+            _rv = await self.async_mock('bla')
+            _sr = await self.async_mock((False, None, None, None))
         else:
-            _rv = asyncio.ensure_future(async_mock('bla'))
-            _sr = asyncio.ensure_future(async_mock((False, None, None, None)))
+            _rv = asyncio.ensure_future(self.async_mock('bla'))
+            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
         
         c_mgr = ConfigurationManager(storage_client_mock)
         patch_read_cat_val = mocker.patch.object(ConfigurationManager, '_read_category_val',
@@ -3598,14 +3368,9 @@ class TestConfigurationManager:
             audit_info.has_calls(audit_calls, any_order=True)
 
     async def test_delete_category_and_children_recursively_exception(self, mocker, reset_singleton):
-        @asyncio.coroutine
         def mock_coro(a, b):
             return expected_result
 
-        async def async_mock(return_value):
-            return return_value
-
-        @asyncio.coroutine
         def mock_read_all_child_category_names(cat):
             """
             Mimics 
@@ -3663,9 +3428,9 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock('bla')
+            _rv = await self.async_mock('bla')
         else:
-            _rv = asyncio.ensure_future(async_mock('bla'))
+            _rv = asyncio.ensure_future(self.async_mock('bla'))
         
         c_mgr = ConfigurationManager(storage_client_mock)
         mocker.patch.object(ConfigurationManager, '_read_category_val', return_value=_rv)
@@ -3682,14 +3447,12 @@ class TestConfigurationManager:
         assert str(msg) == str(excinfo.value)
 
     async def test__read_all_child_category_names(self, reset_singleton):
-        async def mock_coro():
-            return {'rows': [{'parent': 'south', 'child': 'http'}], 'count': 1}
-
+        rows = {'rows': [{'parent': 'south', 'child': 'http'}], 'count': 1}
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -3702,14 +3465,12 @@ class TestConfigurationManager:
         assert payload == json.loads(args[1])
 
     async def test__read_child_info(self, reset_singleton):
-        async def mock_coro():
-            return {'rows': [{'description': 'HTTP South Plugin', 'key': 'HTTP SOUTH'}], 'count': 1}
-
+        rows = {'rows': [{'description': 'HTTP South Plugin', 'key': 'HTTP SOUTH'}], 'count': 1}
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -3724,14 +3485,12 @@ class TestConfigurationManager:
         assert payload == json.loads(args[1])
 
     async def test__create_child(self):
-        async def mock_coro():
-            return {"response": "inserted", "rows_affected": 1}
-
+        response = {"response": "inserted", "rows_affected": 1}
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(response)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(response))
 
         attrs = {"insert_into_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -3746,14 +3505,12 @@ class TestConfigurationManager:
         assert payload == json.loads(args[1])
 
     async def test__create_child_key_error(self, reset_singleton):
-        async def mock_coro():
-            return {"message": "blah"}
-
+        rows = {"message": "blah"}
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await mock_coro()
+            _attr = await self.async_mock(rows)
         else:
-            _attr = asyncio.ensure_future(mock_coro())
+            _attr = asyncio.ensure_future(self.async_mock(rows))
 
         attrs = {"insert_into_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -3933,19 +3690,16 @@ class TestConfigurationManager:
     ])
     async def test_update_configuration_item_bulk_exceptions(self, cat_info, config_item_list, exc_type, exc_msg,
                                                              category_name='testcat'):
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            rv1 = await async_mock(cat_info)
-            rv2 = await async_mock("")
+            rv1 = await self.async_mock(cat_info)
+            rv2 = await self.async_mock("")
         else:
-            rv1 = asyncio.ensure_future(async_mock(cat_info))
-            rv2 = asyncio.ensure_future(async_mock(""))
+            rv1 = asyncio.ensure_future(self.async_mock(cat_info))
+            rv2 = asyncio.ensure_future(self.async_mock(""))
 
         with patch.object(c_mgr, 'get_category_all_items', return_value=rv1) as patch_get_all_items:
             with patch.object(c_mgr, '_check_updates_by_role', return_value=rv2):
@@ -3958,9 +3712,6 @@ class TestConfigurationManager:
         patch_get_all_items.assert_called_once_with(category_name)
 
     async def test_update_configuration_item_bulk(self, category_name='rest_api'):
-        async def async_mock(return_value):
-            return return_value
-
         cat_info = {'enableHttp': {'default': 'true', 'description': 'Enable HTTP', 'type': 'boolean', 'value': 'true'}}
         config_item_list = {"enableHttp": "false"}
         update_result = {"response": "updated", "rows_affected": 1}
@@ -3975,15 +3726,15 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(cat_info)
-            _rv2 = await async_mock(update_result)
-            _rv3 = await async_mock(read_val)
-            _rv4 = await async_mock(None)
+            _rv1 = await self.async_mock(cat_info)
+            _rv2 = await self.async_mock(update_result)
+            _rv3 = await self.async_mock(read_val)
+            _rv4 = await self.async_mock(None)
         else:
-            _rv1 = asyncio.ensure_future(async_mock(cat_info))
-            _rv2 = asyncio.ensure_future(async_mock(update_result))
-            _rv3 = asyncio.ensure_future(async_mock(read_val))
-            _rv4 = asyncio.ensure_future(async_mock(None))
+            _rv1 = asyncio.ensure_future(self.async_mock(cat_info))
+            _rv2 = asyncio.ensure_future(self.async_mock(update_result))
+            _rv3 = asyncio.ensure_future(self.async_mock(read_val))
+            _rv4 = asyncio.ensure_future(self.async_mock(None))
 
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_all_items:
             with patch.object(c_mgr._storage, 'update_tbl', return_value=_rv2) as patch_update:
@@ -4002,9 +3753,6 @@ class TestConfigurationManager:
         patch_get_all_items.assert_called_once_with(category_name)
 
     async def test_update_configuration_item_bulk_no_change(self, category_name='rest_api'):
-        async def async_mock(return_value):
-            return return_value
-
         cat_info = {'enableHttp': {'default': 'true', 'description': 'Enable HTTP', 'type': 'boolean', 'value': 'true'}}
         config_item_list = {"enableHttp": "true"}
         storage_client_mock = MagicMock(spec=StorageClientAsync)
@@ -4012,9 +3760,9 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(cat_info)
+            _rv = await self.async_mock(cat_info)
         else:
-            _rv = asyncio.ensure_future(async_mock(cat_info))
+            _rv = asyncio.ensure_future(self.async_mock(cat_info))
 
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_all_items:
             with patch.object(c_mgr._storage, 'update_tbl') as patch_update:
@@ -4028,9 +3776,6 @@ class TestConfigurationManager:
         patch_get_all_items.assert_called_once_with(category_name)
 
     async def test_update_configuration_item_bulk_dict_no_change(self, category_name='rest_api'):
-        async def async_mock(return_value):
-            return return_value
-
         cat_info = {'providers': {'default': '{"providers": ["username", "ldap"] }', 'description': 'descr',
                                   'type': 'JSON', 'value': '{"providers": ["username", "ldap"] }'}}
         config_item_list = {"providers": {"providers": ["username", "ldap"]}}
@@ -4039,9 +3784,9 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(cat_info)
+            _rv = await self.async_mock(cat_info)
         else:
-            _rv = asyncio.ensure_future(async_mock(cat_info))
+            _rv = asyncio.ensure_future(self.async_mock(cat_info))
 
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_all_items:
             with patch.object(c_mgr._storage, 'update_tbl') as patch_update:
@@ -4055,9 +3800,6 @@ class TestConfigurationManager:
         patch_get_all_items.assert_called_once_with(category_name)
 
     async def test_update_configuration_item_bulk_dict_change(self, category_name='rest_api'):
-        async def async_mock(return_value):
-            return return_value
-
         cat_info = {'providers': {'default': '{"providers": ["username", "ldap"] }', 'description': 'descr',
                                   'type': 'JSON', 'value': '{"providers": ["username", "ldap"] }'}}
         config_item_list = {"providers": {"providers": ["username", "ldap_new"]}}
@@ -4074,15 +3816,15 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(cat_info)
-            _rv2 = await async_mock(update_result)
-            _rv3 = await async_mock(read_val)
-            _rv4 = await async_mock(None)
+            _rv1 = await self.async_mock(cat_info)
+            _rv2 = await self.async_mock(update_result)
+            _rv3 = await self.async_mock(read_val)
+            _rv4 = await self.async_mock(None)
         else:
-            _rv1 = asyncio.ensure_future(async_mock(cat_info))
-            _rv2 = asyncio.ensure_future(async_mock(update_result))
-            _rv3 = asyncio.ensure_future(async_mock(read_val))
-            _rv4 = asyncio.ensure_future(async_mock(None))        
+            _rv1 = asyncio.ensure_future(self.async_mock(cat_info))
+            _rv2 = asyncio.ensure_future(self.async_mock(update_result))
+            _rv3 = asyncio.ensure_future(self.async_mock(read_val))
+            _rv4 = asyncio.ensure_future(self.async_mock(None))
 
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_all_items:
             with patch.object(c_mgr._storage, 'update_tbl', return_value=_rv2) as patch_update:
@@ -4102,9 +3844,6 @@ class TestConfigurationManager:
     ])
     async def test_update_configuration_item_bulk_with_rule_optional_attribute(self, config_item_list,
                                                                                category_name='testcat'):
-        async def async_mock(return_value):
-            return return_value
-
         cat_info = {'info': {'rule': 'value*3==9', 'default': '3', 'description': 'Test', 'value': '3',
                              'type': 'integer'}, 'info1': {'default': '3', 'description': 'Test', 'value': '3',
                                                            'type': 'integer'}}
@@ -4113,9 +3852,9 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(cat_info)
+            _rv = await self.async_mock(cat_info)
         else:
-            _rv = asyncio.ensure_future(async_mock(cat_info))
+            _rv = asyncio.ensure_future(self.async_mock(cat_info))
 
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_all_items:
             with patch.object(_logger, 'exception') as patch_log_exc:
@@ -4146,14 +3885,11 @@ class TestConfigurationManager:
                                     'options': ['13', '999'], 'listSize': '2', 'description': 'test desc',
                                     'value': '[\"13\"]'}}
 
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await async_mock(cat_info) if sys.version_info.major == 3 and sys.version_info.minor >= 8 else (
-            asyncio.ensure_future(async_mock(cat_info)))
+        _rv = await self.async_mock(cat_info) if sys.version_info.major == 3 and sys.version_info.minor >= 8 else (
+            asyncio.ensure_future(self.async_mock(cat_info)))
 
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_all_items:
             with patch.object(_logger, 'exception') as patch_log_exc:
@@ -4165,9 +3901,6 @@ class TestConfigurationManager:
         patch_get_all_items.assert_called_once_with(category_name)
 
     async def test_update_configuration_item_bulk_with_list_name(self, category_name='Test'):
-        async def async_mock(return_value):
-            return return_value
-
         cat_info ={'list': {'type': 'list', 'description': 'A list of variables', 'listName': 'items',
                            'items': 'string', 'default': '{"items": ["A", "B"]}', 'value': '{"items": ["A", "B"]}'}}
         config_item_list = {"list": "[\"C\", \"D\"]"}
@@ -4187,15 +3920,15 @@ class TestConfigurationManager:
 
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(cat_info)
-            _rv2 = await async_mock(update_result)
-            _rv3 = await async_mock(read_val)
-            _rv4 = await async_mock(None)
+            _rv1 = await self.async_mock(cat_info)
+            _rv2 = await self.async_mock(update_result)
+            _rv3 = await self.async_mock(read_val)
+            _rv4 = await self.async_mock(None)
         else:
-            _rv1 = asyncio.ensure_future(async_mock(cat_info))
-            _rv2 = asyncio.ensure_future(async_mock(update_result))
-            _rv3 = asyncio.ensure_future(async_mock(read_val))
-            _rv4 = asyncio.ensure_future(async_mock(None))
+            _rv1 = asyncio.ensure_future(self.async_mock(cat_info))
+            _rv2 = asyncio.ensure_future(self.async_mock(update_result))
+            _rv3 = asyncio.ensure_future(self.async_mock(read_val))
+            _rv4 = asyncio.ensure_future(self.async_mock(None))
 
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_all_items:
             with patch.object(c_mgr._storage, 'update_tbl', return_value=_rv2) as patch_update:
@@ -4214,9 +3947,6 @@ class TestConfigurationManager:
         patch_get_all_items.assert_called_once_with(category_name)
 
     async def test_set_optional_value_entry_good_update(self, reset_singleton):
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         category_name = 'catname'
@@ -4230,11 +3960,11 @@ class TestConfigurationManager:
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _se = await async_mock(storage_value_entry)
-            _rv = await async_mock(update_result)
+            _se = await self.async_mock(storage_value_entry)
+            _rv = await self.async_mock(update_result)
         else:
-            _se = asyncio.ensure_future(async_mock(storage_value_entry))
-            _rv = asyncio.ensure_future(async_mock(update_result))        
+            _se = asyncio.ensure_future(self.async_mock(storage_value_entry))
+            _rv = asyncio.ensure_future(self.async_mock(update_result))
         
         with patch.object(ConfigurationManager, '_read_item_val', side_effect=[_se, _se]) as readpatch:
             with patch.object(c_mgr._storage, 'update_tbl', return_value=_rv) as patch_update:
@@ -4280,9 +4010,6 @@ class TestConfigurationManager:
     ])
     async def test_set_optional_value_entry_bad_update(self, reset_singleton, _type, optional_key_name,
                                                        new_value_entry, exc_msg):
-        async def async_mock(return_value):
-            return return_value
-
         minimum = '2'
         maximum = '20'
         if _type is not None:
@@ -4302,9 +4029,9 @@ class TestConfigurationManager:
         
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(storage_value_entry)
+            _rv = await self.async_mock(storage_value_entry)
         else:
-            _rv = asyncio.ensure_future(async_mock(storage_value_entry))        
+            _rv = asyncio.ensure_future(self.async_mock(storage_value_entry))
         
         with patch.object(_logger, "exception") as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:

--- a/tests/unit/python/fledge/common/test_plugin_discovery.py
+++ b/tests/unit/python/fledge/common/test_plugin_discovery.py
@@ -219,7 +219,6 @@ class TestPluginDiscovery:
     ]
 
     def test_get_plugins_installed_type_none(self, mocker):
-        @asyncio.coroutine
         def mock_folders():
             yield TestPluginDiscovery.mock_north_folders
             yield TestPluginDiscovery.mock_south_folders
@@ -227,7 +226,6 @@ class TestPluginDiscovery:
             yield TestPluginDiscovery.mock_py_notify_folders
             yield TestPluginDiscovery.mock_py_rule_folders
 
-        @asyncio.coroutine
         def mock_c_folders():
             yield TestPluginDiscovery.mock_c_north_folders
             yield TestPluginDiscovery.mock_c_south_folders
@@ -253,11 +251,9 @@ class TestPluginDiscovery:
         assert 5 == mock_get_c_plugin_config.call_count
 
     def test_get_plugins_installed_type_north(self, mocker):
-        @asyncio.coroutine
         def mock_folders():
             yield TestPluginDiscovery.mock_north_folders
 
-        @asyncio.coroutine
         def mock_c_folders():
             yield TestPluginDiscovery.mock_c_north_folders
 
@@ -279,11 +275,9 @@ class TestPluginDiscovery:
         assert 1 == mock_get_c_plugin_config.call_count
 
     def test_get_plugins_installed_type_south(self, mocker):
-        @asyncio.coroutine
         def mock_folders():
             yield TestPluginDiscovery.mock_south_folders
 
-        @asyncio.coroutine
         def mock_c_folders():
             yield TestPluginDiscovery.mock_c_south_folders
 
@@ -305,11 +299,9 @@ class TestPluginDiscovery:
         assert 1 == mock_get_c_plugin_config.call_count
 
     def test_get_filter_plugins_installed(self, mocker):
-        @asyncio.coroutine
         def mock_c_filter_folders():
             yield TestPluginDiscovery.mock_c_filter_folders
 
-        @asyncio.coroutine
         def mock_filter_folders():
             yield TestPluginDiscovery.mock_py_filter_folders
 
@@ -328,11 +320,9 @@ class TestPluginDiscovery:
         assert 1 == mock_get_c_filter_plugin_config.call_count
 
     def test_get_notify_plugins_installed(self, mocker):
-        @asyncio.coroutine
         def mock_folders():
             yield TestPluginDiscovery.mock_py_notify_folders
 
-        @asyncio.coroutine
         def mock_c_folders():
             yield TestPluginDiscovery.mock_c_notify_folders
 
@@ -353,11 +343,9 @@ class TestPluginDiscovery:
         assert 1 == mock_get_c_plugin_config.call_count
 
     def test_get_rules_plugins_installed(self, mocker):
-        @asyncio.coroutine
         def mock_folders():
             yield TestPluginDiscovery.mock_py_rule_folders
 
-        @asyncio.coroutine
         def mock_c_folders():
             yield TestPluginDiscovery.mock_c_rule_folders
 
@@ -379,7 +367,6 @@ class TestPluginDiscovery:
         assert 1 == mock_get_c_plugin_config.call_count
 
     def test_fetch_plugins_installed(self, mocker):
-        @asyncio.coroutine
         def mock_folders():
             yield TestPluginDiscovery.mock_north_folders
 
@@ -394,7 +381,6 @@ class TestPluginDiscovery:
         assert 2 == mock_get_plugin_config.call_count
 
     def test_get_plugin_folders(self, mocker):
-        @asyncio.coroutine
         def mock_folders():
             listdir = copy.deepcopy(TestPluginDiscovery.mock_north_folders)
             listdir.extend(["__init__", "empty", "common"])

--- a/tests/unit/python/fledge/services/core/api/control_service/test_acl_management.py
+++ b/tests/unit/python/fledge/services/core/api/control_service/test_acl_management.py
@@ -292,8 +292,7 @@ class TestACLManagement:
                                                "and": {"column": "name", "condition": "=", "value": "{}".format(
                                                    acl_name)}}}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             if table == 'acl_usage':
                 assert acl_query_payload_service == json.loads(args[1])
@@ -376,8 +375,7 @@ class TestACLManagement:
                                                                           "condition": "=",
                                                                           "value": "{}".format(acl_name)}}}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             if table == 'acl_usage':
                 if acl_query_payload_service == json.loads(args[1]):
@@ -458,8 +456,7 @@ class TestACLManagement:
         sch_result = {"count": 1, "rows": [{"id": "3e84f179-874d-4a91-a524-15512172f8a2", "enabled": "true"}]}
         message = "ACL with name {} is not found.".format(acl_name)
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             if table == 'schedules':
                 assert sch_query_payload == json.loads(args[1])
@@ -491,8 +488,7 @@ class TestACLManagement:
         sch_result = {"count": 1, "rows": [{"id": "3e84f179-874d-4a91-a524-15512172f8a2", "enabled": "true"}]}
         message = "Service {} already has an ACL object.".format(svc_name, acl_name)
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             if table == 'schedules':
                 assert sch_query_payload == json.loads(args[1])
@@ -541,8 +537,8 @@ class TestACLManagement:
         message = "ACL with name {} attached to {} service successfully.".format(acl_name, svc_name)
 
         acl_dict = {'ACL': acl_name}
-        @asyncio.coroutine
-        def q_result(*args):
+
+        async def q_result(*args):
             table = args[0]
             if table == 'schedules':
                 assert sch_query_payload == json.loads(args[1])

--- a/tests/unit/python/fledge/services/core/api/control_service/test_entrypoint.py
+++ b/tests/unit/python/fledge/services/core/api/control_service/test_entrypoint.py
@@ -122,8 +122,7 @@ class TestEntrypoint:
         storage_result = {"count": 0, "rows": []}
         insert_result = {"response": "inserted", "rows_affected": 1}
 
-        @asyncio.coroutine
-        def i_result(*args):
+        async def i_result(*args):
             table = args[0]
             insert_payload = args[1]
             if table == 'control_api':

--- a/tests/unit/python/fledge/services/core/api/control_service/test_script_management.py
+++ b/tests/unit/python/fledge/services/core/api/control_service/test_script_management.py
@@ -237,8 +237,7 @@ class TestScriptManagement:
         script_query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": script_name}}
         acl_query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": acl_name}}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
             if table == 'control_acl':
@@ -309,8 +308,7 @@ class TestScriptManagement:
         acl_query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": acl_name}}
         arv = await mock_coro(None) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(None))
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
             if table == 'control_acl':
@@ -324,8 +322,7 @@ class TestScriptManagement:
             else:
                 return {}
 
-        @asyncio.coroutine
-        def i_result(*args):
+        async def i_result(*args):
             table = args[0]
             payload = args[1]
             if table == 'control_script':
@@ -403,8 +400,7 @@ class TestScriptManagement:
         acl_query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": acl_name}}
         acl_result = {"count": 0, "rows": []}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             if table == 'control_acl':
                 assert acl_query_payload == json.loads(args[1])
@@ -445,8 +441,7 @@ class TestScriptManagement:
         acl_result = {"count": 1, "rows": [{"name": acl_name, "service": [], "url": []}]}
         insert_result = {"response": "inserted", "rows_affected": 1}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             if table == 'control_acl':
                 assert acl_query_payload == json.loads(args[1])
@@ -459,8 +454,7 @@ class TestScriptManagement:
             else:
                 return {}
 
-        @asyncio.coroutine
-        def i_result(*args):
+        async def i_result(*args):
             table = args[0]
             payload_ins = args[1]
             if table == "acl_usage":
@@ -533,8 +527,7 @@ class TestScriptManagement:
         delete_sch_result = (True, 'Schedule deleted successfully.')
         message = '{} script deleted successfully.'.format(script_name)
 
-        @asyncio.coroutine
-        def query_schedule(*args):
+        async def query_schedule(*args):
             table = args[0]
             payload = args[1]
             if table == 'control_script':
@@ -543,8 +536,7 @@ class TestScriptManagement:
             elif table == "acl_usage":
                 return {"count": 0, "rows": []}
 
-        @asyncio.coroutine
-        def d_schedule(*args):
+        async def d_schedule(*args):
             table = args[0]
             payload = args[1]
             if table == 'control_script':
@@ -614,8 +606,7 @@ class TestScriptManagement:
                                                        "and": {"column": "entity_name", "condition": "=",
                                                                "value": script_name}}}
 
-        @asyncio.coroutine
-        def query_result(*args):
+        async def query_result(*args):
             table = args[0]
             payload = args[1]
             if table == 'control_script':
@@ -624,8 +615,7 @@ class TestScriptManagement:
             elif table == "acl_usage":
                 return {"count": 0, "rows": []}
 
-        @asyncio.coroutine
-        def d_result(*args):
+        async def d_result(*args):
             table = args[0]
             payload = args[1]
             if table == 'control_script':

--- a/tests/unit/python/fledge/services/core/api/test_common_ping.py
+++ b/tests/unit/python/fledge/services/core/api/test_common_ping.py
@@ -187,8 +187,7 @@ async def test_ping_http_auth_required_allow_ping_true(aiohttp_server, aiohttp_c
                 {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
                ]}
 
-    @asyncio.coroutine
-    def mock_coro(*args, **kwargs):
+    async def mock_coro(*args, **kwargs):
         return result
 
     async def mock_get_category_item():
@@ -250,8 +249,7 @@ async def test_ping_http_auth_required_allow_ping_false(aiohttp_server, aiohttp_
         {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
     ]}
 
-    @asyncio.coroutine
-    def mock_coro(*args, **kwargs):
+    async def mock_coro(*args, **kwargs):
         return result
 
     async def mock_get_category_item():
@@ -301,8 +299,7 @@ async def test_ping_https_allow_ping_true(aiohttp_server, ssl_ctx, aiohttp_clien
                 {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
                ]}
 
-    @asyncio.coroutine
-    def mock_coro(*args, **kwargs):
+    async def mock_coro(*args, **kwargs):
         return result
 
     # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
@@ -371,8 +368,7 @@ async def test_ping_https_allow_ping_false(aiohttp_server, ssl_ctx, aiohttp_clie
         {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
     ]}
 
-    @asyncio.coroutine
-    def mock_coro(*args, **kwargs):
+    async def mock_coro(*args, **kwargs):
         return result
 
     # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
@@ -435,8 +431,7 @@ async def test_ping_https_auth_required_allow_ping_true(aiohttp_server, ssl_ctx,
                 {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
                ]}
 
-    @asyncio.coroutine
-    def mock_coro(*args, **kwargs):
+    async def mock_coro(*args, **kwargs):
         return result
 
     async def mock_get_category_item():
@@ -502,8 +497,7 @@ async def test_ping_https_auth_required_allow_ping_true(aiohttp_server, ssl_ctx,
 
 
 async def test_ping_https_auth_required_allow_ping_false(aiohttp_server, ssl_ctx, aiohttp_client, loop, get_machine_detail):
-    @asyncio.coroutine
-    def mock_coro(*args, **kwargs):
+    async def mock_coro(*args, **kwargs):
         result = {"rows": [
             {"value": 1, "key": "PURGED", "description": "blah6"},
             {"value": 2, "key": "READINGS", "description": "blah1"},

--- a/tests/unit/python/fledge/services/core/api/test_configuration.py
+++ b/tests/unit/python/fledge/services/core/api/test_configuration.py
@@ -834,8 +834,7 @@ class TestConfiguration:
             assert 1 == patch_logger.call_count
 
     async def test_get_child_category(self, client):
-        @asyncio.coroutine
-        def async_mock():
+        async def async_mock():
             return []
 
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -860,8 +859,7 @@ class TestConfiguration:
         data = {"children": ["coap", "http", "sinusoid"]}
         result = {"children": data["children"]}
 
-        @asyncio.coroutine
-        def async_mock():
+        async def async_mock():
             return result
 
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -883,8 +881,7 @@ class TestConfiguration:
             patch_create_child_cat.assert_called_once_with('south', data['children'])
 
     async def test_delete_child_category(self, client):
-        @asyncio.coroutine
-        def async_mock():
+        async def async_mock():
             return ["http", "sinusoid"]
 
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -906,8 +903,7 @@ class TestConfiguration:
             patch_delete_child_cat.assert_called_once_with('south', 'coap')
 
     async def test_delete_parent_category(self, client):
-        @asyncio.coroutine
-        def async_mock():
+        async def async_mock():
             return None
 
         storage_client_mock = MagicMock(StorageClientAsync)

--- a/tests/unit/python/fledge/services/core/api/test_filters.py
+++ b/tests/unit/python/fledge/services/core/api/test_filters.py
@@ -94,8 +94,7 @@ class TestFilters:
             query_tbl_patch.assert_called_once_with('filters')
 
     async def test_get_filter_by_name(self, client):
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
 
@@ -436,8 +435,7 @@ class TestFilters:
             assert 2 == get_cat_info_patch.call_count
 
     async def test_delete_filter(self, client):
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
 
@@ -1224,8 +1222,7 @@ class TestFilters:
             },
         }
 
-        @asyncio.coroutine
-        def get_cat(category_name):
+        async def get_cat(category_name):
             category = category_name
             if category == "random1_scale1":
                 return mock_cat
@@ -1234,12 +1231,10 @@ class TestFilters:
             if category == 'meta2':
                 return mock_cat
 
-        @asyncio.coroutine
-        def create_cat():
+        async def create_cat():
             return {}
 
-        @asyncio.coroutine
-        def create_child_cat():
+        async def create_child_cat():
             return {}
 
         storage_client_mock = MagicMock(StorageClientAsync)

--- a/tests/unit/python/fledge/services/core/api/test_filters.py
+++ b/tests/unit/python/fledge/services/core/api/test_filters.py
@@ -517,10 +517,10 @@ class TestFilters:
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=rv1):
                 resp = await client.delete('/fledge/filter/{}'.format(filter_name))
                 assert 400 == resp.status
-                assert message == resp.reason
+                assert message in resp.reason
                 r = await resp.text()
                 json_response = json.loads(r)
-                assert message == json_response['message']
+                assert message in json_response['message']
 
     async def test_delete_filter_conflict_error(self, client):
         filter_name = "AssetFilter"
@@ -1231,10 +1231,7 @@ class TestFilters:
             if category == 'meta2':
                 return mock_cat
 
-        async def create_cat():
-            return {}
-
-        async def create_child_cat():
+        async def mock():
             return {}
 
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -1243,16 +1240,16 @@ class TestFilters:
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
             _rv = await asyncio.sleep(.1)
+            _rv2 = await mock()
         else:
-            _rv = asyncio.ensure_future(asyncio.sleep(.1))        
-        
+            _rv = asyncio.ensure_future(asyncio.sleep(.1))
+            _rv2 = asyncio.ensure_future(mock())
+
         connect_mock = mocker.patch.object(connect, 'get_storage_async', return_value=storage_client_mock)
         get_category_mock = mocker.patch.object(c_mgr_mock, 'get_category_all_items', side_effect=get_cat)
-        create_category_mock = mocker.patch.object(c_mgr_mock, 'create_category', return_value=create_cat())
-        create_child_category_mock = mocker.patch.object(c_mgr_mock, 'create_child_category',
-                                                         return_value=create_child_cat())
-        update_config_bulk_mock = mocker.patch.object(c_mgr_mock, 'update_configuration_item_bulk',
-                                                      return_value=_rv)
+        create_category_mock = mocker.patch.object(c_mgr_mock, 'create_category', return_value=_rv2)
+        create_child_category_mock = mocker.patch.object(c_mgr_mock, 'create_child_category', return_value=_rv2)
+        update_config_bulk_mock = mocker.patch.object(c_mgr_mock, 'update_configuration_item_bulk', return_value=_rv)
         cache_manager = mocker.patch.object(c_mgr_mock, '_cacheManager')
         cache_remove = mocker.patch.object(cache_manager, 'remove', return_value=MagicMock())
         insert_tbl_patch = mocker.patch.object(storage_client_mock, 'insert_into_tbl', return_value=_rv)

--- a/tests/unit/python/fledge/services/core/api/test_service.py
+++ b/tests/unit/python/fledge/services/core/api/test_service.py
@@ -236,8 +236,7 @@ class TestService:
     async def test_insert_scheduled_process_exception_add_service(self, client):
         data = {"name": "furnace4", "type": "south", "plugin": "dht11"}
 
-        @asyncio.coroutine
-        def q_result(*arg):
+        async def q_result(*arg):
             return {'count': 0, 'rows': []}
 
         mock_plugin_info = {
@@ -318,8 +317,7 @@ class TestService:
                 patch_get_cat_info.assert_called_once_with(category_name=data['name'])
 
     async def test_dupe_schedule_name_add_service(self, client):
-        @asyncio.coroutine
-        def q_result(*arg):
+        async def q_result(*arg):
             table = arg[0]
             payload = arg[1]
 
@@ -379,8 +377,7 @@ class TestService:
             schedule.schedule_id = '2129cc95-c841-441a-ad39-6469a87dbc8b'
             return schedule
 
-        @asyncio.coroutine
-        def q_result(*arg):
+        async def q_result(*arg):
             table = arg[0]
             _payload = arg[1]
             if table == 'scheduled_processes':
@@ -493,8 +490,7 @@ class TestService:
             schedule.schedule_id = sch_id
             return schedule
 
-        @asyncio.coroutine
-        def q_result(*arg):
+        async def q_result(*arg):
             table = arg[0]
             _payload = json.loads(arg[1])
             if table == 'schedules':
@@ -566,8 +562,7 @@ class TestService:
     async def test_dupe_external_service_schedule(self, client, payload, svc_type):
         data = json.loads(payload)
 
-        @asyncio.coroutine
-        def q_result(*arg):
+        async def q_result(*arg):
             table = arg[0]
             _payload = json.loads(arg[1])
             sch_ps = svc_type if svc_type != "bucketstorage" else "bucket_storage"
@@ -634,8 +629,7 @@ class TestService:
             schedule.schedule_id = '2129cc95-c841-441a-ad39-6469a87dbc8b'
             return schedule
 
-        @asyncio.coroutine
-        def q_result(*arg):
+        async def q_result(*arg):
             table = arg[0]
             _payload = arg[1]
             if table == 'scheduled_processes':
@@ -1173,8 +1167,7 @@ class TestService:
         payload = '{"name": "FL Agent", "type": "management"}'
         data = json.loads(payload)
 
-        @asyncio.coroutine
-        def q_result(*arg):
+        async def q_result(*arg):
             table = arg[0]
             _payload = json.loads(arg[1])
             if table == 'schedules':

--- a/tests/unit/python/fledge/services/core/api/test_statistics_api.py
+++ b/tests/unit/python/fledge/services/core/api/test_statistics_api.py
@@ -113,8 +113,7 @@ class TestStatistics:
         p2 = {"return": ["schedule_interval"],
               "where": {"column": "process_name", "condition": "=", "value": "stats collector"}}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
 
@@ -167,8 +166,7 @@ class TestStatistics:
         p3 = {"return": ["schedule_interval"],
               "where": {"column": "process_name", "condition": "=", "value": "stats collector"}}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
 
@@ -204,8 +202,7 @@ class TestStatistics:
         p1 = {"return": ["schedule_interval"],
               "where": {"column": "process_name", "condition": "=", "value": "stats collector"}}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
 
@@ -234,8 +231,7 @@ class TestStatistics:
         p3 = {"return": ["schedule_interval"],
               "where": {"column": "process_name", "condition": "=", "value": "stats collector"}}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
 
@@ -288,8 +284,7 @@ class TestStatistics:
         p1 = {"return": ["schedule_interval"],
               "where": {"column": "process_name", "condition": "=", "value": "stats collector"}}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
 
@@ -312,8 +307,7 @@ class TestStatistics:
         p2 = {"return": ["schedule_interval"],
               "where": {"column": "process_name", "condition": "=", "value": "stats collector"}}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
 
@@ -341,8 +335,7 @@ class TestStatistics:
         p2 = {'aggregate': {'column': '*', 'operation': 'count'}}
         p3 = {"return": [{"column": "history_ts", "alias": "history_ts", "format": "YYYY-MM-DD HH24:MI:SS.MS"}, "key", "value"], "sort": {"column": "history_ts", "direction": "desc"}, "where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "key", "condition": "=", "value": "READINGS"}}}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
 
@@ -374,8 +367,8 @@ class TestStatistics:
         p1 = {'where': {'value': 'stats collector', 'condition': '=', 'column': 'process_name'}, 'return': ['schedule_interval']}
         p2 = {'aggregate': {'column': '*', 'operation': 'count'}}
         p3 = {"where": {"and": {"column": "key", "condition": "=", "value": "READINGS", "or": {"column": "key", "condition": "=", "value": "PURGED", "or": {"column": "key", "condition": "=", "value": "UNSENT"}}}, "column": "1", "condition": "=", "value": 1}, "return": [{"column": "history_ts", "alias": "history_ts", "format": "YYYY-MM-DD HH24:MI:SS.MS"}, "key", "value"], "sort": {"direction": "desc", "column": "history_ts"}}
-        @asyncio.coroutine
-        def q_result(*args):
+
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
 
@@ -411,8 +404,7 @@ class TestStatistics:
         p1 = {'where': {'value': 'stats collector', 'condition': '=', 'column': 'process_name'}, 'return': ['schedule_interval']}
         p3 = {"return": [{"column": "history_ts", "alias": "history_ts", "format": "YYYY-MM-DD HH24:MI:SS.MS"}, "key", "value"], "sort": {"column": "history_ts", "direction": "desc"}, "where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "key", "condition": "=", "value": "READINGS"}}, "limit": 1}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
 
@@ -443,8 +435,7 @@ class TestStatistics:
               "where": {"column": "1", "condition": "=", "value": 1,
                         "and": {"column": "key", "condition": "=", "value": "blah"}}}
 
-        @asyncio.coroutine
-        def q_result(*args):
+        async def q_result(*args):
             table = args[0]
             payload = args[1]
 

--- a/tests/unit/python/fledge/services/core/api/test_task.py
+++ b/tests/unit/python/fledge/services/core/api/test_task.py
@@ -63,8 +63,7 @@ class TestTask:
     async def test_insert_scheduled_process_exception_add_task(self, client):
         data = {"name": "north bound", "type": "north", "schedule_type": 3, "plugin": "omf", "schedule_repeat": 30}
 
-        @asyncio.coroutine
-        def q_result(*arg):
+        async def q_result(*arg):
             table = arg[0]
             payload = arg[1]
 
@@ -118,8 +117,7 @@ class TestTask:
 
     async def test_dupe_category_name_add_task(self, client):
 
-        @asyncio.coroutine
-        def q_result(*arg):
+        async def q_result(*arg):
             table = arg[0]
 
             if table == 'tasks':
@@ -158,8 +156,7 @@ class TestTask:
                 patch_get_cat_info.assert_called_once_with(category_name=data['name'])
 
     async def test_dupe_schedule_name_add_task(self, client):
-        @asyncio.coroutine
-        def q_result(*arg):
+        async def q_result(*arg):
             table = arg[0]
             payload = arg[1]
 
@@ -307,9 +304,7 @@ class TestTask:
         (10, 400, '400: Unable to reuse name north bound, already used by a previous task.')
     ])
     async def test_add_task_twice(self, client, expected_count, expected_http_code, expected_message):
-
-        @asyncio.coroutine
-        def q_result(*arg):
+        async def q_result(*arg):
             table = arg[0]
 
             if table == 'tasks':

--- a/tests/unit/python/fledge/services/core/scheduler/test_scheduler.py
+++ b/tests/unit/python/fledge/services/core/scheduler/test_scheduler.py
@@ -20,13 +20,13 @@ from fledge.services.core.scheduler.entities import *
 from fledge.services.core.scheduler.exceptions import *
 from fledge.common.storage_client.storage_client import StorageClientAsync
 
-__author__ = "Amarendra K Sinha"
+__author__ = "Amarendra K Sinha, Ashish Jabble"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 
-async def mock_task():
+async def mock():
     return ""
 
 
@@ -54,7 +54,7 @@ class TestScheduler:
         mocker.patch.object(scheduler, '_ready', True)
         mocker.patch.object(scheduler, '_paused', False)
         mocker.patch.object(scheduler, '_process_scripts', return_value="North Readings to PI")
-        mocker.patch.object(scheduler, '_wait_for_task_completion', return_value=asyncio.ensure_future(mock_task()))
+        mocker.patch.object(scheduler, '_wait_for_task_completion', return_value=asyncio.ensure_future(mock()))
         mocker.patch.object(scheduler, '_terminate_child_processes')
         mocker.patch.object(asyncio, 'create_subprocess_exec', return_value=_rv)
 
@@ -195,7 +195,7 @@ class TestScheduler:
             _rv = asyncio.ensure_future(mock_process())
 
         mocker.patch.object(asyncio, 'create_subprocess_exec', return_value=_rv)
-        mocker.patch.object(asyncio, 'ensure_future', return_value=asyncio.ensure_future(mock_task()))
+        mocker.patch.object(asyncio, 'ensure_future', return_value=asyncio.ensure_future(mock()))
         mocker.patch.object(scheduler, '_resume_check_schedules')
         mocker.patch.object(scheduler, '_process_scripts', return_value="North Readings to PI")
         mocker.patch.object(scheduler, '_wait_for_task_completion')
@@ -242,7 +242,7 @@ class TestScheduler:
         scheduler._storage_async = MockStorageAsync(core_management_host=None, core_management_port=None)
         mocker.patch.multiple(scheduler, _purge_tasks_task=None,
                               _last_task_purge_time=None)
-        mocker.patch.object(scheduler, 'purge_tasks', return_value=asyncio.ensure_future(mock_task()))
+        mocker.patch.object(scheduler, 'purge_tasks', return_value=asyncio.ensure_future(mock()))
 
         # WHEN
         scheduler._check_purge_tasks()
@@ -264,7 +264,7 @@ class TestScheduler:
         mocker.patch.multiple(scheduler, _max_running_tasks=10,
                               _start_time=current_time)
         await scheduler._get_schedules()
-        mocker.patch.object(scheduler, '_start_task', return_value=asyncio.ensure_future(mock_task()))
+        mocker.patch.object(scheduler, '_start_task', return_value=asyncio.ensure_future(mock()))
 
         # WHEN
         earliest_start_time = await scheduler._check_schedules()
@@ -522,7 +522,7 @@ class TestScheduler:
         scheduler = Scheduler()
         scheduler._storage = MockStorage(core_management_host=None, core_management_port=None)
         scheduler._storage_async = MockStorageAsync(core_management_host=None, core_management_port=None)
-        cr_cat = mocker.patch.object(ConfigurationManager, "create_category", return_value=asyncio.ensure_future(mock_task()))
+        cr_cat = mocker.patch.object(ConfigurationManager, "create_category", return_value=asyncio.ensure_future(mock()))
         get_cat = mocker.patch.object(ConfigurationManager, "get_category_all_items", return_value=_rv)
 
         # WHEN
@@ -548,13 +548,13 @@ class TestScheduler:
 
         current_time = time.time()
         mocker.patch.object(scheduler, '_schedule_first_task')
-        mocker.patch.object(scheduler, '_scheduler_loop', return_value=asyncio.ensure_future(mock_task()))
+        mocker.patch.object(scheduler, '_scheduler_loop', return_value=asyncio.ensure_future(mock()))
         mocker.patch.multiple(scheduler, _core_management_port=9999,
                               _core_management_host="0.0.0.0",
                               current_time=current_time - 3600)
 
         # TODO: Remove after implementation of above test test__read_config()
-        mocker.patch.object(scheduler, '_read_config', return_value=asyncio.ensure_future(mock_task()))
+        mocker.patch.object(scheduler, '_read_config', return_value=asyncio.ensure_future(mock()))
 
         assert scheduler._ready is False
 
@@ -582,8 +582,8 @@ class TestScheduler:
         log_info = mocker.patch.object(scheduler._logger, "info")
         log_exception = mocker.patch.object(scheduler._logger, "exception")
 
-        mocker.patch.object(scheduler, '_scheduler_loop', return_value=asyncio.ensure_future(mock_task()))
-        mocker.patch.object(scheduler, '_resume_check_schedules', return_value=asyncio.ensure_future(mock_task()))
+        mocker.patch.object(scheduler, '_scheduler_loop', return_value=asyncio.ensure_future(mock()))
+        mocker.patch.object(scheduler, '_resume_check_schedules', return_value=asyncio.ensure_future(mock()))
         mocker.patch.object(scheduler, '_purge_tasks_task', return_value=asyncio.ensure_future(asyncio.sleep(.1)))
         mocker.patch.object(scheduler, '_scheduler_loop_task', return_value=asyncio.ensure_future(asyncio.sleep(.1)))
         current_time = time.time()
@@ -702,18 +702,17 @@ class TestScheduler:
 
     @pytest.mark.asyncio
     async def test_save_schedule_new(self, mocker):
-        async def mock_coro():
-            return ""
-
         # GIVEN
         scheduler, schedule, log_info, log_exception, log_error, log_debug = await self.scheduler_fixture(mocker)
-        audit_logger = mocker.patch.object(AuditLogger, 'information', return_value=asyncio.ensure_future(mock_task()))
+        audit_logger = mocker.patch.object(AuditLogger, 'information', return_value=asyncio.ensure_future(mock()))
         first_task = mocker.patch.object(scheduler, '_schedule_first_task')
         resume_sch = mocker.patch.object(scheduler, '_resume_check_schedules')
         log_info = mocker.patch.object(scheduler._logger, "info")
 
-        enable_schedule = mocker.patch.object(scheduler, "enable_schedule", return_value=mock_coro())
-        disable_schedule = mocker.patch.object(scheduler, "disable_schedule", return_value=mock_coro())
+        enable_schedule = mocker.patch.object(scheduler, "enable_schedule",
+                                              return_value=asyncio.ensure_future(mock()))
+        disable_schedule = mocker.patch.object(scheduler, "disable_schedule",
+                                               return_value=asyncio.ensure_future(mock()))
 
         schedule_id = uuid.uuid4()
         schedule_row = scheduler._ScheduleRow(
@@ -746,17 +745,16 @@ class TestScheduler:
 
     @pytest.mark.asyncio
     async def test_save_schedule_new_with_enable_modified(self, mocker):
-        async def mock_coro():
-            return ""
-
         # GIVEN
         scheduler, schedule, log_info, log_exception, log_error, log_debug = await self.scheduler_fixture(mocker)
-        audit_logger = mocker.patch.object(AuditLogger, 'information', return_value=asyncio.ensure_future(mock_task()))
+        audit_logger = mocker.patch.object(AuditLogger, 'information', return_value=asyncio.ensure_future(mock()))
         first_task = mocker.patch.object(scheduler, '_schedule_first_task')
         resume_sch = mocker.patch.object(scheduler, '_resume_check_schedules')
 
-        enable_schedule = mocker.patch.object(scheduler, "enable_schedule", return_value=mock_coro())
-        disable_schedule = mocker.patch.object(scheduler, "disable_schedule", return_value=mock_coro())
+        enable_schedule = mocker.patch.object(scheduler, "enable_schedule",
+                                              return_value=asyncio.ensure_future(mock()))
+        disable_schedule = mocker.patch.object(scheduler, "disable_schedule",
+                                               return_value=asyncio.ensure_future(mock()))
 
         schedule_id = uuid.uuid4()
         schedule_row = scheduler._ScheduleRow(
@@ -794,12 +792,9 @@ class TestScheduler:
 
     @pytest.mark.asyncio
     async def test_save_schedule_update(self, mocker):
-        async def mock_coro():
-            return ""
-
         # GIVEN
         scheduler, schedule, log_info, log_exception, log_error, log_debug = await self.scheduler_fixture(mocker)
-        audit_logger = mocker.patch.object(AuditLogger, 'information', return_value=asyncio.ensure_future(mock_task()))
+        audit_logger = mocker.patch.object(AuditLogger, 'information', return_value=asyncio.ensure_future(mock()))
         first_task = mocker.patch.object(scheduler, '_schedule_first_task')
         resume_sch = mocker.patch.object(scheduler, '_resume_check_schedules')
         schedule_id = uuid.UUID("2b614d26-760f-11e7-b5a5-be2e44b06b34")  # OMF to PI North
@@ -816,8 +811,10 @@ class TestScheduler:
             process_name='TestProcess')
         schedule = scheduler._schedule_row_to_schedule(schedule_id, schedule_row)
 
-        enable_schedule = mocker.patch.object(scheduler, "enable_schedule", return_value=mock_coro())
-        disable_schedule = mocker.patch.object(scheduler, "disable_schedule", return_value=mock_coro())
+        enable_schedule = mocker.patch.object(scheduler, "enable_schedule",
+                                              return_value=asyncio.ensure_future(mock()))
+        disable_schedule = mocker.patch.object(scheduler, "disable_schedule",
+                                               return_value=asyncio.ensure_future(mock()))
 
         # WHEN
         await scheduler.save_schedule(schedule)
@@ -839,12 +836,9 @@ class TestScheduler:
 
     @pytest.mark.asyncio
     async def test_save_schedule_update_with_enable_modified(self, mocker):
-        async def mock_coro():
-            return ""
-
         # GIVEN
         scheduler, schedule, log_info, log_exception, log_error, log_debug = await self.scheduler_fixture(mocker)
-        audit_logger = mocker.patch.object(AuditLogger, 'information', return_value=asyncio.ensure_future(mock_task()))
+        audit_logger = mocker.patch.object(AuditLogger, 'information', return_value=asyncio.ensure_future(mock()))
         first_task = mocker.patch.object(scheduler, '_schedule_first_task')
         resume_sch = mocker.patch.object(scheduler, '_resume_check_schedules')
         schedule_id = uuid.UUID("2b614d26-760f-11e7-b5a5-be2e44b06b34")  # OMF to PI North
@@ -861,8 +855,10 @@ class TestScheduler:
             process_name='TestProcess')
         schedule = scheduler._schedule_row_to_schedule(schedule_id, schedule_row)
 
-        enable_schedule = mocker.patch.object(scheduler, "enable_schedule", return_value=mock_coro())
-        disable_schedule = mocker.patch.object(scheduler, "disable_schedule", return_value=mock_coro())
+        enable_schedule = mocker.patch.object(scheduler, "enable_schedule",
+                                              return_value=asyncio.ensure_future(mock()))
+        disable_schedule = mocker.patch.object(scheduler, "disable_schedule",
+                                               return_value=asyncio.ensure_future(mock()))
 
         # WHEN
         await scheduler.save_schedule(schedule, is_enabled_modified=True)
@@ -963,7 +959,7 @@ class TestScheduler:
         await scheduler._get_schedules()
         mocker.patch.object(scheduler, '_ready', True)
         mocker.patch.object(scheduler, '_task_processes')
-        audit_logger = mocker.patch.object(AuditLogger, 'information', return_value=asyncio.ensure_future(mock_task()))
+        audit_logger = mocker.patch.object(AuditLogger, 'information', return_value=asyncio.ensure_future(mock()))
         log_info = mocker.patch.object(scheduler._logger, "info")
         sch_id = uuid.UUID("2b614d26-760f-11e7-b5a5-be2e44b06b34")  # OMF to PI North
 
@@ -1039,8 +1035,8 @@ class TestScheduler:
         # GIVEN
         scheduler, schedule, log_info, log_exception, log_error, log_debug = await self.scheduler_fixture(mocker)
         sch_id = uuid.UUID("d1631422-9ec6-11e7-abc4-cec278b6b50a")  # backup
-        queue_task = mocker.patch.object(scheduler, 'queue_task', return_value=asyncio.ensure_future(mock_task()))
-        audit_logger = mocker.patch.object(AuditLogger, 'information', return_value=asyncio.ensure_future(mock_task()))
+        queue_task = mocker.patch.object(scheduler, 'queue_task', return_value=asyncio.ensure_future(mock()))
+        audit_logger = mocker.patch.object(AuditLogger, 'information', return_value=asyncio.ensure_future(mock()))
 
         # WHEN
         status, message = await scheduler.enable_schedule(sch_id)
@@ -1066,7 +1062,7 @@ class TestScheduler:
         # GIVEN
         scheduler, schedule, log_info, log_exception, log_error, log_debug = await self.scheduler_fixture(mocker)
         sch_id = uuid.UUID("ada12840-68d3-11e7-907b-a6006ad3dba0")  #Coap
-        mocker.patch.object(scheduler, 'queue_task', return_value=asyncio.ensure_future(mock_task()))
+        mocker.patch.object(scheduler, 'queue_task', return_value=asyncio.ensure_future(mock()))
 
         # WHEN
         status, message = await scheduler.enable_schedule(sch_id)

--- a/tests/unit/python/fledge/services/core/scheduler/test_scheduler.py
+++ b/tests/unit/python/fledge/services/core/scheduler/test_scheduler.py
@@ -702,8 +702,7 @@ class TestScheduler:
 
     @pytest.mark.asyncio
     async def test_save_schedule_new(self, mocker):
-        @asyncio.coroutine
-        def mock_coro():
+        async def mock_coro():
             return ""
 
         # GIVEN
@@ -747,8 +746,7 @@ class TestScheduler:
 
     @pytest.mark.asyncio
     async def test_save_schedule_new_with_enable_modified(self, mocker):
-        @asyncio.coroutine
-        def mock_coro():
+        async def mock_coro():
             return ""
 
         # GIVEN
@@ -796,8 +794,7 @@ class TestScheduler:
 
     @pytest.mark.asyncio
     async def test_save_schedule_update(self, mocker):
-        @asyncio.coroutine
-        def mock_coro():
+        async def mock_coro():
             return ""
 
         # GIVEN
@@ -842,8 +839,7 @@ class TestScheduler:
 
     @pytest.mark.asyncio
     async def test_save_schedule_update_with_enable_modified(self, mocker):
-        @asyncio.coroutine
-        def mock_coro():
+        async def mock_coro():
             return ""
 
         # GIVEN

--- a/tests/unit/python/fledge/services/core/test_user_model.py
+++ b/tests/unit/python/fledge/services/core/test_user_model.py
@@ -25,8 +25,8 @@ __version__ = "${VERSION}"
 
 pytestmark = pytest.mark.asyncio
 
-@asyncio.coroutine
-def mock_coro(*args, **kwargs):
+
+async def mock_coro(*args, **kwargs):
     return None if len(args) == 0 else args[0]
 
 

--- a/tests/unit/python/fledge/services/south/test_services_south_server.py
+++ b/tests/unit/python/fledge/services/south/test_services_south_server.py
@@ -87,12 +87,7 @@ plugin_attrs = {
 }
 
 
-@asyncio.coroutine
-def mock_coro():
-    yield from false_coro()
-
-
-async def false_coro():
+async def mock_coro():
     return True
 
 


### PR DESCRIPTION
**Problem fixes**:

- [x] In Python 3.10 and higher, asyncio.coroutine is deprecated and no longer works as expected. Instead, you should use async def to define asynchronous functions.
- [x] aiocoap version has been upgraded in Coap Plugin. Related PR-https://github.com/fledge-iot/fledge-south-coap/pull/35
- [x] CI build run report added to JIRA 