### PR TITLE
FOGL-9653 Fix memory leaks in C/common unit tests and library

### DIFF
--- a/C/common/JSONPath.cpp
+++ b/C/common/JSONPath.cpp
@@ -27,6 +27,10 @@ JSONPath::JSONPath(const string& path) : m_path(path)
  */
 JSONPath::~JSONPath()
 {
+	for (int i = 0; i < m_parsed.size(); i++)
+	{
+		delete m_parsed[i];
+	}
 }
 
 /**

--- a/C/common/datapoint.cpp
+++ b/C/common/datapoint.cpp
@@ -172,6 +172,12 @@ void DatapointValue::deleteNestedDPV()
 	}
 	else if (m_type == T_2D_FLOAT_ARRAY)
 	{
+		for (auto it = m_value.a2d->begin();
+				 it != m_value.a2d->end();
+				 ++it)
+		{
+			delete(*it);
+		}
 		delete m_value.a2d;
 		m_value.a2d = NULL;
 	}

--- a/C/common/include/reading.h
+++ b/C/common/include/reading.h
@@ -38,7 +38,7 @@ class Reading {
 		Reading(const std::string& asset, const std::string& datapoints);
 		Reading(const Reading& orig);
 
-		~Reading();	// This should bbe virtual
+		virtual	~Reading();
 		void				addDatapoint(Datapoint *value);
 		Datapoint			*removeDatapoint(const std::string& name);
 		Datapoint			*getDatapoint(const std::string& name) const;

--- a/C/common/pythonreading.cpp
+++ b/C/common/pythonreading.cpp
@@ -281,6 +281,8 @@ DatapointValue *PythonReading::getDatapointValue(PyObject *value)
 				values.push_back(row);
 			}
 			dataPoint = new DatapointValue(values);
+			for (auto& row : values)
+				delete row;
 		}
 		else if (PyDict_Check(item0))	// List of datapoints	T_DP_LIST
 		{

--- a/C/common/readingset_circularbuffer.cpp
+++ b/C/common/readingset_circularbuffer.cpp
@@ -88,7 +88,7 @@ void ReadingSetCircularBuffer::appendReadingSet(const std::vector<Reading *>& re
 	}
 	// Insert ReadingSet into buffer
 	m_circularBuffer.push_back(std::make_shared<ReadingSet>(newReadings));
-	
+	delete newReadings;
 }
 
 /**

--- a/tests/unit/C/common/test_circular_buffer.cpp
+++ b/tests/unit/C/common/test_circular_buffer.cpp
@@ -25,6 +25,7 @@ TEST(TESTCircularBuffer, TestMaxLimitOfBuffer)
     ReadingSet* rs1 = new  ReadingSet(readings1);
     buffer.insert(rs1);
     delete readings1;
+    delete rs1;
 
     //Second ReadingSet
     long dpVal2 = 50;
@@ -34,6 +35,7 @@ TEST(TESTCircularBuffer, TestMaxLimitOfBuffer)
     ReadingSet* rs2 = new  ReadingSet(readings2);
     buffer.insert(rs2);
     delete readings2;
+    delete rs2;
 
     //Third ReadingSet
     long dpVal3 = 40;
@@ -43,6 +45,7 @@ TEST(TESTCircularBuffer, TestMaxLimitOfBuffer)
     ReadingSet* rs3 = new  ReadingSet(readings3);
     buffer.insert(rs3);
     delete readings3;
+    delete rs3;
 
     //Fourth ReadingSet
     long dpVal4 = 45;
@@ -52,6 +55,7 @@ TEST(TESTCircularBuffer, TestMaxLimitOfBuffer)
     ReadingSet* rs4 = new  ReadingSet(readings4);
     buffer.insert(rs4);
     delete readings4;
+    delete rs4;
 
     //Fifth ReadingSet
     long dpVal5 = 86;
@@ -61,6 +65,7 @@ TEST(TESTCircularBuffer, TestMaxLimitOfBuffer)
     ReadingSet* rs5 = new  ReadingSet(readings5);
     buffer.insert(rs5);
     delete readings5;
+    delete rs5;
 
     //Sixth ReadingSet
     long dpVal6 = 75;
@@ -70,6 +75,7 @@ TEST(TESTCircularBuffer, TestMaxLimitOfBuffer)
     ReadingSet* rs6 = new  ReadingSet(readings6);
     buffer.insert(rs6);
     delete readings6;
+    delete rs6;
 
     //Seventh ReadingSet
     long dpVal7 = 49;
@@ -79,6 +85,7 @@ TEST(TESTCircularBuffer, TestMaxLimitOfBuffer)
     ReadingSet* rs7 = new  ReadingSet(readings7);
     buffer.insert(rs7);
     delete readings7;
+    delete rs7;
 
     //Eighth ReadingSet
     long dpVal8 = 15;
@@ -88,6 +95,7 @@ TEST(TESTCircularBuffer, TestMaxLimitOfBuffer)
     ReadingSet* rs8 = new  ReadingSet(readings8);
     buffer.insert(rs8);
     delete readings8;
+    delete rs8;
 
     //Ninth ReadingSet
     long dpVal9 = 23;
@@ -97,6 +105,7 @@ TEST(TESTCircularBuffer, TestMaxLimitOfBuffer)
     ReadingSet* rs9 = new  ReadingSet(readings9);
     buffer.insert(rs9);
     delete readings9;
+    delete rs9;
 
     //Tenth ReadingSet
     long dpVal10 = 38;
@@ -106,6 +115,7 @@ TEST(TESTCircularBuffer, TestMaxLimitOfBuffer)
     ReadingSet* rs10 = new  ReadingSet(readings10);
     buffer.insert(rs10);
     delete readings10;
+    delete rs10;
     ASSERT_EQ(buffer.extract(false).size(),10); // MaxLimit for buffer is reached
     
     //Eleventh ReadingSet
@@ -116,6 +126,7 @@ TEST(TESTCircularBuffer, TestMaxLimitOfBuffer)
     ReadingSet* rs11 = new  ReadingSet(readings11);
     buffer.insert(rs11);
     delete readings11;
+    delete rs11;
     
     ASSERT_EQ(buffer.extract(false).size(),1); // Buffer size can't exceed the default MaxLimit
 }
@@ -133,6 +144,7 @@ TEST(TESTCircularBuffer, TestCustomSizeBuffer)
     ReadingSet* rs1 = new  ReadingSet(readings1);
     buffer.insert(rs1);
     delete readings1;
+    delete rs1;
     ASSERT_EQ(buffer.extract().size(),1);
 
     //Second ReadingSet
@@ -142,6 +154,7 @@ TEST(TESTCircularBuffer, TestCustomSizeBuffer)
     readings2->emplace_back(new Reading("R2", new Datapoint("DP2", dpv2)));
     ReadingSet* rs2 = new  ReadingSet(readings2);
     buffer.insert(rs2);
+    delete rs2;
     delete readings2;
 
     //Third ReadingSet
@@ -151,6 +164,7 @@ TEST(TESTCircularBuffer, TestCustomSizeBuffer)
     readings3->emplace_back(new Reading("R3", new Datapoint("DP3", dpv3)));
     ReadingSet* rs3 = new  ReadingSet(readings3);
     buffer.insert(rs3);
+    delete rs3;
     delete readings3;
 
     //Fourth ReadingSet
@@ -160,6 +174,7 @@ TEST(TESTCircularBuffer, TestCustomSizeBuffer)
     readings4->emplace_back(new Reading("R4", new Datapoint("DP4", dpv4)));
     ReadingSet* rs4 = new  ReadingSet(readings4);
     buffer.insert(rs4);
+    delete rs4;
     delete readings4;
 
     //Fifth ReadingSet
@@ -170,6 +185,7 @@ TEST(TESTCircularBuffer, TestCustomSizeBuffer)
     ReadingSet* rs5 = new  ReadingSet(readings5);
     buffer.insert(rs5);
     delete readings5;
+    delete rs5;
     ASSERT_EQ(buffer.extract(false).size(),4); // Remaining item in buffer
 
     //Sixth ReadingSet
@@ -180,6 +196,7 @@ TEST(TESTCircularBuffer, TestCustomSizeBuffer)
     ReadingSet* rs6 = new  ReadingSet(readings6);
     buffer.insert(rs6);
     delete readings6;
+    delete rs6;
     ASSERT_EQ(buffer.extract(false).size(),1); // Buffer size can't exceed the default MaxLimit
 }
 
@@ -206,7 +223,7 @@ TEST(TESTCircularBuffer, TestHeadAndTailMarkerAdjustment)
     ASSERT_EQ(buff1[0]->getAllReadings()[0]->getAssetName(), "R1");
     ASSERT_EQ(buff1[0]->getAllReadings()[0]->getDatapointsJSON(), readings1->at(0)->getDatapointsJSON());
     delete readings1;
-
+    delete rs1;
 
     //Second ReadingSet
     long dpVal2 = 50;
@@ -221,6 +238,7 @@ TEST(TESTCircularBuffer, TestHeadAndTailMarkerAdjustment)
     ASSERT_EQ(buff2[0]->getAllReadings()[0]->getAssetName(), "R2");
     ASSERT_EQ(buff2[0]->getAllReadings()[0]->getDatapointsJSON(), readings2->at(0)->getDatapointsJSON());
     delete readings2;
+    delete rs2;
 
     //Third ReadingSet
     long dpVal3 = 40;
@@ -235,6 +253,7 @@ TEST(TESTCircularBuffer, TestHeadAndTailMarkerAdjustment)
     ASSERT_EQ(buff3[0]->getAllReadings()[0]->getAssetName(), "R3"); //Buffer is Full
     ASSERT_EQ(buff3[0]->getAllReadings()[0]->getDatapointsJSON(), readings3->at(0)->getDatapointsJSON());
     delete readings3;
+    delete rs3;
 
     //Fourth ReadingSet
     long dpVal4 = 45;
@@ -250,6 +269,7 @@ TEST(TESTCircularBuffer, TestHeadAndTailMarkerAdjustment)
     ASSERT_EQ(buff4[0]->getAllReadings()[0]->getAssetName(), "R4"); 
     ASSERT_EQ(buff4[0]->getAllReadings()[0]->getDatapointsJSON(), readings4->at(0)->getDatapointsJSON());
     delete readings4;
+    delete rs4;
 
 }
 
@@ -270,6 +290,7 @@ TEST(TESTCircularBuffer, TestCustomSizeBufferLessThanOne)
     ASSERT_EQ(buff1[0]->getAllReadings()[0]->getAssetName(), "R1");
     ASSERT_EQ(buff1[0]->getAllReadings()[0]->getDatapointsJSON(), readings1->at(0)->getDatapointsJSON());
     delete readings1;
+    delete rs1;
 
     //Second ReadingSet
     long dpVal2 = 50;
@@ -284,6 +305,7 @@ TEST(TESTCircularBuffer, TestCustomSizeBufferLessThanOne)
     ASSERT_EQ(buff2[0]->getAllReadings()[0]->getAssetName(), "R2");
     ASSERT_EQ(buff2[0]->getAllReadings()[0]->getDatapointsJSON(), readings2->at(0)->getDatapointsJSON());
     delete readings2;
+    delete rs2;
 
 }
 

--- a/tests/unit/C/common/test_imageencode.cpp
+++ b/tests/unit/C/common/test_imageencode.cpp
@@ -41,6 +41,7 @@ TEST(ImageEncodingTest, ImageRoundTrip64)
 			ptr++;
 			ptr2++;
 		}
+	free(data);
 }
 
 TEST(ImageEncodingTest, ImageRoundTrip65)
@@ -75,6 +76,7 @@ TEST(ImageEncodingTest, ImageRoundTrip65)
 			ptr++;
 			ptr2++;
 		}
+	free(data);
 }
 
 TEST(ImageEncodingTest, ImageRoundTrip66)
@@ -109,4 +111,5 @@ TEST(ImageEncodingTest, ImageRoundTrip66)
 			ptr++;
 			ptr2++;
 		}
+	free(data);
 }

--- a/tests/unit/C/common/test_python_reading.cpp
+++ b/tests/unit/C/common/test_python_reading.cpp
@@ -599,6 +599,7 @@ TEST_F(PythonReadingTest, ImageRoundTrip)
 		EXPECT_EQ(image2->getDepth(), image->getDepth());
 	}
 	PyGILState_Release(state);
+	free(data);
 }
 
 TEST_F(PythonReadingTest, UpdateAssetCode)
@@ -642,11 +643,14 @@ TEST_F(PythonReadingTest, Double2DArray)
 		vector<double> *row = new vector<double>;
 		row->push_back(1.4 + i);
 		row->push_back(3.7 + i);
-		array.push_back(row);
+		array.emplace_back(row);
 	}
 
 	DatapointValue value(array);
 	Reading reading("test2d", new Datapoint("array", value));
+
+	for (auto& row : array)
+		delete row;
 	PyGILState_STATE state = PyGILState_Ensure();
 	PyObject *pyReading = ((PythonReading *)(&reading))->toPython();
 	PyObject *element = PyUnicode_FromString("array");

--- a/tests/unit/C/common/test_python_reading_set.cpp
+++ b/tests/unit/C/common/test_python_reading_set.cpp
@@ -117,6 +117,7 @@ TEST_F(PythonReadingSetTest, SingleReading)
 	DatapointValue value(i);
 	readings->push_back(new Reading("test", new Datapoint("long", value)));
 	ReadingSet set(readings);
+	delete readings;
 	PyGILState_STATE state = PyGILState_Ensure();
 	PyObject *pySet = ((PythonReadingSet *)(&set))->toPython();
 	PyObject *obj = callPythonFunc("count", pySet);
@@ -134,6 +135,7 @@ TEST_F(PythonReadingSetTest, MultipleReadings)
 	readings->push_back(new Reading("test", new Datapoint("long", value)));
 	readings->push_back(new Reading("test", new Datapoint("long", value)));
 	ReadingSet set(readings);
+	delete readings;
 	PyGILState_STATE state = PyGILState_Ensure();
 	PyObject *pySet = ((PythonReadingSet *)(&set))->toPython();
 	PyObject *obj = callPythonFunc("count", pySet);

--- a/tests/unit/C/common/test_python_readingnumpy.cpp
+++ b/tests/unit/C/common/test_python_readingnumpy.cpp
@@ -206,5 +206,6 @@ TEST_F(PythonReadingNumpyTest, ImageFloat)
 			}
 		}
 	}
+	free(data);
 }
 }

--- a/tests/unit/C/common/test_reading_array.cpp
+++ b/tests/unit/C/common/test_reading_array.cpp
@@ -73,6 +73,7 @@ TEST(TESTReading, TestReadingForListType )
 
     ASSERT_EQ(dp[2]->getName(),"floor3");
     ASSERT_EQ(dp[2]->getData().toString(),"[38.25, 60.89, 40.28]");
+    delete readings[0];
 }
 
 TEST(TESTReading, TestReadingForNestedListType )
@@ -86,6 +87,6 @@ TEST(TESTReading, TestReadingForNestedListType )
 
     ASSERT_EQ(dp[0]->getName(),"pressure");
     ASSERT_EQ(dp[0]->getData().toString(),"{\"floor1\":30, \"floor2\":34, \"floor3\":[38, 60, 40]}");
-    
+    delete readings[0];
 }
 


### PR DESCRIPTION
One definite leak left, in the unit test code where I catches an exception which is a pointer
==2576541== LEAK SUMMARY:
==2576541==    definitely lost: 1,600 bytes in 200 blocks
==2576541==    indirectly lost: 0 bytes in 0 blocks
==2576541==      possibly lost: 190,584 bytes in 149 blocks
==2576541==    still reachable: 14,528,263 bytes in 4,576 blocks
==2576541==         suppressed: 0 bytes in 0 blocks

`TEST(Categorytest, parseError)
{
        EXPECT_THROW(ConfigCategory("parseTest", json_parse_error), ConfigMalformed*);
}`

This is not usually an issue, but due to the way GTEST is picking up the exception there is no way to free the exception class.

Fixed leaks in ReadingSetCircularBuffer, 2D datapoint arrays, caused by non-virtual Reading destructor, PythonNumpy  issue and Image Encoding.

There are some dubious references in the Python code that should be the subject of another investigation.