### PR TITLE
FOGL-9467 - Ubuntu24 support

### DIFF
--- a/C/common/include/base64.h
+++ b/C/common/include/base64.h
@@ -1,5 +1,6 @@
 #ifndef _BASE64_H_
 #define _BASE64_H_
+#include <cstdint>
 /*
  * Fledge Base64 encoding and decoding tables
  *

--- a/C/plugins/storage/sqlite/common/include/purge_configuration.h
+++ b/C/plugins/storage/sqlite/common/include/purge_configuration.h
@@ -11,6 +11,7 @@
  */
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class PurgeConfiguration {
 	public:

--- a/C/services/storage/include/stream_handler.h
+++ b/C/services/storage/include/stream_handler.h
@@ -16,6 +16,7 @@
 #include <map>
 #include <sys/epoll.h>
 #include <reading_stream.h>
+#include <string>
 
 #define MAX_EVENTS	  40	// Number of epoll events in one epoll_wait call
 #define RDS_BLOCK	 10000	// Number of readings to insert in each call to the storage plugin

--- a/python/fledge/services/core/api/configuration.py
+++ b/python/fledge/services/core/api/configuration.py
@@ -282,10 +282,10 @@ async def set_configuration_item(request):
             await cf_mgr.set_category_item_value_entry(category_name, config_item, value, request=request_details)
         else:
             await cf_mgr.set_optional_value_entry(category_name, config_item, list(found_optional.keys())[0], list(found_optional.values())[0])
-    except ValueError as ex:
-        raise web.HTTPNotFound(reason=ex) if not found_optional else web.HTTPBadRequest(reason=ex)
-    except (TypeError, KeyError) as ex:
-        raise web.HTTPBadRequest(reason=ex)
+    except ValueError as err:
+        raise web.HTTPNotFound(reason=str(err)) if not found_optional else web.HTTPBadRequest(reason=str(err))
+    except (TypeError, KeyError) as err:
+        raise web.HTTPBadRequest(reason=str(err))
     except Exception as ex:
         msg = str(ex)
         if 'Forbidden' in msg:
@@ -332,10 +332,10 @@ async def update_configuration_item_bulk(request):
                             raise TypeError(
                                 "Bulk update not allowed for {} item_name as it has readonly attribute set".format(item_name))
         await cf_mgr.update_configuration_item_bulk(category_name, data, request_details)
-    except (NameError, KeyError) as ex:
-        raise web.HTTPNotFound(reason=ex)
-    except (ValueError, TypeError) as ex:
-        raise web.HTTPBadRequest(reason=ex)
+    except (NameError, KeyError) as err:
+        raise web.HTTPNotFound(reason=str(err))
+    except (ValueError, TypeError) as err:
+        raise web.HTTPBadRequest(reason=str(err))
     except Exception as ex:
         msg = str(ex)
         if 'Forbidden' in msg:

--- a/python/fledge/services/core/api/plugins/discovery.py
+++ b/python/fledge/services/core/api/plugins/discovery.py
@@ -78,8 +78,8 @@ async def get_plugins_available(request: web.Request) -> web.Response:
         if not package_type:
             prefix_list = ['fledge-filter-', 'fledge-north-', 'fledge-notify-', 'fledge-rule-', 'fledge-south-']
             plugins = [p for p in plugins if str(p).startswith(tuple(prefix_list))]
-    except ValueError as e:
-        raise web.HTTPBadRequest(reason=e)
+    except ValueError as err:
+        raise web.HTTPBadRequest(reason=str(err))
     except PackageError as e:
         msg = "Fetch available plugins package request failed."
         raise web.HTTPBadRequest(body=json.dumps({"message": msg, "link": str(e)}), reason=msg)

--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -13,9 +13,11 @@ requests==2.20.0
 pyserial==3.4
 
 # keep this in sync with requirement.txt, as otherwise pytest-aiohttp always pulls the latest
-aiohttp==3.8.6
+aiohttp==3.8.6;python_version<"3.12"
+aiohttp==3.10.11;python_version>="3.12"
 yarl==1.7.2;python_version<="3.10"
-yarl==1.9.4;python_version>="3.11"
+yarl==1.9.4;python_version>="3.11" and python_version<"3.12"
+yarl==1.18.3;python_version>="3.12"
 
 # specific version for setuptools as per pytest version
 setuptools==70.3.0;python_version>="3.8"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,11 +1,14 @@
 # Common - REST interface
-aiohttp==3.8.6
+aiohttp==3.8.6;python_version<"3.12"
+aiohttp==3.10.11;python_version>="3.12"
 aiohttp_cors==0.7.0
+async-timeout==5.0.1;python_version>="3.12"
 cchardet==2.1.4;python_version<"3.9"
-cchardet==2.1.7; python_version >= "3.9" and python_version < "3.11"
-cchardet==2.2.0a2; python_version >= "3.11"
+cchardet==2.1.7; python_version>="3.9" and python_version<"3.11"
+cchardet==2.2.0a2; python_version>="3.11"
 yarl==1.7.2;python_version<="3.10"
-yarl==1.9.4;python_version>="3.11"
+yarl==1.9.4;python_version>="3.11" and python_version<"3.12"
+yarl==1.18.3;python_version>="3.12"
 pyjwt==2.4.0
 
 # only required for Public Proxy multipart payload

--- a/requirements.sh
+++ b/requirements.sh
@@ -121,14 +121,15 @@ get_pip_break_system_flag() {
     PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
     PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
 
-    # Default to empty flag
-    FLAG=""
-
     # Set the FLAG only for Python versions 3.11 or higher
-    if [ "$PYTHON_MAJOR" -gt 3 ] || { [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -ge 11 ]; }; then
+    if [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -ge 11 ] && [ "$PYTHON_MINOR" -lt 12 ]; then
         FLAG="--break-system-packages"
+    elif [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -ge 12 ]; then
+        FLAG="--user --break-system-packages"
+    else
+        # Default to empty flag
+        FLAG=""
     fi
-
     # Return the FLAG (via echo)
     echo "$FLAG"
 }

--- a/tests/unit/python/fledge/common/test_configuration_manager.py
+++ b/tests/unit/python/fledge/common/test_configuration_manager.py
@@ -1781,9 +1781,8 @@ class TestConfigurationManager:
                 readpatch.assert_called_once_with('catname')
             valpatch.assert_has_calls([call('catname', 'catvalue', True), call('catname', {}, False)])
         assert 1 == log_exc.call_count
-        calls = [call('category_value for category_name %s from storage is corrupted; using category_value without merge', 'catname'),
-                 call('Unable to create new category based on category_name %s and category_description %s and category_json_schema %s', 'catname', 'catdesc')]
-        assert log_exc.has_calls(calls, any_order=True)
+        calls = [call('category_value for category_name %s from storage is corrupted; using category_value without merge', 'catname')]
+        log_exc.assert_has_calls(calls, any_order=True)
 
     # (merged_value)
     async def test_create_category_good_newval_good_storageval_nochange(self, reset_singleton):
@@ -3359,12 +3358,9 @@ class TestConfigurationManager:
                        call('CONCH', {'categoryDeleted': 'J'}),
                        call('CONCH', {'categoryDeleted': 'A'})]
         
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            await patch_delete_from_tbl.has_calls(calls, any_order=True)
-            await audit_info.has_calls(audit_calls, any_order=True)
-        else:
-            patch_delete_from_tbl.has_calls(calls, any_order=True)
-            audit_info.has_calls(audit_calls, any_order=True)
+        patch_delete_from_tbl.assert_has_calls(calls, any_order=True)
+        audit_info.assert_has_calls(audit_calls, any_order=True)
+
 
     async def test_delete_category_and_children_recursively_exception(self, mocker, reset_singleton):
         async def mock_coro(a, b):

--- a/tests/unit/python/fledge/services/core/api/control_service/test_script_management.py
+++ b/tests/unit/python/fledge/services/core/api/control_service/test_script_management.py
@@ -653,7 +653,7 @@ class TestScriptManagement:
         ({"parameters": {}}, "parameters cannot be an empty."),
     ])
     async def test_bad_schedule_script_with_parameters(self, client, payload, message):
-        resp = await client.post('/fledge/control/script/{}/schedule', data=json.dumps(payload))
+        resp = await client.post('/fledge/control/script/test/schedule', data=json.dumps(payload))
         assert 400 == resp.status
         assert message == resp.reason
         result = await resp.text()

--- a/tests/unit/python/fledge/services/core/api/test_service.py
+++ b/tests/unit/python/fledge/services/core/api/test_service.py
@@ -936,7 +936,7 @@ class TestService:
         query_tbl_payload = {"return": ["status"], "where": {"column": "action", "condition": "=", "value": "install",
                                                              "and": {"column": "name", "condition": "=",
                                                                      "value": pkg_name}}}
-        
+        svc_list = ["storage", "south"]
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
             _rv1 = await async_mock({'count': 0, 'rows': []})
@@ -949,29 +949,34 @@ class TestService:
             _rv3 = asyncio.ensure_future(async_mock({"response": "inserted", "rows_affected": 1}))
         
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
-            with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1) as query_tbl_patch:
-                with patch.object(common, 'fetch_available_packages', return_value=(_rv2)) as patch_fetch_available_package:
-                    with patch.object(storage_client_mock, 'insert_into_tbl', return_value=_rv3) as insert_tbl_patch:
-                        with patch.object(service._logger, "info") as log_info:
-                            with patch('multiprocessing.Process'):
-                                resp = await client.post('/fledge/service?action=install', data=json.dumps(param))
-                                assert 200 == resp.status
-                                result = await resp.text()
-                                response = json.loads(result)
-                                assert 'id' in response
-                                assert '{} service installation started'.format(pkg_name) == response['message']
-                                assert response['statusLink'].startswith('fledge/package/install/status?id=')
-                        assert 1 == log_info.call_count
-                        log_info.assert_called_once_with('{} service installation started...'.format(pkg_name))
-                    args, kwargs = insert_tbl_patch.call_args_list[0]
-                    assert 'packages' == args[0]
-                    actual = json.loads(args[1])
-                    assert 'id' in actual
-                    assert pkg_name == actual['name']
-                    assert 'install' == actual['action']
-                    assert -1 == actual['status']
-                    assert '' == actual['log_file_uri']
-                patch_fetch_available_package.assert_called_once_with()
+            with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1
+                              ) as query_tbl_patch:
+                with patch.object(service, 'get_service_installed', return_value=svc_list) as svc_list_patch:
+                    with patch.object(common, 'fetch_available_packages', return_value=_rv2
+                                      ) as patch_fetch_available_package:
+                        with patch.object(storage_client_mock, 'insert_into_tbl', return_value=_rv3
+                                          ) as insert_tbl_patch:
+                            with patch.object(service._logger, "info") as log_info:
+                                with patch('multiprocessing.Process'):
+                                    resp = await client.post('/fledge/service?action=install', data=json.dumps(param))
+                                    assert 200 == resp.status
+                                    result = await resp.text()
+                                    response = json.loads(result)
+                                    assert 'id' in response
+                                    assert '{} service installation started'.format(pkg_name) == response['message']
+                                    assert response['statusLink'].startswith('fledge/package/install/status?id=')
+                            assert 1 == log_info.call_count
+                            log_info.assert_called_once_with('{} service installation started...'.format(pkg_name))
+                        args, kwargs = insert_tbl_patch.call_args_list[0]
+                        assert 'packages' == args[0]
+                        actual = json.loads(args[1])
+                        assert 'id' in actual
+                        assert pkg_name == actual['name']
+                        assert 'install' == actual['action']
+                        assert -1 == actual['status']
+                        assert '' == actual['log_file_uri']
+                    patch_fetch_available_package.assert_called_once_with()
+                svc_list_patch.assert_called_once_with()
             args, kwargs = query_tbl_patch.call_args_list[0]
             assert 'packages' == args[0]
             actual = json.loads(args[1])
@@ -1001,7 +1006,8 @@ class TestService:
         payload = {"return": ["status"], "where": {"column": "action", "condition": "=", "value": "install",
                                                    "and": {"column": "name", "condition": "=", "value": pkg_name}}}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
+        svc_list = ["storage", "south"]
+
         # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
         if sys.version_info.major == 3 and sys.version_info.minor >= 8:
             _rv1 = await async_mock({'count': 0, 'rows': []})
@@ -1014,11 +1020,14 @@ class TestService:
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               return_value=_rv1) as query_tbl_patch:
-                with patch.object(common, 'fetch_available_packages', return_value=_rv2) as patch_fetch_available_package:
-                    resp = await client.post('/fledge/service?action=install', data=json.dumps(param))
-                    assert 404 == resp.status
-                    assert "'{} service is not available for the given repository'".format(pkg_name) == resp.reason
-                patch_fetch_available_package.assert_called_once_with()
+                with patch.object(service, 'get_service_installed', return_value=svc_list) as svc_list_patch:
+                    with patch.object(common, 'fetch_available_packages', return_value=_rv2
+                                      ) as patch_fetch_available_package:
+                        resp = await client.post('/fledge/service?action=install', data=json.dumps(param))
+                        assert 404 == resp.status
+                        assert "'{} service is not available for the given repository'".format(pkg_name) == resp.reason
+                    patch_fetch_available_package.assert_called_once_with()
+                svc_list_patch.assert_called_once_with()
             args, kwargs = query_tbl_patch.call_args_list[0]
             assert 'packages' == args[0]
             assert payload == json.loads(args[1])


### PR DESCRIPTION
**Known issue**

- [ ] C based tests are failing. Raised a JIRA FOGL-9685.
- [ ] An additional problem arises when stopping, restarting, or shutting down the Fledge instance, as the aiohttp-based REST server does not shut down smoothly and becomes unresponsive due to the blocking nature of the server closure.
We already have a JIRA-9520 to tackle this separately.