### PR TITLE
FOGL-9770 Updates to Logger class

### DIFF
--- a/C/common/include/logger.h
+++ b/C/common/include/logger.h
@@ -27,8 +27,16 @@
  * At startup this class should be constructed
  * using the standard constructor. To log a message
  * call debug, info, warn etc. using the instance
- * of the class. TO get that instance call the static
+ * of the class.
+ *
+ * To obtain that singleton instance call the static
  * method getLogger.
+ *
+ * It is generally unsafe to delete the logger class
+ * as it may be called asynchronouly from multiple
+ * threads and single handlers. The destructor has
+ * hence been made private to prevent the destruction
+ * of the class.
  */
 class Logger {
 	public:
@@ -45,7 +53,7 @@ class Logger {
 		~Logger();
 		static Logger *getLogger();
 		void debug(const std::string& msg, ...);
-		void printLongString(const std::string&);
+		void printLongString(const std::string&, LogLevel = LogLevel::DEBUG);
 		void info(const std::string& msg, ...);
 		void warn(const std::string& msg, ...);
 		void error(const std::string& msg, ...);
@@ -83,11 +91,11 @@ class Logger {
 			void* userData;
 		};
 
-		std::queue<LogTask> m_taskQueue;
-		std::mutex m_queueMutex;
+		std::queue<LogTask>	m_taskQueue;
+		std::mutex		m_queueMutex;
 		std::condition_variable m_condition;
-		std::atomic<bool> m_running;
-		std::thread m_workerThread;
+		std::atomic<bool>	m_runWorker;
+		std::thread 		*m_workerThread;
 
 		void executeInterceptor(LogLevel level, const std::string& message);
 		void workerThread();

--- a/C/common/logger.cpp
+++ b/C/common/logger.cpp
@@ -45,9 +45,8 @@ static char ident[80];
 
 	if (instance)
 	{
-		// Prevent two instances of a logger class
-		instance->error("An attempt is beign made to create a second logger class");
-		throw runtime_error("A singleton logger instance has already been created");
+		instance->error("Attempt to create second singleton instance, original application name %s, current attempt made by %s", ident, application.c_str());
+		throw runtime_error("Attempt to create secnd Logger instance");
 	}
 	/* Prepend "Fledge " in all cases other than Fledge itself and Fledge Storage.
 	 */
@@ -98,7 +97,7 @@ Logger *Logger::getLogger()
 		// and clearly identify this. We should ideally avoid
 		// the use of a default as this will not identify the
 		// source of the log message.
-		instance = new Logger("fledge (default)");
+		instance = new Logger("(default)");
 	}
 
 	return instance;

--- a/C/common/logger.cpp
+++ b/C/common/logger.cpp
@@ -284,20 +284,35 @@ void Logger::printLongString(const string& s, LogLevel level)
 		switch (level)
 		{
 			case LogLevel::FATAL:
-				this->fatal("%s%s", cstr+i*charsPerLine, len - i > charsPerLine ? "..." : "");
+				this->fatal("%.*s%s",
+						charsPerLine,
+						cstr+i*charsPerLine,
+						len - i > charsPerLine ? "..." : "");
 				break;
 			case LogLevel::ERROR:
-				this->error("%s%s", cstr+i*charsPerLine, len - i > charsPerLine ? "..." : "");
+				this->error("%.*s%s",
+						charsPerLine,
+						cstr+i*charsPerLine,
+						len - i > charsPerLine ? "..." : "");
 				break;
 			case LogLevel::WARNING:
-				this->warn("%s%s", cstr+i*charsPerLine, len - i > charsPerLine ? "..." : "");
+				this->warn("%.*s%s",
+						charsPerLine,
+						cstr+i*charsPerLine,
+						len - i > charsPerLine ? "..." : "");
 				break;
 			case LogLevel::INFO:
-				this->info("%s%s", cstr+i*charsPerLine, len - i > charsPerLine ? "..." : "");
+				this->info("%.*s%s",
+						charsPerLine,
+						cstr+i*charsPerLine,
+						len - i > charsPerLine ? "..." : "");
 				break;
 			case LogLevel::DEBUG:
 			default:
-				this->debug("%s%s", cstr+i*charsPerLine, len - i > charsPerLine ? "..." : "");
+				this->debug("%.*s%s",
+						charsPerLine,
+						cstr+i*charsPerLine,
+						len - i > charsPerLine ? "..." : "");
 				break;
 		}
 	}

--- a/C/common/logger.cpp
+++ b/C/common/logger.cpp
@@ -79,6 +79,7 @@ Logger::~Logger()
 	{
 		m_runWorker = false;
 		m_workerThread->join();
+		delete m_workerThread;
 		m_workerThread = NULL;
 	}
 

--- a/C/services/storage/storage.cpp
+++ b/C/services/storage/storage.cpp
@@ -221,8 +221,8 @@ StorageService::StorageService(const string& myName) : m_name(myName),
 {
 unsigned short servicePort;
 
+	logger = new Logger(myName);	// Do this first to make sure we have the right logger
 	config = new StorageConfiguration();
-	logger = new Logger(myName);
 
 	signal(SIGSEGV, handler);
 	signal(SIGILL, handler);

--- a/C/tasks/check_updates/check_updates.cpp
+++ b/C/tasks/check_updates/check_updates.cpp
@@ -36,7 +36,7 @@ CheckUpdates::CheckUpdates(int argc, char** argv) : FledgeProcess(argc, argv)
 {
 	std::string paramName;
 	paramName = getName();
-	m_logger = new Logger(paramName);
+	m_logger = Logger::getLogger();	// Logger is created by FledgeProcess
 	m_logger->info("CheckUpdates starting - parameters name :%s:", paramName.c_str() );
 	m_mgtClient = this->getManagementClient();
 

--- a/C/tasks/check_updates/main.cpp
+++ b/C/tasks/check_updates/main.cpp
@@ -15,8 +15,6 @@ using namespace std;
 
 int main(int argc, char** argv)
 {
-	Logger *logger = new Logger(LOG_NAME);
-
 	try
 	{
 		CheckUpdates check(argc, argv);
@@ -32,7 +30,7 @@ int main(int argc, char** argv)
                 }
                 catch(const std::exception& e)
                 {
-                        logger->error("An error occurred during the execution : %s", e.what());
+			Logger::getLogger()->error("An error occurred during the execution : %s", e.what());
                 }
 
 		exit(1);

--- a/C/tasks/purge_system/main.cpp
+++ b/C/tasks/purge_system/main.cpp
@@ -15,7 +15,6 @@ using namespace std;
 
 int main(int argc, char** argv)
 {
-	Logger *logger = new Logger(LOG_NAME);
 
 	try
 	{
@@ -25,7 +24,7 @@ int main(int argc, char** argv)
 	}
 	catch (const std::exception& e)
 	{
-		logger->error("An error occurred during the execution, :%s: ", e.what());
+		Logger::getLogger()->error("An error occurred during the execution, :%s: ", e.what());
 		exit(1);
 	}
 	catch (...)
@@ -33,7 +32,7 @@ int main(int argc, char** argv)
 		std::exception_ptr p = std::current_exception();
 		string name = (p ? p.__cxa_exception_type()->name() : "null");
 
-		logger->error("An error occurred during the execution, :%s: ", name.c_str() );
+		Logger::getLogger()->error("An error occurred during the execution, :%s: ", name.c_str() );
 		exit(1);
 	}
 

--- a/C/tasks/purge_system/purge_system.cpp
+++ b/C/tasks/purge_system/purge_system.cpp
@@ -78,7 +78,7 @@ PurgeSystem::PurgeSystem(int argc, char** argv) : FledgeProcess(argc, argv)
 
 	paramName = getName();
 
-	m_logger = new Logger(paramName);
+	m_logger = Logger::getLogger();		// Logger is created by FledgeProcess
 	m_logger->info("PurgeSystem starting - parameters name :%s:", paramName.c_str() );
 
 	m_retainStatsHistory = 0;

--- a/C/tasks/statistics_history/main.cpp
+++ b/C/tasks/statistics_history/main.cpp
@@ -24,7 +24,7 @@ int main(int argc, char** argv)
 	}
 	catch (const std::exception& e)
 	{
-		cerr << "Exception " << e.what() << endl;
+		Logger::getLogger()->fatal("Exception %s starting Stats History task", e.what());
 		// Return failure for class instance/configuration etc
 		exit(1);
 	}
@@ -33,7 +33,7 @@ int main(int argc, char** argv)
 	{
 		std::exception_ptr p = std::current_exception();
 		string name = (p ? p.__cxa_exception_type()->name() : "null");
-		cerr << "Generic Exception" << name << endl;
+		Logger::getLogger()->fatal("Exception %s starting Stats History task", name);
 		exit(1);
 	}
 


### PR DESCRIPTION
A number of things have been done

- Allow only a single instance to be created
- Delay the creation of the worker thread until the first intercepter requires it - reduced overhead if no intercepters are registered
- Protect the deletion of the Logger class
- Clean up tasks that created multiple Logger
- Added missing Doxygen comments
- Cleaned up the printLogString entry point and enabled use at different log levels