### PR TITLE
FOGL-9746 implementation of Remote UDP Logging for syslog

### DIFF
--- a/C/common/include/logger.h
+++ b/C/common/include/logger.h
@@ -98,7 +98,7 @@ class Logger {
 		std::atomic<bool>	m_runWorker;
 		std::thread 		*m_workerThread;
 
-		void log(int sysLogLvl, const char * lvlName, LogLevel appLogLvl, const std::string& msg, ...);
+		void log(int sysLogLvl, const char * lvlName, LogLevel appLogLvl, const std::string& msg, va_list args);
 		void sendToUdpSink(const std::string& msg);
 		void executeInterceptor(LogLevel level, const std::string& message);
 		void workerThread();

--- a/C/common/include/logger.h
+++ b/C/common/include/logger.h
@@ -98,14 +98,13 @@ class Logger {
 		std::atomic<bool>	m_runWorker;
 		std::thread 		*m_workerThread;
 
-		void log(int lvl, const char * lvlName, const std::string& msg, ...);
+		void log(int sysLogLvl, const char * lvlName, LogLevel appLogLvl, const std::string& msg, ...);
 		void sendToUdpSink(const std::string& msg);
 		void executeInterceptor(LogLevel level, const std::string& message);
 		void workerThread();
 		int m_UdpSockFD = -1;
 		struct sockaddr_in m_UdpServerAddr;
 		bool m_SyslogUdpEnabled = false;
-		bool m_logTS = false;
 };
 
 #endif

--- a/C/common/include/logger.h
+++ b/C/common/include/logger.h
@@ -105,6 +105,8 @@ class Logger {
 		int m_UdpSockFD = -1;
 		struct sockaddr_in m_UdpServerAddr;
 		bool m_SyslogUdpEnabled = false;
+		std::string m_identifier;
+		std::string m_hostname;
 };
 
 #endif

--- a/C/common/include/logger.h
+++ b/C/common/include/logger.h
@@ -18,7 +18,8 @@
 #include <thread>
 #include <condition_variable>
 #include <atomic>
-
+#include <sys/socket.h>
+#include <arpa/inet.h>
 #define PRINT_FUNC	Logger::getLogger()->info("%s:%d", __FUNCTION__, __LINE__);
 
 /**
@@ -97,8 +98,14 @@ class Logger {
 		std::atomic<bool>	m_runWorker;
 		std::thread 		*m_workerThread;
 
+		void log(int lvl, const char * lvlName, const std::string& msg, ...);
+		void sendToUdpSink(const std::string& msg);
 		void executeInterceptor(LogLevel level, const std::string& message);
 		void workerThread();
+		int m_UdpSockFD = -1;
+		struct sockaddr_in m_UdpServerAddr;
+		bool m_SyslogUdpEnabled = false;
+		bool m_logTS = false;
 };
 
 #endif

--- a/C/common/logger.cpp
+++ b/C/common/logger.cpp
@@ -457,7 +457,7 @@ void Logger::fatal(const string& msg, ...)
  * @param msg		A printf format string
  * @param ...		The variable arguments required by the printf format
  */
-void Logger::log(int sysLogLvl, const char * lvlName, LogLevel appLogLvl, const std::string& msg, ...)
+void Logger::log(int sysLogLvl, const char * lvlName, LogLevel appLogLvl, const std::string& msg, va_list args)
 {
 	// Check if the current log level allows messages
 	if (m_level < sysLogLvl) 
@@ -467,9 +467,6 @@ void Logger::log(int sysLogLvl, const char * lvlName, LogLevel appLogLvl, const 
 
 	constexpr size_t MAX_BUFFER_SIZE = 1024; // Maximum allowed log size
 	char buffer[MAX_BUFFER_SIZE]; // Stack-allocated buffer for formatting
-
-	va_list args;
-	va_start(args, msg);
 
 	int copied = 0;
 
@@ -481,7 +478,6 @@ void Logger::log(int sysLogLvl, const char * lvlName, LogLevel appLogLvl, const 
 
 	// Format the log message using vsnprintf
 	vsnprintf(buffer + copied, sizeof(buffer) - copied, msg.c_str(), args);
-	va_end(args); // Ensure `va_list` is cleaned up immediately after usage
 
 	if(m_SyslogUdpEnabled)
 	{
@@ -490,7 +486,7 @@ void Logger::log(int sysLogLvl, const char * lvlName, LogLevel appLogLvl, const 
 	}
 	else
 	{
-		syslog(sysLogLvl, buffer);
+		syslog(sysLogLvl, "%s", buffer);
 	}
 
 	// Execute interceptors if any are present

--- a/python/fledge/common/logger.py
+++ b/python/fledge/common/logger.py
@@ -11,7 +11,7 @@ import logging
 import traceback
 from logging.handlers import SysLogHandler
 from functools import wraps
-
+import socket
 
 __author__ = "Praveen Garg, Ashish Jabble"
 __copyright__ = "Copyright (c) 2017-2023 OSIsoft, LLC"
@@ -31,6 +31,21 @@ FLEDGE_LOGS_DESTINATION = 'FLEDGE_LOGS_DESTINATION'
 default_destination = SYSLOG
 """Default destination of logger"""
 
+log_udp = os.getenv('SYSLOG_UDP_ENABLED', 'False')
+
+def get_format() -> str:
+    """Set the format for the logger
+
+    Args:
+        fmt: format string
+    """
+        # TODO: Consider using %r with message when using syslog .. \n looks better than #
+    if log_udp.lower() == 'false':
+        fmt = '{}[%(process)d] %(levelname)s: %(module)s: %(name)s: %(message)s'.format(get_process_name())
+    else:
+        fmt = '{} {}[%(process)d] %(levelname)s: %(module)s: %(name)s: %(message)s'.format(socket.gethostname(), get_process_name())
+    return fmt
+
 def get_syslog_handler():
     """Defines a syslog handler
 
@@ -38,7 +53,6 @@ def get_syslog_handler():
          logging handler object : the syslog handler
     """
     # Retrieve LOG_PORT and LOG_IP from environment variables
-    log_udp = os.getenv('SYSLOG_UDP_ENABLED', 'False')
     if log_udp.lower() == 'true':
         log_port = os.getenv('SYSLOG_PORT', '5140')
         log_ip = os.getenv('SYSLOG_IP', '127.0.0.1') 
@@ -126,9 +140,7 @@ def setup(logger_name: str = None,
     else:
         raise ValueError("Invalid destination {}".format(destination))
 
-    # TODO: Consider using %r with message when using syslog .. \n looks better than #
-    fmt = '{}[%(process)d] %(levelname)s: %(module)s: %(name)s: %(message)s'.format(get_process_name())
-    formatter = logging.Formatter(fmt=fmt)
+    formatter = logging.Formatter(fmt=get_format())
     handler.setFormatter(formatter)
     if level is not None:
         logger.setLevel(level)
@@ -195,9 +207,7 @@ class FLCoreLogger:
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
-            process_name = get_process_name()
-            fmt = '{}[%(process)d] %(levelname)s: %(module)s: %(name)s: %(message)s'.format(process_name)
-            cls.formatter = logging.Formatter(fmt=fmt)
+            cls.formatter = logging.Formatter(fmt=get_format())
         return cls._instance
 
     def get_syslog_handler(self):

--- a/python/fledge/common/logger.py
+++ b/python/fledge/common/logger.py
@@ -31,6 +31,24 @@ FLEDGE_LOGS_DESTINATION = 'FLEDGE_LOGS_DESTINATION'
 default_destination = SYSLOG
 """Default destination of logger"""
 
+def get_syslog_handler():
+    """Defines a syslog handler
+
+    Returns:
+         logging handler object : the syslog handler
+    """
+    # Retrieve LOG_PORT and LOG_IP from environment variables
+    log_udp = os.getenv('SYSLOG_UDP_ENABLED', 'False')
+    if log_udp.lower() == 'true':
+        log_port = os.getenv('SYSLOG_PORT', '5140')
+        log_ip = os.getenv('SYSLOG_IP', '127.0.0.1') 
+        syslog_address = (log_ip, int(log_port))
+        syslog_handler = SysLogHandler(address=syslog_address)
+    else:
+        syslog_handler = SysLogHandler(address='/dev/log')
+
+    return syslog_handler
+
 
 def set_default_destination(destination: int):
     """ set_default_destination - allow a global default to be set, once, for all fledge modules
@@ -102,7 +120,7 @@ def setup(logger_name: str = None,
         destination = default_destination
 
     if destination == SYSLOG:
-        handler = SysLogHandler(address='/dev/log')
+        handler = get_syslog_handler()
     elif destination == CONSOLE:
         handler = logging.StreamHandler()  # stderr
     else:
@@ -188,7 +206,7 @@ class FLCoreLogger:
         Returns:
              logging handler object : the syslog handler
         """
-        syslog_handler = SysLogHandler(address='/dev/log')
+        syslog_handler = get_syslog_handler()
         syslog_handler.setFormatter(self.formatter)
         syslog_handler.name = "syslogHandler"
         return syslog_handler

--- a/scripts/common/write_log.sh
+++ b/scripts/common/write_log.sh
@@ -83,7 +83,7 @@ write_log() {
       tag="Fledge ${1}[${BASHPID}] ${severity}: ${2}"
       if [[ "${SYSLOG_UDP_ENABLED,,}" == "true" ]]; then
           # Send log to remote syslog server using logger
-          logger --server "${LOG_IP}" --port "${LOG_PORT}" "${tag} ${4}"
+          logger --server "${LOG_IP}" --port "${LOG_PORT}" -t ${tag} "${4}"
       else
           # Log locally
           logger -t "${tag}" "${4}"

--- a/scripts/common/write_log.sh
+++ b/scripts/common/write_log.sh
@@ -80,9 +80,10 @@ write_log() {
 
   # Log to syslog
   if [[ "$5" =~ ^(logonly|all)$ ]]; then
-      if [[ "${SYSLOG_UDP_ENABLED}" == "true" ]]; then
+      tag="Fledge ${1}[${BASHPID}] ${severity}: ${2}"
+      if [[ "${SYSLOG_UDP_ENABLED,,}" == "true" ]]; then
           # Send log to remote syslog server using logger
-          logger -n "${LOG_IP}" -P "${LOG_PORT}" -t "${tag}" "${4}"
+          logger --server "${LOG_IP}" --port "${LOG_PORT}" "${tag} ${4}"
       else
           # Log locally
           logger -t "${tag}" "${4}"

--- a/scripts/common/write_log.sh
+++ b/scripts/common/write_log.sh
@@ -23,7 +23,10 @@
 
 #set -x
 
-
+# Fetch environment variables for remote syslog configuration
+SYSLOG_UDP_ENABLED=${SYSLOG_UDP_ENABLED:-false} # Enable/disable remote syslog (default: false)
+LOG_IP=${LOG_IP:-"127.0.0.1"}                   # Remote syslog server IP (default: localhost)
+LOG_PORT=${LOG_PORT:-5140}                       # Remote syslog server port (default: 514)
 ## The Loggging Handler
 #
 # Paramaters: $1 - Module
@@ -77,8 +80,13 @@ write_log() {
 
   # Log to syslog
   if [[ "$5" =~ ^(logonly|all)$ ]]; then
-      tag="Fledge ${1}[${BASHPID}] ${severity}: ${2}"
-      logger -t "${tag}" "${4}"
+      if [[ "${SYSLOG_UDP_ENABLED}" == "true" ]]; then
+          # Send log to remote syslog server using logger
+          logger -n "${LOG_IP}" -P "${LOG_PORT}" -t "${tag}" "${4}"
+      else
+          # Log locally
+          logger -t "${tag}" "${4}"
+      fi
   fi
 
   # Log to Stdout


### PR DESCRIPTION
### **Remote UDP Logging:**

1. **Added support for logging messages to a remote syslog via UDP protocol.**
The logging system initializes a UDP socket (m_UdpSockFD) and sends log messages to a remote server defined by environment variables.

1. **Environment Variables:**
Introduced the following environment variables for dynamic configuration:
**SYSLOG_UDP_ENABLED:** Enables or disables UDP logging. If set to true, logs are sent to the configured UDP sink.
**LOG_IP:** Specifies the IP address of the remote logging server. Defaults to 127.0.0.1 if not set.
**LOG_PORT:** Specifies the port number for the remote logging server. Defaults to 5140 if not set.
The environment variables allow customization without requiring code changes, making the system adaptable to different deployment environments
