### PR TITLE
FOGL-9792: FledgeAsset Type mismatch error when Static Data properties change

### DIFF
--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -5313,13 +5313,11 @@ bool OMF::sendFledgeAssetType()
 	catch (const Unauthorized &e)
 	{
 		Logger::getLogger()->error(MESSAGE_UNAUTHORIZED);
-		
 	}
 	catch (const Conflict& e)
 	{
-		handleRESTException(e, "The OMF endpoint reported a Conflict when sending FledgeAsset Type");
-		Logger::getLogger()->warn(MESSAGE_PI_UNSTABLE, 409);
-		m_PIstable = false;
+		Logger::getLogger()->warn("FledgeAsset Type exists with a different definition");
+		retCode = true;
 	}
 	catch (const std::exception &e)
 	{

--- a/C/plugins/north/OMF/plugin.cpp
+++ b/C/plugins/north/OMF/plugin.cpp
@@ -156,7 +156,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"displayName": "Data Source"
 		},
 		"StaticData": {
-			"description": "Static data to include in each sensor reading sent to the PI Server.",
+			"description": "Static data to include in every Container created by OMF",
 			"type": "string",
 			"default": "Location: Palo Alto, Company: Dianomic",
 			"order": "9",

--- a/docs/OMF.rst
+++ b/docs/OMF.rst
@@ -835,32 +835,44 @@ The AF Element also has three static data values named *Company*, *Domain* and *
 | |OMF_StaticData| |
 +------------------+
 
+Each Static Data item in the Fledge configuration consists of a key/value pair separated by a colon(":").
+You can specify multiple Static Data items separated by commas (",").
+Static Data keys and values are applied when a Container is created.
 Static Data values are always strings.
-Static Data values are set when a Container is created.
-OMF North cannot change the values later.
-This means that if you change the Static Data values when you edit your configuration with the Fledge GUI, your change will apply only to new Containers.
+OMF North cannot easily change the keys or add new keys after OMF North has started the first time.
+You can, however, edit the values of the Static Data keys.
 
-Static Data values are included in AF Templates which are then used by OMF to create Containers.
+Static Data values are included in AF Element Templates which are then used by OMF to create Containers.
 The design of the AF Templates depends on whether Linked Types or Complex Types are configured:
 
 Linked Types
 ~~~~~~~~~~~~
 
-OMF creates a single AF Template called *FledgeAsset*.
-Besides the essential *id*, *index* and *name* OMF attributes, the *FledgeAsset* template has attributes defined by your Static Data properties configuration.
-The first OMF North instance to start will create the *FledgeAsset* AF Template.
-Any subsequent OMF North instance that starts will not detect an error but the *FledgeAsset* template will remain unchanged.
-The best practice is to decide early which Static Data properties should be added to all OMF North configurations.
-Each OMF North configuration can have its own values for these Static Data properties.
-Each OMF North instance will assign its own Static Data values to the Containers it creates.
+OMF creates a single AF Element Template called *FledgeAsset*.
+Besides the essential *__id*, *__indexProperty* and *__nameProperty* OMF attributes, the *FledgeAsset* template will have attributes defined by your Static Data configuration.
+The first OMF North instance to start will create the *FledgeAsset* AF Element Template.
+Any subsequent OMF North instance that starts will not change the *FledgeAsset* template.
+The best practice is to decide early which Static Data keys should be added to all OMF North configurations.
+Each OMF North instance can have its own values for these Static Data items which will be applied to any Container it creates.
+Updated Static Data values in your configuration will be applied to both new and existing Containers.
 
 Complex Types
 ~~~~~~~~~~~~~
 
-OMF creates multiple AF Templates, one per asset.
-These AF Templates own the Static Data properties and have names that end in "...\ *assetname*\ _typename_sensor."
+OMF creates multiple AF Element Templates, one per asset.
+These AF Element Templates own the Static Data items and have names that end in "...\ *assetname*\ _typename_sensor."
 Each template is used to create a Container for one asset.
 Because of this, the risk of overlapping definitions is lower.
+Once Containers are created, editing the Static Data values in your configuration does not update any existing AF Elements.
+
+.. note::
+
+    When OMF North starts, you may see this warning in */var/log/syslog*::
+
+        WARNING: FledgeAsset Type exists with a different definition
+
+    This warning does not affect the normal flow of data.
+    A detailed explanation of this warning and how to address it can be found in the |OMF North Troubleshooting| guide.
 
 .. _Linked_Types:
 

--- a/docs/troubleshooting_pi-server_integration.rst
+++ b/docs/troubleshooting_pi-server_integration.rst
@@ -27,6 +27,15 @@ You should be running PI Web API 2019 SP1 (1.13.0.6518) or later.
 - `Log files`_
 - `How to confirm that PI Web API is installed and running`_
 - `Error Messages and Causes`_
+
+  - `Loss of Connection to the PI Web API Server`_
+  - `HTTP Code 409: Processing cannot continue until data archive errors are corrected`_
+  - `HTTP Code 409: The supplied container overlaps with a different existing container`_
+  - `HTTP Code 409:  One or more PI Points could not be created`_
+  - `PI License Expired or Limit Exceeded`_
+  - `HTTP Code 409: AF Element could not be created`_
+  - `WARNING: FledgeAsset Type exists with a different definition`_
+  - `Changing the Tag Name OMF Hint`_
 - `Possible Solutions to Common Problems`_
 
 Complex Types vs. Linked Types
@@ -513,6 +522,60 @@ If you have the `Tracing File`_ enabled, you may see supporting information labe
 This Suggestion is evidence that the OMF message sent by OMF North included an item that conflicted with an item in the OMF cache
 even though the item had been deleted from the AF Database manually and checked in.
 To address this, restart the PI Web API.
+
+WARNING: FledgeAsset Type exists with a different definition
+------------------------------------------------------------
+
+This warning can appear in Fledge systems that have already had one or more instances of OMF North running.
+The first OMF North instance to start will create the *FledgeAsset* AF Element Template which is used by OMF to create AF Elements that represent Containers in Linked Type configurations.
+The warning means that the OMF North Static Data parameters have changed since the *FledgeAsset* template was created.
+The flow of data to the PI System will not stop.
+However, any new AF Elements created by OMF North will have AF Attributes defined by the existing definition of *FledgeAsset*, not the Static Data parameter in your configuration.
+
+.. note::
+
+    Support for Static Data in Linked Types was introduced in Fledge 3.1.0.
+    Any instance of the *FledgeAsset* AF Element Template created before Fledge 3.1.0 will have only the minimum AF Attribute Templates: *__id*, *__indexProperty* and *__nameProperty*.
+    The presence of the even the default value of the Static Data parameter ("*Location: Palo Alto, Company: Dianomic*") will generate this warning.
+
+.. note::
+
+    The *FledgeAsset* AF Element Template is not used for Complex Types.
+    If all of your configurations use Complex Types, this warning is benign.
+
+Eliminating the Warning
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Techniques for eliminating the warning depend on your requirements for Static Data in your Containers.
+
+Clearing the Static Data
+########################
+
+If you are upgrading to Fledge 3.1.0 and don't need to add Static Data values to your OMF Containers, clear the Static Data configuration using the Fledge GUI.
+The OMF message that attempts to create the *FledgeAsset* AF Element Template will then match the existing definition of *FledgeAsset* so there will be no warning.
+You will see only the message "*Confirmed FledgeAsset Type.*"
+
+Recreating FledgeAsset to include Static Data
+#############################################
+
+If you want to use your Static Data configuration in your Containers, you can delete all AF Elements that derive from *FledgeAsset* and then the *FledgeAsset* AF Element Template itself.
+OMF North will recreate the *FledgeAsset* AF Element Template and AF Elements when readings are processed.
+Before doing any work on your AF Database, shut down any OMF North instance that is sending data to it.
+After deleting AF Elements and AF Templates, you must check in your changes.
+Restart PI Web API and then your OMF North instance.
+
+Finding AF Elements that derive from FledgeAsset
+################################################
+
+The PI System Explorer allows you to search for all AF Elements that derive from the *FledgeAsset* AF Template:
+
+- In the *Elements* tab, locate *Element Searches* in the upper-left pane.
+- Right-click *Element Searches* and choose *New Search*.
+- In the *Element Search* dialog, click the *Template* drop-down and select *FledgeAsset*.
+- Click *OK* to invoke the search.
+- Select all items in the list of matching AF Elements.
+- Right-click and choose *Delete…*
+- In the resulting dialog box, choose "*Delete these objects and all references to them. Check in is required to complete this action.*"
 
 Changing the Tag Name OMF Hint
 ------------------------------


### PR DESCRIPTION
Support for Static Data values for Linked Types was added in [FOGL-9056](https://scaledb.atlassian.net/browse/[FOGL-9056](https://scaledb.atlassian.net/browse/FOGL-9056)). Static Data values become AF Attribute Templates in the AF Template _FledgeAsset_. Upgrading existing Fledge systems failed because OMF North would attempt to define _FledgeAsset_ with Static Data values that did not exist before. This resulted in OMF HTTP 409 (Conflict) which would stop all processing until "unstable" PI was corrected. This has been fixed. If creation of _FledgeAsset_ results in HTTP 409, OMF North will write the message "_FledgeAsset Type exists with a different definition_" and continue processing normally.

Sending Static Data in later OMF Data messages is benign. Static Data properties that do not exist in the AF Elements derived from _FledgeAsset_ are ignored.