### PR TITLE
FOGL-9520 smooth termination or shutdown of the microservice across all compatible Python versions that we have supported to date

### DIFF
--- a/python/fledge/services/core/server.py
+++ b/python/fledge/services/core/server.py
@@ -1291,7 +1291,7 @@ class Server:
                 return
 
             tasks = [cls._request_microservice_shutdown(svc) for svc in services_to_stop]
-            await asyncio.wait(tasks)
+            await asyncio.gather(*tasks)
         except service_registry_exceptions.DoesNotExist:
             pass
         except Exception as ex:


### PR DESCRIPTION
Used `gather` tasks for clean, parallel async execution when you want all tasks to finish and don’t need complex control.