### PR TITLE
FOGL-9845: OMF North reports AF Attribute name conflict when creating OMF Links

### DIFF
--- a/C/plugins/north/OMF/omf.cpp
+++ b/C/plugins/north/OMF/omf.cpp
@@ -183,6 +183,17 @@ static void parseLinkData(const char *json, std::vector<std::pair<std::string, s
 }
 
 /**
+ * Parse "index" and "containerid" values from JSON containing link "source" and "target"
+ *
+ * @param json    JSON text as std::string
+ * @param links   Vector of source-target name pairs
+ */
+static void parseLinkData(const std::string &json, std::vector<std::pair<std::string, std::string>> &links)
+{
+	parseLinkData(json.c_str(), links);
+}
+
+/**
  * Parse "Name" from JSON containing a Data message with element definitions
  *
  * @param json	JSON text

--- a/docs/troubleshooting_pi-server_integration.rst
+++ b/docs/troubleshooting_pi-server_integration.rst
@@ -34,6 +34,7 @@ You should be running PI Web API 2019 SP1 (1.13.0.6518) or later.
   - `HTTP Code 409:  One or more PI Points could not be created`_
   - `PI License Expired or Limit Exceeded`_
   - `HTTP Code 409: AF Element could not be created`_
+  - `HTTP Code 409: An existing LINK includes an AF Attribute that overlaps`_
   - `HTTP Code 413: Payload Too Large`_
   - `WARNING: FledgeAsset Type exists with a different definition`_
   - `Changing the Tag Name OMF Hint`_
@@ -53,6 +54,8 @@ In the initial release of the OMF North plugin, all Types were Complex Types.
 This means the Type would include data streams that represent all Datapoints in the Reading.
 If a Reading arrived later with the same asset name but with additional Datapoints, OMF would be forced to create a new Type and new Containers.
 Previously defined Containers would be abandoned.
+
+.. _Linked Types Description:
 
 Linked Types
 ------------
@@ -523,6 +526,46 @@ If you have the `Tracing File`_ enabled, you may see supporting information labe
 This Suggestion is evidence that the OMF message sent by OMF North included an item that conflicted with an item in the OMF cache
 even though the item had been deleted from the AF Database manually and checked in.
 To address this, restart the PI Web API.
+
+HTTP Code 409: An existing LINK includes an AF Attribute that overlaps
+----------------------------------------------------------------------
+
+The full text of this error message is much longer.
+The context is:
+
+.. code-block:: bash
+
+    ERROR: HTTP 409: Conflict sending Data: 1 message
+    ERROR: Message 0 HTTP 409: Error, An existing LINK includes an AF Attribute that overlaps with the name of an AF Attribute that would be created for the specified LINK.,
+    ERROR: Error 409 creating Link random to random.randomwalk
+    ERROR: Error 409 creating Link random to random.temperature
+    ERROR: Error 409 creating Link random to random.units
+    ERROR: Error 409 creating Link random to random.location
+    WARNING: HTTP Code 409: Processing cannot continue until data archive errors are corrected
+
+A complete description of a OMF LINKs can be found in the :ref:`Linked Types<Linked Types Description>` section.
+In this case, an OMF message is attempting to create a new AF Attribute in an AF Element that already has an AF Attribute with the same name.
+OMF North logs all links that were attempted when this OMF Data message failed.
+
+Unfortunately, OMF does not return the name of the conflicting AF Attribute.
+You should compare the list of attempted links against the existing AF Attributes of the AF Element.
+The AF Element name is the first item in each *Error 409 creating Link* message.
+The AF Attribute name is the text after the dot (".") in the second item of the message.
+
+The solution to this problem depends on the situation.
+It is possible that an AF user manually added an AF Attribute to the AF Element.
+If this is the case, remove or rename the conflicting AF Attribute.
+
+Take note of the *Static Data* parameter in the OMF North configuration.
+Items in *Static Data* are added to every AF Element that represents an OMF Container.
+In this example, *Static Data* was left at its default which is:
+
+.. code-block:: bash
+
+    Location: Palo Alto, Company: Dianomic
+
+This creates AF Attributes *Location* and *Company* in every AF Element.
+Since comparisons in AF are case-insensitive, the name of the static AF Attribute *Location* conflicted with the *location* datapoint in the OMF Data message.
 
 HTTP Code 413: Payload Too Large
 --------------------------------


### PR DESCRIPTION
OMF error message is "*An existing LINK includes an AF Attribute that overlaps with the name of an AF Attribute that would be created for the specified LINK*." This means that an OMF Data message for Linked Types is attempting to create an AF Attribute with the same name as an existing attribute.

OMF does not report the name of the conflicting AF Attribute. To help with troubleshooting, OMF North now logs the links that were attempted if the OMF Data message fails. The [Troubleshooting the PI Server Integration](https://github.com/fledge-iot/fledge/blob/develop/docs/troubleshooting_pi-server_integration.rst) page has been updated with a detailed explanation.

OMF North does not log the Links created if there are no errors because the OMF Data messages are often large. It is expensive to parse the Data JSON document for Links when they are only created once per Asset/Datapoint.

This Pull Request also fixes two minor memory leaks in two *catch* blocks for failed OMF Data messages. The leaks would only occur upon failure.