### PR TITLE
FOGL-9981 Fledge restart and shutdown fixes

### DIFF
--- a/python/fledge/services/core/server.py
+++ b/python/fledge/services/core/server.py
@@ -1252,7 +1252,7 @@ class Server:
             try:
                 await asyncio.wait_for(cls.service_server.wait_closed(), timeout=5.0)
             except asyncio.TimeoutError:
-                _logger.warning("REST server wait_closed() timeout - continuing with shutdown")
+                _logger.debug("REST server wait_closed() timeout - continuing with shutdown")
         else:
             await cls.service_server.wait_closed()
 
@@ -1707,16 +1707,16 @@ class Server:
         :Example:
             curl -X POST http://localhost:<core mgt port>/fledge/service/shutdown
         """
-        async def _shutdown_event_loop(loop):
+        async def _stop_event_loop(loop):
             await async_sleep(2.0)
             _logger.info("Stopping the Fledge Core event loop. Good Bye!")
             loop.stop()
 
         try:
             await cls._stop()
-            await _shutdown_event_loop(request.loop)
+            await _stop_event_loop(request.loop)
         except asyncio.TimeoutError as err:
-            await _shutdown_event_loop(request.loop)
+            await _stop_event_loop(request.loop)
         except TimeoutError as err:
             raise web.HTTPInternalServerError(reason=str(err))
         except Exception as ex:
@@ -1729,7 +1729,6 @@ class Server:
         """ Restart the core microservice and its components """
 
         async def _restart_process():
-            """ Handle the logic for restarting the current process """
             loop = request.loop
             # allow some time
             await async_sleep(2.0)

--- a/python/fledge/services/core/server.py
+++ b/python/fledge/services/core/server.py
@@ -1245,7 +1245,17 @@ class Server:
         # Delete all user tokens
         await User.Objects.delete_all_user_tokens()
         cls.service_server.close()
-        await cls.service_server.wait_closed()
+
+        # Python 3.12 + aiohttp 3.10.11 specific fix: wait_closed() can hang indefinitely
+        # if there are active connections, so we add a timeout
+        if sys.version_info >= (3, 12):
+            try:
+                await asyncio.wait_for(cls.service_server.wait_closed(), timeout=5.0)
+            except asyncio.TimeoutError:
+                _logger.warning("REST server wait_closed() timeout - continuing with shutdown")
+        else:
+            await cls.service_server.wait_closed()
+
         await cls.service_app.shutdown()
         await cls.service_server_handler.shutdown(60.0)
         await cls.service_app.cleanup()
@@ -1715,11 +1725,13 @@ class Server:
     @classmethod
     async def restart(cls, request):
         """ Restart the core microservice and its components """
-        try:
-            await cls._stop()
+
+        async def _restart_process():
+            """ Handle the logic for restarting the current process """
             loop = request.loop
             # allow some time
             await async_sleep(2.0)
+
             _logger.info("Stopping the Fledge Core event loop. Good Bye!")
             loop.stop()
 
@@ -1728,10 +1740,13 @@ class Server:
                 sys.argv.append('')
 
             python3 = sys.executable
-            os.execl(python3, python3, *sys.argv)
+            os.execl(python3, python3, *sys.argv)  # Replaces current process, no return
 
-            return web.json_response({'message': 'Fledge stopped successfully. '
-                                                 'Wait for few seconds for restart.'})
+        try:
+            await cls._stop()
+            await _restart_process()
+        except asyncio.TimeoutError as err:
+            await _restart_process()
         except TimeoutError as err:
             raise web.HTTPInternalServerError(reason=str(err))
         except Exception as ex:


### PR DESCRIPTION
Problem with Python 3.12 and aiohttp 3.10.11 specific resolution: wait_closed() hang indefinitely or block for minutes when there are active connections.

Therefore, we addressed the asyncio timeout exception to ensure a forced restart in such scenarios. As we approach the release, I have refrained from modifying the aiohttp specific release version, as this stable version encompasses our functionality and includes the necessary test dependencies.