### PR TITLE
FOGL-10043 aiohttp expects the reason parameter to be a string, not an exception object

### DIFF
--- a/python/fledge/common/web/middleware.py
+++ b/python/fledge/common/web/middleware.py
@@ -103,9 +103,9 @@ async def auth_middleware(app, handler):
                 await validate_requests(request)
             except User.SessionTimeout as e:
                 await User.Objects.delete_token(token)
-                raise web.HTTPUnauthorized(reason=e)
+                raise web.HTTPUnauthorized(reason=str(e))
             except (jwt.DecodeError, jwt.ExpiredSignatureError, User.InvalidToken, User.TokenExpired) as e:
-                raise web.HTTPUnauthorized(reason=e)
+                raise web.HTTPUnauthorized(reason=str(e))
             except jwt.exceptions.InvalidAlgorithmError:
                 raise web.HTTPUnauthorized(reason="The token has expired, login again.")
         else:


### PR DESCRIPTION
The fix ensures that all authentication errors now return proper HTTP 401 responses with clear error messages instead of causing internal 500 errors.

On-demand packages are available at `fixes/FOGL-10043`