### PR TITLE
FOGL-9930 Added endpoint for plugin configuration validation (Phase 1 as outlined in the documentation)

### DIFF
--- a/docs/plugin_developers_guide/10_testing.rst
+++ b/docs/plugin_developers_guide/10_testing.rst
@@ -466,3 +466,429 @@ You can also check your default configuration. Although in Python this is usuall
    $ python3 -c 'from fledge.plugins.south.sinusoid.sinusoid import plugin_info; print(plugin_info()["config"])'
    {'plugin': {'description': 'Sinusoid Poll Plugin which implements sine wave with data points', 'type': 'string', 'default': 'sinusoid', 'readonly': 'true'}, 'assetName': {'description': 'Name of Asset', 'type': 'string', 'default': 'sinusoid', 'displayName': 'Asset name', 'mandatory': 'true'}}
 
+Plugin Configuration Validation
+-------------------------------
+
+The plugin configuration validation feature provides automated connectivity testing for plugin configurations. This feature validates that network-related configuration parameters are correct and reachable before deploying or activating a plugin, helping to identify configuration issues early in the plugin testing process.
+
+This is the first iteration of the configuration validation feature, focusing on network connectivity validation for common plugin patterns.
+
+Overview
+~~~~~~~~
+
+The validation system performs two primary types of tests:
+
+**Host Reachability Test**
+   Tests whether the configured host or server is reachable over the network using socket-based connectivity testing.
+
+**Listening Test**
+   Tests whether a service is actively listening on the specified host and port combination.
+
+The validation automatically detects relevant configuration fields and applies appropriate tests based on the field types and naming conventions.
+
+Supported Configuration Keys
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The validation system recognizes the following configuration field patterns (case insensitive):
+
+**Address Fields**
+   - ``address``
+   - ``ip``
+   - ``server``
+   - ``host``
+   - ``hostname``
+
+**Port Fields**
+   - ``port``
+   - ``brokerport``
+
+**URL Fields**
+   - ``url``
+
+**Broker Fields**
+   - ``broker``
+   - ``brokerhost``
+
+Configuration Value Priority
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When both ``default`` and ``value`` keys are present in a configuration field, the validation system uses the following priority:
+
+1. **``value``** - Takes precedence when present
+2. **``default``** - Used when ``value`` is not present
+3. **Error** - Raised if neither ``value`` nor ``default`` is present
+
+Common Configuration Patterns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Host and Port Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Standard server configuration with separate host and port fields:
+
+.. code-block:: json
+
+   {
+       "plugin": {
+           "description": "Modbus TCP Plugin",
+           "type": "string",
+           "default": "modbus",
+           "readonly": "true"
+       },
+       "address": {
+           "description": "Address of Modbus TCP server",
+           "type": "string",
+           "default": "192.168.1.100",
+           "order": "1",
+           "displayName": "Server Address"
+       },
+       "port": {
+           "description": "Port of Modbus TCP server",
+           "type": "integer",
+           "default": "502",
+           "order": "2",
+           "displayName": "Port"
+       }
+   }
+
+**Validation Behavior:**
+   - Tests host reachability to ``192.168.1.100``
+   - Tests service listening on ``192.168.1.100:502``
+
+Address-Only Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Industrial protocol configuration with address field only:
+
+.. code-block:: json
+
+   {
+       "plugin": {
+           "description": "S7 PLC Plugin",
+           "type": "string",
+           "default": "s7",
+           "readonly": "true"
+       },
+       "IP": {
+           "description": "PLC IP Address",
+           "type": "string",
+           "default": "192.168.1.151",
+           "order": "1",
+           "displayName": "PLC IP Address"
+       }
+   }
+
+**Validation Behavior:**
+   - Tests host reachability to ``192.168.1.151``
+   - Tests service listening on common industrial ports: ``102`` (S7), ``44818`` (EtherNet/IP), ``502`` (Modbus), ``80`` (HTTP), ``443`` (HTTPS)
+
+IP Address Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Similar to address-only, but specifically for IP fields:
+
+.. code-block:: json
+
+   {
+       "plugin": {
+           "description": "EtherNet/IP Plugin",
+           "type": "string",
+           "default": "etherip",
+           "readonly": "true"
+       },
+       "address": {
+           "description": "Address of PLC",
+           "type": "string",
+           "default": "127.0.0.1",
+           "value": "192.168.1.199",
+           "order": "1",
+           "displayName": "PLC IP Address"
+       }
+   }
+
+**Validation Behavior:**
+   - Uses ``value`` (``192.168.1.199``) over ``default``
+   - Tests host reachability to ``192.168.1.199``
+   - Tests service listening on default industrial ports
+
+Broker Configuration
+^^^^^^^^^^^^^^^^^^^^
+
+MQTT broker configuration supports multiple patterns:
+
+**Pattern 1: Broker URL**
+
+.. code-block:: json
+
+   {
+       "plugin": {
+           "description": "MQTT South Plugin",
+           "type": "string",
+           "default": "mqtt",
+           "readonly": "true"
+       },
+       "broker": {
+           "description": "MQTT Broker URL",
+           "type": "string",
+           "default": "tcp://mqtt.local:1883",
+           "order": "1",
+           "displayName": "MQTT Broker"
+       }
+   }
+
+**Validation Behavior:**
+   - Parses URL to extract host (``mqtt.local``) and port (``1883``)
+   - Tests host reachability to ``mqtt.local``
+   - Tests service listening on ``mqtt.local:1883``
+
+**Pattern 2: Separate Host and Port**
+
+.. code-block:: json
+
+   {
+       "brokerHost": {
+           "description": "Hostname or IP address of the broker",
+           "type": "string",
+           "default": "localhost",
+           "order": "1",
+           "displayName": "MQTT Broker Host"
+       },
+       "brokerPort": {
+           "description": "The network port of the broker",
+           "type": "integer",
+           "default": "1883",
+           "order": "2",
+           "displayName": "MQTT Broker Port"
+       }
+   }
+
+**Validation Behavior:**
+   - Tests host reachability to ``localhost``
+   - Tests service listening on ``localhost:1883``
+
+**Pattern 3: Broker Hostname Only**
+
+.. code-block:: json
+
+   {
+       "broker": {
+           "description": "The address of the MQTT broker",
+           "type": "string",
+           "default": "localhost",
+           "order": "1",
+           "displayName": "MQTT Broker"
+       }
+   }
+
+**Validation Behavior:**
+   - Tests host reachability to ``localhost``
+   - Tests service listening on default MQTT ports: ``1883``, ``8883``
+
+URL Configuration
+^^^^^^^^^^^^^^^^^
+
+Service URL configuration with protocol-specific handling:
+
+.. code-block:: json
+
+   {
+       "plugin": {
+           "description": "OPC UA South Plugin",
+           "type": "string",
+           "default": "opcua",
+           "readonly": "true"
+       },
+       "url": {
+           "description": "OPC UA Server URL",
+           "type": "string",
+           "default": "opc.tcp://localhost:4840/server",
+           "order": "1",
+           "displayName": "Server URL"
+       }
+   }
+
+**Validation Behavior:**
+   - Parses ``opc.tcp://`` URL format
+   - Tests host reachability to ``localhost``
+   - Tests service listening on ``localhost:4840``
+
+**Supported URL Schemes:**
+   - ``http://``, ``https://``
+   - ``opc.tcp://`` (OPC UA)
+   - ``tcp://`` (MQTT)
+   - ``mqtt://``, ``mqtts://``
+   - ``ftp://``
+
+Server and Port Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Generic server configuration pattern:
+
+.. code-block:: json
+
+   {
+       "plugin": {
+           "description": "Database North Plugin",
+           "type": "string",
+           "default": "database",
+           "readonly": "true"
+       },
+       "ServerHostname": {
+           "description": "Database server hostname",
+           "type": "string",
+           "default": "db.example.com",
+           "order": "1",
+           "displayName": "Server Hostname"
+       },
+       "ServerPort": {
+           "description": "Database server port",
+           "type": "integer",
+           "default": "5432",
+           "order": "2",
+           "displayName": "Server Port"
+       }
+   }
+
+**Validation Behavior:**
+   - Tests host reachability to ``db.example.com``
+   - Tests service listening on ``db.example.com:5432``
+
+Default Port Assignment
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When no explicit port is configured, the validation system applies default ports based on field names and common protocols:
+
+**IP Fields** (``ip``, ``IP``)
+   - ``102`` (S7 PLC)
+   - ``44818`` (EtherNet/IP)
+   - ``502`` (Modbus TCP)
+   - ``80`` (HTTP)
+   - ``443`` (HTTPS)
+
+**Address Fields** (``address``)
+   - ``502`` (Modbus TCP)
+   - ``80`` (HTTP)
+   - ``443`` (HTTPS)
+
+**Host/Server Fields** (``host``, ``hostname``, ``server``)
+   - ``80`` (HTTP)
+   - ``443`` (HTTPS)
+
+**Broker Fields** (``broker``, ``brokerhost``)
+   - ``1883`` (MQTT)
+   - ``8883`` (MQTTS)
+
+Testing Configuration Validation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**API Endpoint:** ``PUT /fledge/plugin/validate``
+
+**Request Body:** JSON configuration object
+
+**Example Test Request:**
+
+.. code-block:: bash
+
+   curl -X PUT http://localhost:8081/fledge/plugin/validate \
+        -H "Content-Type: application/json" \
+        -d '{
+            "plugin": {
+                "description": "Test Plugin",
+                "type": "string",
+                "default": "test",
+                "readonly": "true"
+            },
+            "address": {
+                "description": "Server address",
+                "type": "string",
+                "default": "192.168.1.100"
+            },
+            "port": {
+                "description": "Server port",
+                "type": "integer",
+                "default": "502"
+            }
+        }'
+
+Validation Response Format
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The validation API returns a JSON response with test results:
+
+**Success Response (HTTP 200):**
+
+.. code-block:: json
+
+   {
+       "HostReachable": {
+           "description": "Host Reachable",
+           "result": "pass",
+           "values": [
+               {"address": "192.168.1.100", "port": "502"}
+           ]
+       },
+       "Listening": {
+           "description": "Listening",
+           "result": "fail",
+           "values": [
+               {"address": "192.168.1.100", "port": "502"}
+           ],
+           "detail": {
+               "reason": "No service is listening on 192.168.1.100:502"
+           }
+       }
+   }
+
+**No Validation Required (HTTP 204):**
+
+Returned when no network-related configuration fields are detected.
+
+**Error Response (HTTP 400):**
+
+.. code-block:: json
+
+   {
+       "error": "Configuration item 'address' must have either 'value' or 'default' key"
+   }
+
+Configuration Testing Best Practices
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**During Plugin Development**
+   - Test configurations with the validation API before finalizing plugin design
+   - Use realistic default values that can be validated
+   - Ensure network-related fields follow recognized naming patterns
+
+**Configuration Design**
+   - Use consistent field naming conventions (``address``, ``port``, ``host``)
+   - Provide meaningful default values for testing
+   - Include both ``default`` and ``value`` support for flexibility
+
+**Field Naming**
+   - Use recognized field names for automatic detection
+   - Follow consistent naming patterns across plugins
+   - Consider using descriptive field names that match the validation patterns
+
+**Error Handling**
+   - Always provide either ``default`` or ``value`` keys for network-related fields
+   - Use appropriate data types (``string`` for hostnames, ``integer`` for ports)
+   - Provide clear descriptions for configuration fields
+
+**Integration Testing**
+   - Validate configurations during plugin development
+   - Use validation results to verify network connectivity before deployment
+   - Consider validation feedback when designing plugin configurations
+
+Validation Limitations
+~~~~~~~~~~~~~~~~~~~~~~
+
+This is the first iteration of the plugin configuration validation feature. Current limitations include:
+
+- Network connectivity testing only (no protocol-specific validation)
+- Limited to common network configuration patterns
+- No support for complex authentication scenarios
+- Basic URL scheme support
+- No certificate or encryption validation
+
+Future enhancements may include additional validation types, protocol-specific testing, and expanded configuration pattern support.
+

--- a/python/fledge/common/web/middleware.py
+++ b/python/fledge/common/web/middleware.py
@@ -217,7 +217,7 @@ async def validate_requests(request):
     elif int(request.user["role_id"]) == 3:
         if request.method != 'GET':
             supported_endpoints = ['/fledge/user', '/fledge/user/{}/password'.format(user_id), '/logout',
-                                   '/fledge/extension/bucket/match']
+                                   '/fledge/extension/bucket/match', '/fledge/plugin/validate']
             if not str(request.rel_url).endswith(tuple(supported_endpoints)):
                 raise web.HTTPForbidden
         else:

--- a/python/fledge/services/core/api/plugins/config_validator.py
+++ b/python/fledge/services/core/api/plugins/config_validator.py
@@ -14,7 +14,7 @@ from aiohttp import web
 from fledge.common.logger import FLCoreLogger
 
 __author__ = "Ashish Jabble"
-__copyright__ = "Copyright (c) 2024 Dianomic Systems Inc."
+__copyright__ = "Copyright (c) 2025 Dianomic Systems Inc."
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 

--- a/python/fledge/services/core/api/plugins/config_validator.py
+++ b/python/fledge/services/core/api/plugins/config_validator.py
@@ -1,0 +1,603 @@
+# -*- coding: utf-8 -*-
+
+# FLEDGE_BEGIN
+# See: http://fledge-iot.readthedocs.io/
+# FLEDGE_END
+
+import asyncio
+import json
+import socket
+import re
+from urllib.parse import urlparse
+from aiohttp import web
+
+from fledge.common.logger import FLCoreLogger
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2024 Dianomic Systems Inc."
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+_logger = FLCoreLogger().get_logger(__name__)
+
+_help = """
+    ------------------------------------------------------------------------------
+    | PUT                 | /fledge/plugin/validate                              |
+    ------------------------------------------------------------------------------
+"""
+
+class ConfigurationValidator:
+    """
+    Configuration Validation System
+    
+    Provides connectivity validation for plugin configurations
+    through ICMP ping tests and TCP connection attempts.
+    """
+    
+    # Configuration item names to check (case insensitive)
+    ADDRESS_FIELDS = ['address', 'ip', 'server', 'host', 'hostname']
+    URL_FIELDS = ['url']
+    BROKER_FIELDS = ['broker']
+    PORT_FIELDS = ['port']
+    
+    # Standard protocol ports
+    STANDARD_PORTS = {
+        'http': 80,
+        'https': 443,
+        'ftp': 21,
+        'ssh': 22,
+        'telnet': 23,
+        'smtp': 25,
+        'dns': 53,
+        'dhcp': 67,
+        'tftp': 69,
+        'pop3': 110,
+        'imap': 143,
+        'snmp': 161,
+        'ldap': 389,
+        'ldaps': 636,
+        'mqtt': 1883,
+        'mqtts': 8883,
+        'opcua': 4840,
+        'modbus': 502,
+        'bacnet': 47808,
+        'coap': 5683,
+        'coaps': 5684
+    }
+    
+    def __init__(self):
+        self.results = {}
+    
+    def extract_configuration_items(self, config_data):
+        """
+        Extract relevant configuration items for validation.
+        
+        Args:
+            config_data (dict): Configuration category contents
+            
+        Returns:
+            dict: Categorized configuration items
+            
+        Raises:
+            ValueError: If configuration item has neither 'value' nor 'default' key
+        """
+        extracted = {
+            'addresses': [],
+            'urls': [],
+            'brokers': [],
+            'ports': []
+        }
+        
+        if not isinstance(config_data, dict):
+            return extracted
+            
+        for key, value in config_data.items():
+            if not isinstance(value, dict):
+                continue
+            
+            # Check for value first, then default, then error
+            config_value = None
+            if 'value' in value:
+                config_value = str(value['value']).strip()
+            elif 'default' in value:
+                config_value = str(value['default']).strip()
+            else:
+                raise ValueError(f"Configuration item '{key}' must have either 'value' or 'default' key")
+            
+            # Skip empty or zero values
+            if not config_value or config_value == '0':
+                continue
+                
+            key_lower = key.lower()
+            field_type = value.get('type', 'string').lower()
+            
+            # Check for port fields first (more specific)
+            if any(field in key_lower for field in self.PORT_FIELDS):
+                try:
+                    port_val = int(config_value)
+                    if port_val > 0:
+                        extracted['ports'].append({
+                            'name': key,
+                            'value': port_val,
+                            'type': value.get('type', 'integer')
+                        })
+                except ValueError:
+                    pass
+            
+            # Check for URL fields
+            elif any(field in key_lower for field in self.URL_FIELDS):
+                extracted['urls'].append({
+                    'name': key,
+                    'value': config_value,
+                    'type': value.get('type', 'string')
+                })
+            
+            # Check for broker fields
+            elif any(field in key_lower for field in self.BROKER_FIELDS):
+                extracted['brokers'].append({
+                    'name': key,
+                    'value': config_value,
+                    'type': value.get('type', 'string')
+                })
+            
+            # Check for address fields (less specific, checked last)
+            # Exclude certain types that are not network addresses
+            elif (any(field in key_lower for field in self.ADDRESS_FIELDS) and 
+                  field_type not in ['enumeration', 'password', 'boolean']):
+                extracted['addresses'].append({
+                    'name': key,
+                    'value': config_value,
+                    'type': value.get('type', 'string')
+                })
+                    
+        return extracted
+    
+    def parse_url(self, url_string):
+        """
+        Parse URL to extract hostname and port.
+        
+        Args:
+            url_string (str): URL to parse
+            
+        Returns:
+            tuple: (hostname, port, protocol) or (None, None, None) if invalid
+        """
+        try:
+            # Handle special protocols like opc.tcp
+            if url_string.startswith('opc.tcp://'):
+                url_string = url_string.replace('opc.tcp://', 'opcua://')
+            
+            parsed = urlparse(url_string)
+            
+            if not parsed.hostname:
+                return None, None, None
+                
+            hostname = parsed.hostname
+            port = parsed.port
+            protocol = parsed.scheme.lower()
+            
+            # Use standard port if not specified
+            if port is None and protocol in self.STANDARD_PORTS:
+                port = self.STANDARD_PORTS[protocol]
+                
+            return hostname, port, protocol
+            
+        except Exception as e:
+            _logger.debug(f"URL parsing error for '{url_string}': {e}")
+            return None, None, None
+    
+    def is_url(self, value):
+        """
+        Check if a value is a valid URL.
+        
+        Args:
+            value (str): Value to check
+            
+        Returns:
+            bool: True if value appears to be a URL
+        """
+        url_pattern = re.compile(
+            r'^(https?|ftp|mqtt|mqtts|opcua|opc\.tcp|coap|coaps)://'
+            r'[\w\-\.]+(:\d+)?(/.*)?$',
+            re.IGNORECASE
+        )
+        return bool(url_pattern.match(value))
+    
+    async def ping_host(self, hostname):
+        """
+        Perform host reachability test using socket connection.
+        
+        This method uses socket-based connectivity testing instead of ICMP ping
+        to work in containerized environments where ping may not be available.
+        
+        For Docker hostnames, this test simply validates DNS resolution since
+        Docker internal hosts may only have specific services running.
+        
+        Args:
+            hostname (str): Hostname or IP address to test
+            
+        Returns:
+            tuple: (success, reason)
+        """
+        try:
+            # First try to resolve the hostname
+            _logger.debug(f"Attempting to resolve hostname: {hostname}")
+            
+            # Use getaddrinfo to resolve hostname and test connectivity
+            import socket
+            try:
+                # Resolve hostname to IP addresses
+                addr_info = await asyncio.get_event_loop().run_in_executor(
+                    None, socket.getaddrinfo, hostname, None
+                )
+                
+                if not addr_info:
+                    return False, "Hostname could not be resolved"
+                
+                _logger.debug(f"Resolved {hostname} to {len(addr_info)} addresses")
+                
+                # Special handling for Docker internal hostnames
+                if hostname in ['host.docker.internal', 'gateway.docker.internal'] or hostname.endswith('.docker.internal'):
+                    _logger.debug(f"Docker hostname detected: {hostname}")
+                    return True, f"Docker hostname '{hostname}' is resolvable and assumed reachable"
+                
+                # Try to connect to each resolved address on a common port
+                # We'll try port 80 (HTTP) as it's commonly open and fast to test
+                for family, socktype, proto, canonname, sockaddr in addr_info:
+                    if family in (socket.AF_INET, socket.AF_INET6):
+                        try:
+                            # Extract IP address from sockaddr
+                            ip_addr = sockaddr[0]
+                            
+                            # Test connectivity using a socket connection to port 80
+                            # This is faster and more reliable than ping in containers
+                            test_port = 80  # HTTP port - commonly accessible
+                            
+                            _logger.debug(f"Testing connectivity to {ip_addr}:{test_port}")
+                            
+                            # Create socket connection with short timeout
+                            sock = socket.socket(family, socket.SOCK_STREAM)
+                            sock.settimeout(3)  # 3 second timeout
+                            
+                            try:
+                                result = await asyncio.get_event_loop().run_in_executor(
+                                    None, sock.connect, (ip_addr, test_port)
+                                )
+                                sock.close()
+                                _logger.debug(f"Successfully connected to {ip_addr}:{test_port}")
+                                return True, f"Host '{hostname}' is reachable"
+                                
+                            except (socket.timeout, OSError) as conn_err:
+                                sock.close()
+                                _logger.debug(f"Connection to {ip_addr}:{test_port} failed: {conn_err}")
+                                
+                                # Try a few more common ports to increase success rate
+                                for alt_port in [443, 22, 53]:  # HTTPS, SSH, DNS
+                                    try:
+                                        sock = socket.socket(family, socket.SOCK_STREAM)
+                                        sock.settimeout(2)  # Shorter timeout for alt ports
+                                        
+                                        await asyncio.get_event_loop().run_in_executor(
+                                            None, sock.connect, (ip_addr, alt_port)
+                                        )
+                                        sock.close()
+                                        _logger.debug(f"Successfully connected to {ip_addr}:{alt_port}")
+                                        return True, f"Host '{hostname}' is reachable"
+                                        
+                                    except (socket.timeout, OSError):
+                                        sock.close()
+                                        continue
+                                
+                                # If we get here, the host might be up but not responding on tested ports
+                                # This is still considered "reachable" from a network perspective
+                                continue
+                        
+                        except Exception as e:
+                            _logger.debug(f"Error testing {ip_addr}: {e}")
+                            continue
+                
+                # If we tried all addresses and none worked, the host is likely unreachable
+                return False, f"Host '{hostname}' appears to be unreachable - no response on common ports (80, 443, 22, 53)"
+                
+            except socket.gaierror as e:
+                error_msg = str(e).lower()
+                _logger.error(f"DNS resolution failed for {hostname}: {e}")
+                
+                if 'name or service not known' in error_msg or 'nodename nor servname provided' in error_msg:
+                    return False, f"Cannot resolve hostname '{hostname}' - please check the hostname is correct"
+                elif 'temporary failure' in error_msg:
+                    return False, f"Temporary DNS failure for '{hostname}' - please try again later"
+                else:
+                    return False, f"DNS lookup failed for '{hostname}'"
+                    
+        except asyncio.TimeoutError:
+            _logger.warning(f"Host reachability test timed out for {hostname}")
+            return False, f"Connection test to '{hostname}' timed out - host may be unreachable"
+        except Exception as e:
+            _logger.error(f"Unexpected error during host reachability test for {hostname}: {e}")
+            return False, f"Cannot test reachability of '{hostname}' - network error occurred"
+    
+    async def check_port_listening(self, hostname, port):
+        """
+        Check if a service is listening on the specified host and port.
+        
+        Args:
+            hostname (str): Hostname or IP address
+            port (int): Port number
+            
+        Returns:
+            tuple: (success, reason)
+        """
+        try:
+            # Attempt TCP connection
+            _logger.debug(f"Testing connection to {hostname}:{port}")
+            future = asyncio.open_connection(hostname, port)
+            reader, writer = await asyncio.wait_for(future, timeout=5.0)
+            
+            # Close the connection immediately
+            writer.close()
+            await writer.wait_closed()
+            
+            _logger.debug(f"Successfully connected to {hostname}:{port}")
+            return True, f"Service is listening on port {port}"
+        except asyncio.TimeoutError:
+            _logger.warning(f"Connection timeout to {hostname}:{port}")
+            return False, f"Connection to {hostname}:{port} timed out after 5 seconds"
+        except ConnectionRefusedError:
+            _logger.error(f"Connection refused by {hostname}:{port}")
+            return False, f"No service is listening on {hostname}:{port}"
+        except socket.gaierror as e:
+            error_msg = str(e).lower()
+            _logger.error(f"DNS resolution failed for {hostname}: {e}")
+            
+            if 'name or service not known' in error_msg or 'nodename nor servname provided' in error_msg:
+                return False, f"Cannot resolve hostname '{hostname}' - please check the hostname is correct"
+            elif 'temporary failure' in error_msg:
+                return False, f"Temporary DNS failure for '{hostname}' - please try again later"
+            else:
+                return False, f"DNS lookup failed for '{hostname}'"
+        except OSError as e:
+            error_code = getattr(e, 'errno', None)
+            error_msg = str(e).lower()
+            _logger.error(f"Network error connecting to {hostname}:{port}: {e}")
+            
+            # Handle specific error codes for better user messages
+            if error_code == 111 or 'connection refused' in error_msg:
+                return False, f"No service is listening on {hostname}:{port}"
+            elif error_code == 113 or 'no route to host' in error_msg:
+                return False, f"Cannot reach host '{hostname}' - check network connectivity"
+            elif error_code == 110 or 'connection timed out' in error_msg:
+                return False, f"Connection to {hostname}:{port} timed out - host may be unreachable"
+            elif 'network is unreachable' in error_msg:
+                return False, f"Network unreachable to '{hostname}' - check network configuration"
+            elif 'host is unreachable' in error_msg:
+                return False, f"Host '{hostname}' is unreachable - check if host is online"
+            elif 'multiple exceptions' in error_msg:
+                # Handle IPv6/IPv4 dual stack connection failures
+                return False, f"Cannot connect to {hostname}:{port} - no service available"
+            else:
+                return False, f"Network error connecting to {hostname}:{port}"
+        except Exception as e:
+            _logger.error(f"Unexpected error testing {hostname}:{port}: {e}")
+            return False, f"Connection test failed for {hostname}:{port}"
+    
+    async def test_host_reachable(self, config_items):
+        """
+        Test host reachability using ICMP ping.
+        
+        Args:
+            config_items (dict): Extracted configuration items
+            
+        Returns:
+            dict: Test results
+        """
+        hosts_to_test = set()
+        test_values = []
+        
+        # Process direct address fields
+        for item in config_items['addresses']:
+            hosts_to_test.add(item['value'])
+            test_values.append({item['name']: item['value']})
+        
+        # Process URLs
+        for item in config_items['urls']:
+            hostname, _, _ = self.parse_url(item['value'])
+            if hostname:
+                hosts_to_test.add(hostname)
+                test_values.append({item['name']: item['value']})
+            else:
+                return {
+                    "description": "Host Reachable",
+                    "result": "fail",
+                    "detail": {"reason": f"Invalid URL format '{item['value']}' - please check the URL is correct"},
+                    "values": [{item['name']: item['value']}]
+                }
+        
+        # Process brokers
+        for item in config_items['brokers']:
+            if self.is_url(item['value']):
+                hostname, _, _ = self.parse_url(item['value'])
+                if hostname:
+                    hosts_to_test.add(hostname)
+                    test_values.append({item['name']: item['value']})
+                else:
+                    return {
+                        "description": "Host Reachable",
+                        "result": "fail",
+                        "detail": {"reason": f"Invalid URL format '{item['value']}' - please check the URL is correct"},
+                        "values": [{item['name']: item['value']}]
+                    }
+            else:
+                hosts_to_test.add(item['value'])
+                test_values.append({item['name']: item['value']})
+        
+        if not hosts_to_test:
+            return None  # No applicable tests
+        
+        # Test all unique hosts
+        all_passed = True
+        failure_reason = None
+        
+        for hostname in hosts_to_test:
+            success, reason = await self.ping_host(hostname)
+            if not success:
+                all_passed = False
+                failure_reason = reason
+                break
+        
+        result = {
+            "description": "Host Reachable",
+            "result": "pass" if all_passed else "fail",
+            "values": test_values
+        }
+        
+        if not all_passed:
+            result["detail"] = {"reason": failure_reason}
+            
+        return result
+    
+    async def test_listening(self, config_items):
+        """
+        Test if services are listening on specified ports.
+        
+        Args:
+            config_items (dict): Extracted configuration items
+            
+        Returns:
+            dict: Test results
+        """
+        connections_to_test = []
+        test_values = []
+        
+        # Find port and corresponding address combinations
+        if config_items['ports']:
+            port_item = config_items['ports'][0]  # Use first port found
+            port = port_item['value']
+            
+            # Look for corresponding address
+            address = None
+            for item in config_items['addresses']:
+                address = item['value']
+                # Combine address and port into single object
+                test_values.append({
+                    item['name']: item['value'],
+                    port_item['name']: str(port)
+                })
+                break
+            
+            if address:
+                connections_to_test.append((address, port))
+        
+        # Process URLs with ports
+        for item in config_items['urls']:
+            hostname, port, protocol = self.parse_url(item['value'])
+            if hostname and port:
+                connections_to_test.append((hostname, port))
+                test_values.append({item['name']: item['value']})
+        
+        # Process brokers
+        for item in config_items['brokers']:
+            if self.is_url(item['value']):
+                hostname, port, protocol = self.parse_url(item['value'])
+                if hostname and port:
+                    connections_to_test.append((hostname, port))
+                    test_values.append({item['name']: item['value']})
+            else:
+                # Broker as hostname, look for port
+                if config_items['ports']:
+                    port_item = config_items['ports'][0]
+                    port = port_item['value']
+                    connections_to_test.append((item['value'], port))
+                    # Combine broker and port into single object
+                    test_values.append({
+                        item['name']: item['value'],
+                        port_item['name']: str(port)
+                    })
+        
+        if not connections_to_test:
+            return None  # No applicable tests
+        
+        # Test all connections
+        all_passed = True
+        failure_reason = None
+        
+        for hostname, port in connections_to_test:
+            success, reason = await self.check_port_listening(hostname, port)
+            if not success:
+                all_passed = False
+                failure_reason = reason
+                break
+        
+        result = {
+            "description": "Listening",
+            "result": "pass" if all_passed else "fail",
+            "values": test_values
+        }
+        
+        if not all_passed:
+            result["detail"] = {"reason": failure_reason}
+            
+        return result
+    
+    async def validate_configuration(self, config_data):
+        """
+        Validate plugin configuration by running all applicable tests.
+        
+        Args:
+            config_data (dict): Plugin configuration category contents
+            
+        Returns:
+            dict: Validation results
+        """
+        self.results = {}
+        
+        # Extract configuration items
+        config_items = self.extract_configuration_items(config_data)
+        
+        # Run host reachability test
+        host_result = await self.test_host_reachable(config_items)
+        if host_result:
+            self.results["HostReachable"] = host_result
+        
+        # Run listening test
+        listening_result = await self.test_listening(config_items)
+        if listening_result:
+            self.results["Listening"] = listening_result
+        
+        return self.results
+
+
+async def validate_configuration(request):
+    """
+    API endpoint for plugin configuration validation.
+    
+    PUT /fledge/plugin/validate
+    
+    Validates connectivity aspects of plugin configurations.
+    """
+    try:
+        data = await request.json()
+        
+        if not isinstance(data, dict):
+            raise ValueError("Configuration data must be a JSON object")
+        
+        validator = ConfigurationValidator()
+        results = await validator.validate_configuration(data)
+        if not results:
+            # No validation could be performed
+            return web.Response(status=204)
+        
+        return web.json_response(results)
+    except json.JSONDecodeError:
+        raise web.HTTPBadRequest(reason="Invalid JSON payload")
+    except ValueError as e:
+        # This catches both general validation errors and missing value/default errors
+        raise web.HTTPBadRequest(reason=str(e))
+    except Exception as e:
+        _logger.error(f"Plugin validation error: {e}")
+        raise web.HTTPInternalServerError(reason="Internal server error during validation")
+
+def setup(app):
+    """Setup plugin validation routes"""
+    app.router.add_route('PUT', '/fledge/plugin/validate', validate_configuration)
+

--- a/python/fledge/services/core/api/plugins/config_validator.py
+++ b/python/fledge/services/core/api/plugins/config_validator.py
@@ -269,46 +269,39 @@ class ConfigurationValidator:
                             # Test connectivity using a socket connection to port 80
                             # This is faster and more reliable than ping in containers
                             test_port = 80  # HTTP port - commonly accessible
-                            
                             _logger.debug(f"Testing connectivity to {ip_addr}:{test_port}")
-                            
                             # Create socket connection with short timeout
-                            sock = socket.socket(family, socket.SOCK_STREAM)
-                            sock.settimeout(3)  # 3 second timeout
-                            
                             try:
-                                result = await asyncio.get_event_loop().run_in_executor(
-                                    None, sock.connect, (ip_addr, test_port)
-                                )
-                                sock.close()
-                                _logger.debug(f"Successfully connected to {ip_addr}:{test_port}")
-                                return True, f"Host '{hostname}' is reachable"
-                                
+                                with socket.socket(family, socket.SOCK_STREAM) as sock:
+                                    sock.settimeout(3)  # 3 second timeout
+
+                                    result = await asyncio.get_event_loop().run_in_executor(
+                                        None, sock.connect, (ip_addr, test_port)
+                                    )
+                                    _logger.debug(f"Successfully connected to {ip_addr}:{test_port}")
+                                    return True, f"Host '{hostname}' is reachable"
+
                             except (socket.timeout, OSError) as conn_err:
-                                sock.close()
                                 _logger.debug(f"Connection to {ip_addr}:{test_port} failed: {conn_err}")
                                 
                                 # Try a few more common ports to increase success rate
                                 for alt_port in [443, 22, 53]:  # HTTPS, SSH, DNS
                                     try:
-                                        sock = socket.socket(family, socket.SOCK_STREAM)
-                                        sock.settimeout(2)  # Shorter timeout for alt ports
-                                        
-                                        await asyncio.get_event_loop().run_in_executor(
-                                            None, sock.connect, (ip_addr, alt_port)
-                                        )
-                                        sock.close()
-                                        _logger.debug(f"Successfully connected to {ip_addr}:{alt_port}")
-                                        return True, f"Host '{hostname}' is reachable"
+                                        with socket.socket(family, socket.SOCK_STREAM) as sock:
+                                            sock.settimeout(2)  # Shorter timeout for alt ports
+
+                                            await asyncio.get_event_loop().run_in_executor(
+                                                None, sock.connect, (ip_addr, alt_port)
+                                            )
+                                            _logger.debug(f"Successfully connected to {ip_addr}:{alt_port}")
+                                            return True, f"Host '{hostname}' is reachable"
                                         
                                     except (socket.timeout, OSError):
-                                        sock.close()
                                         continue
                                 
                                 # If we get here, the host might be up but not responding on tested ports
                                 # This is still considered "reachable" from a network perspective
                                 continue
-                        
                         except Exception as e:
                             _logger.debug(f"Error testing {ip_addr}: {e}")
                             continue
@@ -326,7 +319,6 @@ class ConfigurationValidator:
                     return False, f"Temporary DNS failure for '{hostname}' - please try again later"
                 else:
                     return False, f"DNS lookup failed for '{hostname}'"
-                    
         except asyncio.TimeoutError:
             _logger.warning(f"Host reachability test timed out for {hostname}")
             return False, f"Connection test to '{hostname}' timed out - host may be unreachable"

--- a/python/fledge/services/core/api/plugins/config_validator.py
+++ b/python/fledge/services/core/api/plugins/config_validator.py
@@ -37,8 +37,8 @@ class ConfigurationValidator:
     # Configuration item names to check (case insensitive)
     ADDRESS_FIELDS = ['address', 'ip', 'server', 'host', 'hostname']
     URL_FIELDS = ['url']
-    BROKER_FIELDS = ['broker']
-    PORT_FIELDS = ['port']
+    BROKER_FIELDS = ['broker', 'brokerhost']
+    PORT_FIELDS = ['port', 'brokerport']
     
     # Standard protocol ports
     STANDARD_PORTS = {
@@ -163,9 +163,12 @@ class ConfigurationValidator:
             tuple: (hostname, port, protocol) or (None, None, None) if invalid
         """
         try:
-            # Handle special protocols like opc.tcp
+            # Handle special protocols like opc.tcp and tcp (MQTT)
             if url_string.startswith('opc.tcp://'):
                 url_string = url_string.replace('opc.tcp://', 'opcua://')
+            elif url_string.startswith('tcp://'):
+                # Convert tcp:// to mqtt:// for standard parsing
+                url_string = url_string.replace('tcp://', 'mqtt://')
             
             parsed = urlparse(url_string)
             
@@ -176,9 +179,18 @@ class ConfigurationValidator:
             port = parsed.port
             protocol = parsed.scheme.lower()
             
+            # Map back to original protocol names
+            if protocol == 'opcua':
+                protocol = 'opc.tcp'
+            elif protocol == 'mqtt' and 'tcp://' in url_string:
+                protocol = 'tcp'  # Original was tcp://
+
             # Use standard port if not specified
             if port is None and protocol in self.STANDARD_PORTS:
                 port = self.STANDARD_PORTS[protocol]
+            elif port is None and protocol == 'tcp':
+                # Default MQTT port for tcp:// URLs
+                port = self.STANDARD_PORTS['mqtt']
                 
             return hostname, port, protocol
             
@@ -197,7 +209,7 @@ class ConfigurationValidator:
             bool: True if value appears to be a URL
         """
         url_pattern = re.compile(
-            r'^(https?|ftp|mqtt|mqtts|opcua|opc\.tcp|coap|coaps)://'
+            r'^(https?|ftp|mqtt|mqtts|opcua|opc\.tcp|tcp|coap|coaps)://'
             r'[\w\-\.]+(:\d+)?(/.*)?$',
             re.IGNORECASE
         )
@@ -241,6 +253,11 @@ class ConfigurationValidator:
                     _logger.debug(f"Docker hostname detected: {hostname}")
                     return True, f"Docker hostname '{hostname}' is resolvable and assumed reachable"
                 
+                # Special handling for localhost and loopback addresses - these are always considered reachable if they resolve
+                if hostname.lower() in ['localhost', '127.0.0.1', '::1'] or hostname.startswith('127.'):
+                    _logger.debug(f"Localhost/loopback address detected: {hostname}")
+                    return True, f"Localhost address '{hostname}' is always reachable"
+
                 # Try to connect to each resolved address on a common port
                 # We'll try port 80 (HTTP) as it's commonly open and fast to test
                 for family, socktype, proto, canonname, sockaddr in addr_info:
@@ -416,6 +433,7 @@ class ConfigurationValidator:
         # Process brokers
         for item in config_items['brokers']:
             if self.is_url(item['value']):
+                # Broker is a URL
                 hostname, _, _ = self.parse_url(item['value'])
                 if hostname:
                     hosts_to_test.add(hostname)
@@ -428,7 +446,9 @@ class ConfigurationValidator:
                         "values": [{item['name']: item['value']}]
                     }
             else:
-                hosts_to_test.add(item['value'])
+                # Broker is hostname only or brokerHost
+                hostname = item['value']
+                hosts_to_test.add(hostname)
                 test_values.append({item['name']: item['value']})
         
         if not hosts_to_test:
@@ -468,51 +488,154 @@ class ConfigurationValidator:
         """
         connections_to_test = []
         test_values = []
+        processed_combinations = set()  # Track processed host:port combinations to avoid duplicates
         
-        # Find port and corresponding address combinations
-        if config_items['ports']:
-            port_item = config_items['ports'][0]  # Use first port found
-            port = port_item['value']
+        # Handle separated broker host/port fields first (most specific)
+        broker_hosts = [item for item in config_items['brokers'] if 'host' in item['name'].lower()]
+        broker_ports = [item for item in config_items['ports'] if 'broker' in item['name'].lower()]
+
+        # Pair broker hosts with broker ports
+        for host_item in broker_hosts:
+            hostname = host_item['value']
+            port = None
             
-            # Look for corresponding address
-            address = None
-            for item in config_items['addresses']:
-                address = item['value']
-                # Combine address and port into single object
-                test_values.append({
-                    item['name']: item['value'],
-                    port_item['name']: str(port)
-                })
+            # Find corresponding broker port
+            for port_item in broker_ports:
+                port = port_item['value']
+                combination_key = f"{hostname}:{port}"
+                if combination_key not in processed_combinations:
+                    # Combine broker host and port into single object
+                    test_values.append({
+                        host_item['name']: hostname,
+                        port_item['name']: str(port)
+                    })
+                    connections_to_test.append((hostname, port))
+                    processed_combinations.add(combination_key)
                 break
             
-            if address:
-                connections_to_test.append((address, port))
+            if not port:
+                # Use MQTT defaults if no broker port found
+                for default_port in [1883, 8883]:  # MQTT, MQTTS
+                    combination_key = f"{hostname}:{default_port}"
+                    if combination_key not in processed_combinations:
+                        connections_to_test.append((hostname, default_port))
+                        processed_combinations.add(combination_key)
+
+                test_values.append({
+                    host_item['name']: hostname,
+                    "default_ports": "1883,8883"
+                })
         
+        # Process broker URLs
+        for item in config_items['brokers']:
+            if self.is_url(item['value']):
+                # Broker is a URL
+                hostname, port, protocol = self.parse_url(item['value'])
+                if hostname and port:
+                    combination_key = f"{hostname}:{port}"
+                    if combination_key not in processed_combinations:
+                        connections_to_test.append((hostname, port))
+                        test_values.append({item['name']: item['value']})
+                        processed_combinations.add(combination_key)
+            else:
+                # Broker is hostname only (check if not already processed by broker host/port logic)
+                if not any('host' in broker['name'].lower() for broker in config_items['brokers']):
+                    hostname = item['value']
+                    port = None
+
+                    # Look for a corresponding port field
+                    for port_item in config_items['ports']:
+                        # Skip broker-specific ports as they're handled separately
+                        if 'broker' not in port_item['name'].lower():
+                            port = port_item['value']
+                            combination_key = f"{hostname}:{port}"
+                            if combination_key not in processed_combinations:
+                                # Combine broker and port into single object
+                                test_values.append({
+                                    item['name']: item['value'],
+                                    port_item['name']: str(port)
+                                })
+                                connections_to_test.append((hostname, port))
+                                processed_combinations.add(combination_key)
+                            break
+
+                    # If no explicit port, use MQTT defaults
+                    if port is None:
+                        # Try both standard MQTT ports
+                        for default_port in [1883, 8883]:  # MQTT, MQTTS
+                            combination_key = f"{hostname}:{default_port}"
+                            if combination_key not in processed_combinations:
+                                connections_to_test.append((hostname, default_port))
+                                processed_combinations.add(combination_key)
+
+                        test_values.append({
+                            item['name']: item['value'],
+                            "default_ports": "1883,8883"
+                        })
+
         # Process URLs with ports
         for item in config_items['urls']:
             hostname, port, protocol = self.parse_url(item['value'])
             if hostname and port:
-                connections_to_test.append((hostname, port))
-                test_values.append({item['name']: item['value']})
-        
-        # Process brokers
-        for item in config_items['brokers']:
-            if self.is_url(item['value']):
-                hostname, port, protocol = self.parse_url(item['value'])
-                if hostname and port:
+                combination_key = f"{hostname}:{port}"
+                if combination_key not in processed_combinations:
                     connections_to_test.append((hostname, port))
                     test_values.append({item['name']: item['value']})
-            else:
-                # Broker as hostname, look for port
-                if config_items['ports']:
-                    port_item = config_items['ports'][0]
-                    port = port_item['value']
-                    connections_to_test.append((item['value'], port))
-                    # Combine broker and port into single object
+                    processed_combinations.add(combination_key)
+
+        # Handle standard address + port combinations (skip if broker processing already handled them)
+        if config_items['ports'] and not broker_hosts:
+            port_item = config_items['ports'][0]  # Use first port found
+            port = port_item['value']
+
+            # Look for corresponding address
+            address = None
+            for item in config_items['addresses']:
+                address = item['value']
+                combination_key = f"{address}:{port}"
+                if combination_key not in processed_combinations:
+                    # Combine address and port into single object
                     test_values.append({
                         item['name']: item['value'],
                         port_item['name']: str(port)
                     })
+                    connections_to_test.append((address, port))
+                    processed_combinations.add(combination_key)
+                break
+
+        # Handle addresses without ports (like S7, EtherIP) - use common protocol ports
+        if not connections_to_test and config_items['addresses']:
+            for address_item in config_items['addresses']:
+                hostname = address_item['value']
+
+                # Try common protocol ports based on field names only
+                field_name = address_item['name'].lower()
+                default_ports = []
+
+                if 'ip' in field_name:
+                    # IP fields often used for industrial protocols
+                    default_ports = [102, 44818, 502, 80, 443]  # S7, EtherNet/IP, Modbus, HTTP, HTTPS
+                elif 'address' in field_name:
+                    # Address fields commonly used for network services
+                    default_ports = [502, 80, 443]  # Modbus, HTTP, HTTPS
+                elif 'host' in field_name or 'server' in field_name:
+                    # Host/server fields typically web services
+                    default_ports = [80, 443]  # HTTP, HTTPS
+                else:
+                    # Generic network address
+                    default_ports = [80, 443]  # HTTP, HTTPS
+
+                for default_port in default_ports:
+                    combination_key = f"{hostname}:{default_port}"
+                    if combination_key not in processed_combinations:
+                        connections_to_test.append((hostname, default_port))
+                        processed_combinations.add(combination_key)
+
+                test_values.append({
+                    address_item['name']: hostname,
+                    "default_ports": ",".join(map(str, default_ports))
+                })
+                break  # Only process first address to avoid duplicates
         
         if not connections_to_test:
             return None  # No applicable tests

--- a/python/fledge/services/core/routes.py
+++ b/python/fledge/services/core/routes.py
@@ -17,6 +17,7 @@ from fledge.services.core.api.plugins import data as plugin_data
 from fledge.services.core.api.plugins import install as plugins_install, discovery as plugins_discovery
 from fledge.services.core.api.plugins import update as plugins_update
 from fledge.services.core.api.plugins import remove as plugins_remove
+from fledge.services.core.api.plugins import config_validator
 from fledge.services.core.api.repos import configure as configure_repo
 from fledge.services.core.api.snapshot import plugins as snapshot_plugins
 from fledge.services.core.api.snapshot import table as snapshot_table
@@ -192,6 +193,8 @@ def setup(app):
     app.router.add_route('GET', '/fledge/service/{service_name}/plugin/{plugin_name}/data', plugin_data.get)
     app.router.add_route('POST', '/fledge/service/{service_name}/plugin/{plugin_name}/data', plugin_data.add)
     app.router.add_route('DELETE', '/fledge/service/{service_name}/plugin/{plugin_name}/data', plugin_data.delete)
+    # Plugin validation
+    config_validator.setup(app)
 
     # Filters 
     app.router.add_route('POST', '/fledge/filter', filters.create_filter)

--- a/tests/system/python/api/test_endpoints_with_different_user_types.py
+++ b/tests/system/python/api/test_endpoints_with_different_user_types.py
@@ -188,7 +188,7 @@ class TestAPIEndpointsWithViewUserType:
         ("GET", "/fledge/plugins/installed", 200),
         # ("GET", "/fledge/plugins/available", 200), -- checked manually and commented out only to avoid apt-update
         ("POST", "/fledge/plugins", 403), ("PUT", "/fledge/plugins/south/sinusoid/update", 403),
-        ("DELETE", "/fledge/plugins/south/sinusoid", 403), ("GET", "/fledge/service/foo/persist", 404),
+        ("DELETE", "/fledge/plugins/south/sinusoid", 403), ("PUT", "/fledge/plugin/validate", 400), ("GET", "/fledge/service/foo/persist", 404),
         ("GET", "/fledge/service/foo/plugin/omf/data", 404), ("POST", "/fledge/service/foo/plugin/omf/data", 403),
         ("DELETE", "/fledge/service/foo/plugin/omf/data", 403),
         # filters
@@ -355,7 +355,7 @@ class TestAPIEndpointsWithDataViewUserType:
         # plugins
         ("GET", "/fledge/plugins/installed", 403), ("GET", "/fledge/plugins/available", 403),
         ("POST", "/fledge/plugins", 403), ("PUT", "/fledge/plugins/south/sinusoid/update", 403),
-        ("DELETE", "/fledge/plugins/south/sinusoid", 403), ("GET", "/fledge/service/foo/persist", 403),
+        ("DELETE", "/fledge/plugins/south/sinusoid", 403), ("PUT", "/fledge/plugin/validate", 403), ("GET", "/fledge/service/foo/persist", 403),
         ("GET", "/fledge/service/foo/plugin/omf/data", 403), ("POST", "/fledge/service/foo/plugin/omf/data", 403),
         ("DELETE", "/fledge/service/foo/plugin/omf/data", 403),
         # filters
@@ -452,7 +452,7 @@ class TestAPIEndpointsWithControlUserType:
         ("PUT", "/fledge/user", 500), ("PUT", "/fledge/user/1/password", 401), ("PUT", "/fledge/user/5/password", 500),
         ("GET", "/fledge/user/role", 403),
         # auth
-        ("POST", "/fledge/login", 500), ("PUT", "/fledge/31/logout", 401),
+        ("POST", "/fledge/login", 400), ("PUT", "/fledge/31/logout", 401),
         ("GET", "/fledge/auth/ott", 200),
         # admin
         ("POST", "/fledge/admin/user", 403), ("DELETE", "/fledge/admin/3/delete", 403), ("PUT", "/fledge/admin/3", 403),
@@ -528,7 +528,7 @@ class TestAPIEndpointsWithControlUserType:
         # ("GET", "/fledge/plugins/available", 200), -- checked manually and commented out only to avoid apt operations
         # ("PUT", "/fledge/plugins/south/sinusoid/update", 200),
         # ("DELETE", "/fledge/plugins/south/sinusoid", 404),
-        ("POST", "/fledge/plugins", 400), ("GET", "/fledge/service/foo/persist", 404),
+        ("POST", "/fledge/plugins", 400), ("PUT", "/fledge/plugin/validate", 400), ("GET", "/fledge/service/foo/persist", 404),
         ("GET", "/fledge/service/foo/plugin/omf/data", 404), ("POST", "/fledge/service/foo/plugin/omf/data", 404),
         ("DELETE", "/fledge/service/foo/plugin/omf/data", 404),
         # filters

--- a/tests/unit/python/fledge/services/core/api/plugins/test_config_validator.py
+++ b/tests/unit/python/fledge/services/core/api/plugins/test_config_validator.py
@@ -1,0 +1,298 @@
+# -*- coding: utf-8 -*-
+
+# FLEDGE_BEGIN
+# See: http://fledge-iot.readthedocs.io/
+# FLEDGE_END
+
+import json
+import pytest
+from unittest.mock import patch, AsyncMock
+from aiohttp import web
+from fledge.services.core import routes
+from fledge.services.core.api.plugins.config_validator import ConfigurationValidator
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2025 Dianomic Systems Inc."
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+class TestConfigurationValidator:
+
+    @pytest.fixture
+    def client(self, aiohttp_client, loop):
+        app = web.Application()
+        # fill the routes table
+        routes.setup(app)
+        return loop.run_until_complete(aiohttp_client(app))
+
+    
+    async def test_bad_json_payload(self, client):
+        config = 1
+        resp = await client.put('/fledge/plugin/validate', data=json.dumps(config))
+        assert 400 == resp.status
+        assert "Configuration data must be a JSON object" == resp.reason
+
+
+    @pytest.mark.parametrize("config", [
+        {},
+        {"plugin": {"description": "Dummy Plugin", "type": "string", "default": "dummy", "readonly": "true"}}
+    ])
+    async def test_no_config_check_performed(self, client, config):
+        resp = await client.put('/fledge/plugin/validate', data=json.dumps(config))
+        assert 204 == resp.status
+        assert "No Content" == resp.reason
+
+    @pytest.mark.parametrize("config, ping_result, listening_result, expected_host_result, expected_listening_result", [
+        # Host reachable, port listening (both pass)
+        ({"plugin": {"description": "MQTT Plugin", "type": "string", "default": "mqtt", "readonly": "true"}, 
+          "brokerHost": {"type": "string", "default": "mqtt.example.com", "value": "mqtt.example.com"}, 
+          "brokerPort": {"type": "integer", "default": "1883", "value": "1883"}},
+          (True, "Host 'mqtt.example.com' is reachable"),
+          (True, "Service is listening on port 1883"),
+          "pass", "pass"),
+        
+        # Host unreachable, port not listening (both fail)
+        ({"plugin": {"description": "Modbus Plugin", "type": "string", "default": "modbus", "readonly": "true"}, 
+          "address": {"description": "Modbus server address", "type": "string", "default": "unreachable.host.com"}, 
+          "port": {"description": "Modbus port", "type": "integer", "default": "502"}},
+          (False, "Host 'unreachable.host.com' appears to be unreachable - no response on common ports (80, 443, 22, 53)"),
+          (False, "Connection to unreachable.host.com:502 timed out after 5 seconds"),
+          "fail", "fail"),
+        
+        # Host reachable, port not listening (mixed result)
+        ({"plugin": {"description": "HTTP Plugin", "type": "string", "default": "http", "readonly": "true"}, 
+          "ServerHostname": {"type": "string", "default": "example.com"}, 
+          "ServerPort": {"type": "integer", "default": "8080"}},
+          (True, "Host 'example.com' is reachable"),
+          (False, "No service is listening on example.com:8080"),
+          "pass", "fail"),
+        
+        # DNS resolution failure
+        ({"plugin": {"description": "OPC UA Plugin", "type": "string", "default": "opcua", "readonly": "true"}, 
+          "url": {"type": "string", "default": "opc.tcp://invalid.hostname.xyz:4840/server"}},
+          (False, "Cannot resolve hostname 'invalid.hostname.xyz' - please check the hostname is correct"),
+          (False, "DNS lookup failed for 'invalid.hostname.xyz'"),
+          "fail", "fail"),
+        
+        # Connection timeout scenario
+        ({"plugin": {"description": "Database Plugin", "type": "string", "default": "database", "readonly": "true"}, 
+          "host": {"type": "string", "default": "slow.database.com"}, 
+          "port": {"type": "integer", "default": "5432"}},
+          (False, "Connection test to 'slow.database.com' timed out - host may be unreachable"),
+          (False, "Connection to slow.database.com:5432 timed out after 5 seconds"),
+          "fail", "fail"),
+        
+        # Address-only config with default ports
+        ({"plugin": {"description": "S7 Plugin", "type": "string", "default": "s7", "readonly": "true"}, 
+          "IP": {"type": "string", "default": "192.168.1.100"}},
+          (True, "Host '192.168.1.100' is reachable"),
+          (False, "No service is listening on 192.168.1.100:102"),
+          "pass", "fail"),
+        
+        # Broker URL scenario
+        ({"plugin": {"description": "MQTT Sparkplug Plugin", "type": "string", "default": "mqtt-sparkplug", "readonly": "true"}, 
+          "broker": {"type": "string", "default": "tcp://broker.hivemq.com:1883"}},
+          (True, "Host 'broker.hivemq.com' is reachable"),
+          (True, "Service is listening on port 1883"),
+          "pass", "pass")
+    ])
+    async def test_validate_configuration(self, client, config, ping_result, listening_result, expected_host_result, expected_listening_result):
+        with patch.object(ConfigurationValidator, 'ping_host', new_callable=AsyncMock) as mock_ping, \
+             patch.object(ConfigurationValidator, 'check_port_listening', new_callable=AsyncMock) as mock_listening:
+            
+            # Configure mock returns
+            mock_ping.return_value = ping_result
+            mock_listening.return_value = listening_result
+            
+            # Make the API call
+            resp = await client.put('/fledge/plugin/validate', data=json.dumps(config))
+            assert 200 == resp.status
+            
+            result = await resp.text()
+            json_response = json.loads(result)
+            
+            # Verify HostReachable test results
+            assert 'HostReachable' in json_response
+            assert json_response['HostReachable']['description'] == 'Host Reachable'
+            assert json_response['HostReachable']['result'] == expected_host_result
+            
+            # Check for detail on failed host reachable
+            if expected_host_result == "fail":
+                assert 'detail' in json_response['HostReachable']
+                assert json_response['HostReachable']['detail']['reason'] == ping_result[1]
+            
+            # Verify Listening test results
+            assert 'Listening' in json_response
+            assert json_response['Listening']['description'] == 'Listening'
+            assert json_response['Listening']['result'] == expected_listening_result
+            
+            # Check for detail on failed listening
+            if expected_listening_result == "fail":
+                assert 'detail' in json_response['Listening']
+                assert json_response['Listening']['detail']['reason'] == listening_result[1]
+            
+            # Verify mocks were called
+            assert mock_ping.called
+            if any(field in str(config).lower() for field in ['port', 'url']) or \
+               any('address' in str(config).lower() for _ in [1]):  # Address-only configs get default ports
+                assert mock_listening.called
+
+    @pytest.mark.parametrize("config, ping_result, listening_result, expected_host_result, expected_listening_result, config_type", [
+        # a) Default KV pair only - uses default value
+        ({"plugin": {"description": "Default Only Plugin", "type": "string", "default": "default-only", "readonly": "true"}, 
+          "address": {"description": "Server address", "type": "string", "default": "default.example.com"}, 
+          "port": {"description": "Server port", "type": "integer", "default": "8080"}},
+          (True, "Host 'default.example.com' is reachable"),
+          (False, "No service is listening on default.example.com:8080"),
+          "pass", "fail", "default_only"),
+        
+        # b) Value KV pair only - uses value (no default)
+        ({"plugin": {"description": "Value Only Plugin", "type": "string", "default": "value-only", "readonly": "true"}, 
+          "hostname": {"description": "Server hostname", "type": "string", "value": "value.example.com"}, 
+          "port": {"description": "Server port", "type": "integer", "value": "9090"}},
+          (True, "Host 'value.example.com' is reachable"),
+          (True, "Service is listening on port 9090"),
+          "pass", "pass", "value_only"),
+        
+        # c) Both default and value KV pairs - value takes precedence over default
+        ({"plugin": {"description": "Both Keys Plugin", "type": "string", "default": "both-keys", "readonly": "true"}, 
+          "ServerHostname": {"description": "Server hostname", "type": "string", "default": "default.server.com", "value": "override.server.com"}, 
+          "ServerPort": {"description": "Server port", "type": "integer", "default": "3000", "value": "4000"}},
+          (False, "Host 'override.server.com' appears to be unreachable - no response on common ports (80, 443, 22, 53)"),
+          (False, "Connection to override.server.com:4000 timed out after 5 seconds"),
+          "fail", "fail", "both_keys_value_precedence"),
+        
+        # d) Default and value with URL field - value takes precedence
+        ({"plugin": {"description": "URL Override Plugin", "type": "string", "default": "url-override", "readonly": "true"}, 
+          "url": {"description": "Service URL", "type": "string", "default": "http://default.service.com:8080", "value": "https://custom.service.com:8443"}},
+          (True, "Host 'custom.service.com' is reachable"),
+          (True, "Service is listening on port 8443"),
+          "pass", "pass", "url_value_precedence"),
+        
+        # e) Broker field with default only
+        ({"plugin": {"description": "Broker Default Plugin", "type": "string", "default": "broker-default", "readonly": "true"}, 
+          "broker": {"description": "MQTT Broker", "type": "string", "default": "tcp://default.broker.com:1883"}},
+          (False, "Cannot resolve hostname 'default.broker.com' - please check the hostname is correct"),
+          (False, "DNS lookup failed for 'default.broker.com'"),
+          "fail", "fail", "broker_default_only"),
+        
+        # f) Mixed fields - some with default, some with value
+        ({"plugin": {"description": "Mixed Fields Plugin", "type": "string", "default": "mixed", "readonly": "true"}, 
+          "brokerHost": {"description": "Broker hostname", "type": "string", "value": "mixed.broker.com"}, 
+          "brokerPort": {"description": "Broker port", "type": "integer", "default": "1883"}},
+          (True, "Host 'mixed.broker.com' is reachable"),
+          (False, "No service is listening on mixed.broker.com:1883"),
+          "pass", "fail", "mixed_default_value"),
+        
+        # g) Address-only with value override
+        ({"plugin": {"description": "Address Value Plugin", "type": "string", "default": "address-value", "readonly": "true"}, 
+          "IP": {"description": "PLC IP Address", "type": "string", "default": "192.168.1.100", "value": "192.168.1.200"}},
+          (True, "Host '192.168.1.200' is reachable"),
+          (False, "No service is listening on 192.168.1.200:102"),
+          "pass", "fail", "address_value_override")
+    ])
+    async def test_configuration_key_value_patterns(self, client, config, ping_result, listening_result, 
+                                                   expected_host_result, expected_listening_result, config_type):
+        """Test different configuration key-value patterns: default only, value only, and both default+value."""
+        
+        with patch.object(ConfigurationValidator, 'ping_host', new_callable=AsyncMock) as mock_ping, \
+             patch.object(ConfigurationValidator, 'check_port_listening', new_callable=AsyncMock) as mock_listening:
+            
+            # Configure mock returns
+            mock_ping.return_value = ping_result
+            mock_listening.return_value = listening_result
+            
+            # Make the API call
+            resp = await client.put('/fledge/plugin/validate', data=json.dumps(config))
+            assert 200 == resp.status
+            
+            result = await resp.text()
+            json_response = json.loads(result)
+            
+            # Verify HostReachable test results
+            assert 'HostReachable' in json_response
+            assert json_response['HostReachable']['result'] == expected_host_result
+            
+            # Verify Listening test results  
+            assert 'Listening' in json_response
+            assert json_response['Listening']['result'] == expected_listening_result
+            
+            # Verify the correct values are being used based on config type
+            host_values = json_response['HostReachable']['values'][0]
+            listening_values = json_response['Listening']['values'][0]
+            
+            if config_type == "default_only":
+                # Should use default values
+                assert 'address' in host_values
+                assert 'address' in listening_values and 'port' in listening_values
+                
+            elif config_type == "value_only":
+                # Should use value fields
+                assert 'hostname' in host_values
+                assert 'hostname' in listening_values and 'port' in listening_values
+                
+            elif config_type == "both_keys_value_precedence":
+                # Value should take precedence over default
+                assert 'ServerHostname' in host_values
+                assert 'ServerHostname' in listening_values and 'ServerPort' in listening_values
+                # Verify the value field was used, not default
+                mock_ping.assert_called_with('override.server.com')
+                
+            elif config_type == "url_value_precedence":
+                # URL value should take precedence
+                assert 'url' in host_values
+                mock_ping.assert_called_with('custom.service.com')
+                
+            elif config_type == "broker_default_only":
+                # Broker default should be used
+                assert 'broker' in host_values
+                mock_ping.assert_called_with('default.broker.com')
+                
+            elif config_type == "mixed_default_value":
+                # Mixed: brokerHost uses value, brokerPort uses default
+                assert 'brokerHost' in listening_values and 'brokerPort' in listening_values
+                mock_ping.assert_called_with('mixed.broker.com')
+                
+            elif config_type == "address_value_override":
+                # Address value should override default
+                assert 'IP' in host_values
+                mock_ping.assert_called_with('192.168.1.200')
+            
+            # Verify error details for failed tests
+            if expected_host_result == "fail":
+                assert 'detail' in json_response['HostReachable']
+                assert json_response['HostReachable']['detail']['reason'] == ping_result[1]
+                
+            if expected_listening_result == "fail":
+                assert 'detail' in json_response['Listening']
+                assert json_response['Listening']['detail']['reason'] == listening_result[1]
+
+    @pytest.mark.parametrize("config, expected_error_message", [
+        # Test invalid URL format
+        ({"plugin": {"description": "Invalid URL Plugin", "type": "string", "default": "invalid", "readonly": "true"}, 
+          "url": {"type": "string", "default": "not-a-valid-url"}},
+          "Invalid URL format 'not-a-valid-url' - please check the URL is correct"),
+        
+        # Test missing value and default
+        ({"plugin": {"description": "Missing Value Plugin", "type": "string", "default": "missing", "readonly": "true"}, 
+          "address": {"type": "string", "description": "Server address"}},
+          "Configuration item 'address' must have either 'value' or 'default' key")
+    ])
+    async def test_validate_configuration_error_cases(self, client, config, expected_error_message):
+        """Test configuration validation error handling without network calls."""
+        
+        resp = await client.put('/fledge/plugin/validate', data=json.dumps(config))
+        
+        if "Invalid URL format" in expected_error_message:
+            # URL format errors return 200 with fail result
+            assert 200 == resp.status
+            result = await resp.text()
+            json_response = json.loads(result)
+            assert json_response['HostReachable']['result'] == 'fail'
+            assert expected_error_message in json_response['HostReachable']['detail']['reason']
+        else:
+            # Missing value/default errors return 400
+            assert 400 == resp.status
+            assert expected_error_message in resp.reason
+


### PR DESCRIPTION
Below are the sample of JSON response:

a) Both HostReachable and Listening are good
```
$ curl -H "authorization: $TOKEN" -sX PUT localhost:8081/fledge/plugin/validate -d '{"plugin":{"description":"HTTP Listener South Plugin","type":"string","default":"http_south","readonly":"true"},"host":{"description":"Address to accept data on","type":"string","default":"127.0.0.1","order":"1","displayName":"Host"},"port":{"description":"Port to listen on","type":"integer","default":"6683","order":"2","displayName":"Port"}}' | jq
{
  "HostReachable": {
    "description": "Host Reachable",
    "result": "pass",
    "values": [
      {
        "host": "127.0.0.1"
      }
    ]
  },
  "Listening": {
    "description": "Listening",
    "result": "pass",
    "values": [
      {
        "host": "127.0.0.1",
        "port": "6683"
      }
    ]
  }
}
```

b) HostReachable is good but Listening is Not

```
{
  "HostReachable": {
    "description": "Host Reachable",
    "result": "pass",
    "values": [
      {
        "host": "127.0.0.1"
      }
    ]
  },
  "Listening": {
    "description": "Listening",
    "result": "fail",
    "values": [
      {
        "host": "127.0.0.1",
        "port": "6683"
      }
    ],
    "detail": {
      "reason": "No service is listening on 127.0.0.1:6683"
    }
  }
}

```