### PR TITLE
Reactivated C-based tests on the GitHub workflow for the Ubuntu 24 platform

### DIFF
--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -42,12 +42,8 @@ jobs:
           sudo ./requirements.sh
           make -j"$(nproc)"
 
-      - name: 🚫 Skipping C Unit Tests on ubuntu-24.04
-        if: matrix.os == 'ubuntu-24.04'
-        run: echo "⚠️ Skipping C unit tests on ubuntu-24.04 due to increased execution time. See JIRA FOGL-9817 for details."
-
       - name: 🧪 Run C Unit Tests
-        if: matrix.os != 'ubuntu-24.04' && steps.make_fledge.outcome == 'success'
+        if: steps.make_fledge.outcome == 'success'
         continue-on-error: true
         run: |
           set +e


### PR DESCRIPTION
The following is a comparison regarding the execution time of specific C-based unit tests.

| Platform    | CI/CD Runner on AWS (Nightly) |                | GitHub Runner on PR |                |
|-------------|-------------------------------|----------------|----------------------|----------------|
|             | _Previous_                      | **New**            | _Previous_             | **New**            |
| Ubuntu 20   |  5min 2 sec                 | 5 min 58 sec     | ❌               | ❌             |
| Ubuntu 22   |  6min 52 sec                  | 6 min 9 sec   |     3min 32 sec |  3 min 26 sec
| Ubuntu 24   |    28min 24 sec               | 6 min 38 sec   |   16min    | 3 min 18 sec

**Note**: Tests were executed with a single iteration, and timing results are based on approximation. However, a significant difference was observed on Ubuntu 24.