### PR TITLE
FOGL-10104 Remove unit test compatibility logic targeting Python versions below 3.8

### DIFF
--- a/C/common/CMakeLists.txt
+++ b/C/common/CMakeLists.txt
@@ -35,12 +35,7 @@ find_package(PkgConfig REQUIRED)
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
     pkg_check_modules(PYTHON REQUIRED python3)
 else()
-    if("${OS_NAME}" STREQUAL "mendel")
-        # We will explicitly set include path later for NumPy.
-        find_package(Python3 REQUIRED COMPONENTS Interpreter Development )
-    else()
-        find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
-    endif()
+    find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
 endif()
 
 # Find source files
@@ -53,19 +48,7 @@ include_directories(include ../services/common/include ../common/include ../thir
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
     include_directories(${PYTHON_INCLUDE_DIRS})
 else()
-    if("${OS_NAME}" STREQUAL "mendel")
-        # The following command gets the location of NumPy.
-        execute_process(
-            COMMAND python3
-                -c "import numpy; print(numpy.get_include())"
-                OUTPUT_VARIABLE Python3_NUMPY_INCLUDE_DIRS
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        # Now we can add include directories as usual.
-        include_directories(${Python3_INCLUDE_DIRS} ${Python3_NUMPY_INCLUDE_DIRS})
-    else()
-        include_directories(${Python3_INCLUDE_DIRS} ${Python3_NUMPY_INCLUDE_DIRS})
-    endif()
+    include_directories(${Python3_INCLUDE_DIRS} ${Python3_NUMPY_INCLUDE_DIRS})
 endif()
 
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
@@ -82,11 +65,7 @@ add_library(${PROJECT_NAME} SHARED ${SOURCES})
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
     target_link_libraries(${PROJECT_NAME} ${PYTHON_LIBRARIES})
 else()
-    if("${OS_NAME}" STREQUAL "mendel")
-        target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES})
-    else()
-	    target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES} Python3::NumPy)
-	endif()
+	target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES} Python3::NumPy)
 endif()
 
 target_link_libraries(${PROJECT_NAME} ${UUIDLIB})

--- a/C/services/south/CMakeLists.txt
+++ b/C/services/south/CMakeLists.txt
@@ -35,12 +35,7 @@ find_package(PkgConfig REQUIRED)
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
     pkg_check_modules(PYTHON REQUIRED python3)
 else()
-    if("${OS_NAME}" STREQUAL "mendel")
-        # We will explicitly set include path later for NumPy.
-        find_package(Python3 REQUIRED COMPONENTS Interpreter Development )
-    else()
-        find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
-    endif()
+    find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
 endif()
 
 file(GLOB south_src "*.cpp")
@@ -49,19 +44,7 @@ file(GLOB south_src "*.cpp")
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
     include_directories(${PYTHON_INCLUDE_DIRS})
 else()
-    if("${OS_NAME}" STREQUAL "mendel")
-        # The following command gets the location of NumPy.
-        execute_process(
-            COMMAND python3
-                -c "import numpy; print(numpy.get_include())"
-                OUTPUT_VARIABLE Python3_NUMPY_INCLUDE_DIRS
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        # Now we can add include directories as usual.
-        include_directories(${Python3_INCLUDE_DIRS} ${Python3_NUMPY_INCLUDE_DIRS})
-    else()
-        include_directories(${Python3_INCLUDE_DIRS} ${Python3_NUMPY_INCLUDE_DIRS})
-    endif()
+    include_directories(${Python3_INCLUDE_DIRS} ${Python3_NUMPY_INCLUDE_DIRS})
 endif()
 
 link_directories(${PROJECT_BINARY_DIR}/../../lib)

--- a/README.rst
+++ b/README.rst
@@ -71,11 +71,10 @@ Fledge is currently based on C/C++ and Python code. The packages needed to build
 Linux distributions
 -------------------
 
-Fledge can be built or installed in one of the following Linux distributions :
+Fledge can be built or installed on the following Linux distributions, supporting both x86_64 and aarch64 architectures.
 
-- Ubuntu 20.04, 22.04
-- Raspbian Bullseye
-- Coral Mendel
+- Ubuntu 20.04, 22.04, 24.04
+- Raspbian Bullseye, Bookworm
 
 Install the prerequisites
 -------------------------

--- a/docs/plugin_developers_guide/09_packaging.rst
+++ b/docs/plugin_developers_guide/09_packaging.rst
@@ -209,7 +209,6 @@ Examples of filename along with content
     echo "Platform is ${os_name}, Version: ${os_version}"
     arch=`arch`
     ID=$(cat /etc/os-release | grep -w ID | cut -f2 -d"=")
-    if [ ${ID} != "mendel" ]; then
     case $os_name in
       *"Ubuntu"*)
         if [ ${arch} = "aarch64" ]; then
@@ -217,8 +216,7 @@ Examples of filename along with content
         fi
         ;;
 
-      esac
-    fi
+    esac
 
 6. requirements-{PLUGIN_NAME}.txt
 

--- a/python/fledge/services/core/api/repos/configure.py
+++ b/python/fledge/services/core/api/repos/configure.py
@@ -73,29 +73,13 @@ async def add_package_repo(request: web.Request) -> web.Response:
                 raise ValueError("{} is not supported".format(_platform))
         else:
             pkg_mgt = 'apt'
-            if 'x86_64-with-Ubuntu-18.04' in _platform:
-                os_name = "ubuntu1804"
-                architecture = "x86_64"
-                extra_commands = ""
-            elif 'x86_64-with-glib' in _platform:
+            if 'x86_64-with-glib' in _platform:
                 os_name = "ubuntu2004"
                 architecture = "x86_64"
-                extra_commands = ""
-            elif 'armv7l-with-debian' in _platform:
-                os_name = "buster"
-                architecture = "armv7l"
                 extra_commands = ""
             elif 'armv7l-with-glibc' in _platform:
                 os_name = "bullseye"
                 architecture = "armv7l"
-                extra_commands = ""
-            elif 'aarch64-with-Ubuntu-18.04' in _platform:
-                os_name = "ubuntu1804"
-                architecture = "aarch64"
-                extra_commands = ""
-            elif 'aarch64-with-Mendel' in _platform:
-                os_name = "mendel"
-                architecture = "aarch64"
                 extra_commands = ""
             else:
                 raise ValueError("{} is not supported".format(_platform))

--- a/scripts/extras/update_task.apt
+++ b/scripts/extras/update_task.apt
@@ -11,8 +11,8 @@
 #        wget -q -O - http://archives.fledge-iot.org/KEY.gpg | sudo apt-key add -
 # 2. Add the repository location to your sources list.
 #    Add the following lines to your "/etc/apt/sources.list" or separate /etc/apt/sources.list.d/fledge.list file.
-#        Below example for ubuntu18.04 64bit machine
-#        echo "deb http://archives.fledge-iot.org/latest/ubuntu1804/x86_64/ / " > /etc/apt/sources.list.d/fledge.list
+#        Below example for ubuntu20.04 64bit machine
+#        echo "deb http://archives.fledge-iot.org/latest/ubuntu2004/x86_64/ / " > /etc/apt/sources.list.d/fledge.list
 ##
 
 __author__="Amarendra K Sinha, Ashish Jabble"

--- a/tests/unit/C/common/CMakeLists.txt
+++ b/tests/unit/C/common/CMakeLists.txt
@@ -59,31 +59,14 @@ find_package(PkgConfig REQUIRED)
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
     pkg_check_modules(PYTHON REQUIRED python3)
 else()
-    if("${OS_NAME}" STREQUAL "mendel")
-        # We will explicitly set include path later for NumPy.
-        find_package(Python3 REQUIRED COMPONENTS Interpreter Development )
-    else()
-        find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
-    endif()
+    find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
 endif()
 
 # Add Python 3.x header files
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
     include_directories(${PYTHON_INCLUDE_DIRS})
 else()
-    if("${OS_NAME}" STREQUAL "mendel")
-        # The following command gets the location of NumPy.
-        execute_process(
-            COMMAND python3
-                -c "import numpy; print(numpy.get_include())"
-                OUTPUT_VARIABLE Python3_NUMPY_INCLUDE_DIRS
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        # Now we can add include directories as usual.
-        include_directories(${Python3_INCLUDE_DIRS} ${Python3_NUMPY_INCLUDE_DIRS})
-    else()
-        include_directories(${Python3_INCLUDE_DIRS} ${Python3_NUMPY_INCLUDE_DIRS})
-    endif()
+    include_directories(${Python3_INCLUDE_DIRS} ${Python3_NUMPY_INCLUDE_DIRS})
 endif()
 
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
@@ -110,11 +93,7 @@ target_link_libraries(RunTests ${PLUGINS_COMMON_LIB})
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
     target_link_libraries(RunTests ${PYTHON_LIBRARIES})
 else()
-    if("${OS_NAME}" STREQUAL "mendel")
-        target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES})
-    else()
-	    target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES} Python3::NumPy)
-    endif()
+    target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES} Python3::NumPy)
 endif()
 
 setup_target_for_coverage_gcovr_html(

--- a/tests/unit/C/requirements.sh
+++ b/tests/unit/C/requirements.sh
@@ -31,16 +31,7 @@ install_gtest_from_package() {
 
     # Install the libgtest-dev package
     sudo apt-get install -y libgtest-dev
-
-    if [[ "${OS_VERSION}" == "18.04" || "${OS_CODENAME}" == "buster" ]]; then
-        echo "Building Google Test libraries manually..."
-        cd /usr/src/gtest
-        sudo cmake -E make_directory build
-        sudo cmake -E chdir build cmake ..
-        sudo cmake --build build
-        sudo cp build/libgtest* /usr/lib
-    fi
-    
+   
     echo "Google Test has been successfully installed."
 }
 

--- a/tests/unit/C/services/storage/postgres/CMakeLists.txt
+++ b/tests/unit/C/services/storage/postgres/CMakeLists.txt
@@ -32,31 +32,14 @@ find_package(PkgConfig REQUIRED)
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
     pkg_check_modules(PYTHON REQUIRED python3)
 else()
-    if("${OS_NAME}" STREQUAL "mendel")
-        # We will explicitly set include path later for NumPy.
-        find_package(Python3 REQUIRED COMPONENTS Interpreter Development )
-    else()
-        find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
-    endif()
+    find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
 endif()
 
 # Add Python 3.x header files
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
     include_directories(${PYTHON_INCLUDE_DIRS})
 else()
-    if("${OS_NAME}" STREQUAL "mendel")
-        # The following command gets the location of NumPy.
-        execute_process(
-            COMMAND python3
-                -c "import numpy; print(numpy.get_include())"
-                OUTPUT_VARIABLE Python3_NUMPY_INCLUDE_DIRS
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        # Now we can add include directories as usual.
-        include_directories(${Python3_INCLUDE_DIRS} ${Python3_NUMPY_INCLUDE_DIRS})
-    else()
-        include_directories(${Python3_INCLUDE_DIRS} ${Python3_NUMPY_INCLUDE_DIRS})
-    endif()
+    include_directories(${Python3_INCLUDE_DIRS} ${Python3_NUMPY_INCLUDE_DIRS})
 endif()
 
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
@@ -80,11 +63,7 @@ target_link_libraries(RunTests ${PLUGINS_COMMON_LIB})
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
     target_link_libraries(RunTests ${PYTHON_LIBRARIES})
 else()
-    if("${OS_NAME}" STREQUAL "mendel")
-        target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES})
-    else()
-            target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES} Python3::NumPy)
-    endif()
+    target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES} Python3::NumPy)
 endif()
 
 setup_target_for_coverage_gcovr_html(

--- a/tests/unit/python/fledge/common/test_alert_manager.py
+++ b/tests/unit/python/fledge/common/test_alert_manager.py
@@ -1,6 +1,4 @@
-import asyncio
 import json
-import sys
 
 from unittest.mock import MagicMock, patch
 import pytest
@@ -55,8 +53,7 @@ class TestAlertManager:
             "The Service RW restarted 1 times", "urgency": "Normal", "timestamp": "2024-03-01 09:40:34.482"}])
     ])
     async def test_get_all(self, storage_result, response):
-        rv = await self.async_mock(storage_result) if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(self.async_mock(storage_result))
+        rv = await self.async_mock(storage_result)
         with patch.object(self.alert_manager.storage_client, 'query_tbl_with_payload', return_value=rv
                           ) as patch_query_tbl:
             result = await self.alert_manager.get_all()
@@ -69,8 +66,7 @@ class TestAlertManager:
 
     async def test_bad_get_all(self):
         storage_result = {"rows": [{}], 'count': 1}
-        rv = await self.async_mock(storage_result) if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(self.async_mock(storage_result))
+        rv = await self.async_mock(storage_result)
         with patch.object(self.alert_manager.storage_client, 'query_tbl_with_payload', return_value=rv
                           ) as patch_query_tbl:
             with pytest.raises(Exception) as ex:
@@ -91,8 +87,7 @@ class TestAlertManager:
     async def test_get_by_key_not_found(self):
         key = "Sine"
         storage_result = {"rows": [], 'count': 1}
-        rv = await self.async_mock(storage_result) if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(self.async_mock(storage_result))
+        rv = await self.async_mock(storage_result)
         with patch.object(self.alert_manager.storage_client, 'query_tbl_with_payload', return_value=rv
                           ) as patch_query_tbl:
             with pytest.raises(Exception) as ex:
@@ -109,8 +104,7 @@ class TestAlertManager:
         key = 'update'
         storage_result = {"rows": [{"key": "RW", "message": "The Service RW restarted 1 times", "urgency": 3,
                     "timestamp": "2024-03-01 09:40:34.482"}], 'count': 1}
-        rv = await self.async_mock(storage_result) if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(self.async_mock(storage_result))
+        rv = await self.async_mock(storage_result)
         with patch.object(self.alert_manager.storage_client, 'query_tbl_with_payload', return_value=rv
                           ) as patch_query_tbl:
             result = await self.alert_manager.get_by_key(key)
@@ -125,8 +119,7 @@ class TestAlertManager:
     async def test_add(self):
         params = {"key": "update", 'message': 'New version available', 'urgency': 'High'}
         storage_result = {'rows_affected': 1, "response": "inserted"}
-        rv = await self.async_mock(storage_result) if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(self.async_mock(storage_result))
+        rv = await self.async_mock(storage_result)
         with patch.object(self.alert_manager.storage_client, 'insert_into_tbl', return_value=rv
                           ) as insert_tbl_patch:
             result = await self.alert_manager.add(params)
@@ -139,8 +132,7 @@ class TestAlertManager:
     async def test_bad_add(self):
         params = {"key": "update", 'message': 'New version available', 'urgency': 'High'}
         storage_result = {}
-        rv = await self.async_mock(storage_result) if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(self.async_mock(storage_result))
+        rv = await self.async_mock(storage_result)
         with patch.object(self.alert_manager.storage_client, 'insert_into_tbl', return_value=rv
                           ) as insert_tbl_patch:
             with pytest.raises(Exception) as ex:
@@ -152,8 +144,7 @@ class TestAlertManager:
 
     async def test_delete(self):
         storage_result = {'rows_affected': 1, "response": "deleted"}
-        rv = await self.async_mock(storage_result) if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(self.async_mock(storage_result))
+        rv = await self.async_mock(storage_result)
         with patch.object(self.alert_manager.storage_client, 'delete_from_tbl', return_value=rv
                           ) as delete_tbl_patch:
             result = await self.alert_manager.delete()
@@ -167,8 +158,7 @@ class TestAlertManager:
         self.alert_manager.alerts = [{"key": key, "message": "The Service RW restarted 1 times", "urgency": 3,
                                       "timestamp": "2024-03-01 09:40:34.482"}]
         storage_result = {'rows_affected': 1, "response": "deleted"}
-        rv = await self.async_mock(storage_result) if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(self.async_mock(storage_result))
+        rv = await self.async_mock(storage_result)
         with patch.object(self.alert_manager.storage_client, 'delete_from_tbl', return_value=rv
                           ) as delete_tbl_patch:
             result = await self.alert_manager.delete(key)

--- a/tests/unit/python/fledge/common/test_configuration_manager.py
+++ b/tests/unit/python/fledge/common/test_configuration_manager.py
@@ -5,7 +5,6 @@ import json
 import ipaddress
 from unittest.mock import MagicMock, patch, call
 import pytest
-import sys
 from fledge.common.configuration_manager import ConfigurationManager, ConfigurationManagerSingleton, \
     _valid_type_strings, _logger, _optional_items
 from fledge.common.storage_client.payload_builder import PayloadBuilder
@@ -1298,11 +1297,7 @@ class TestConfigurationManager:
         assert test_config_new is not test_config_storage
 
     async def test__merge_category_vals_deprecated(self, reset_singleton, mocker):
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock('CONCH')
-        else:
-            _rv = asyncio.ensure_future(self.async_mock('CONCH'))
-
+        _rv = await self.async_mock('CONCH')
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         test_config_new = {
@@ -1705,13 +1700,7 @@ class TestConfigurationManager:
         d = {'info': {'rule': rule, 'default': '3', 'type': 'integer', 'description': 'Test', 'value': '3'}}
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _se = await self.async_mock(d)
-        else:
-            _se = asyncio.ensure_future(self.async_mock(d))
-        
+        _se = await self.async_mock(d)
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_validate_category_val', side_effect=[_se,
                                                                                            Exception()]) as valpatch:
@@ -1726,16 +1715,9 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock({})
-            _se = await self.async_mock({})
-            _sr = await self.async_mock((False, None, None, None))
-        else:
-            _rv = asyncio.ensure_future(self.async_mock({}))
-            _se = asyncio.ensure_future(self.async_mock({}))
-            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
-        
+        _rv = await self.async_mock({})
+        _se = await self.async_mock({})
+        _sr = await self.async_mock((False, None, None, None))
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_validate_category_val', side_effect=[_se, Exception()]) as valpatch:
                 with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv) as readpatch:
@@ -1757,16 +1739,9 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock({})
-            _se = await self.async_mock({})
-            _sr = await self.async_mock((False, None, None, None))
-        else:
-            _rv = asyncio.ensure_future(self.async_mock({}))
-            _se = asyncio.ensure_future(self.async_mock({}))
-            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
-                
+        _rv = await self.async_mock({})
+        _se = await self.async_mock({})
+        _sr = await self.async_mock((False, None, None, None))
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_validate_category_val', side_effect=[_se, Exception]) as valpatch:
                 with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv) as readpatch:
@@ -1790,16 +1765,9 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock({})
-            _rv2 = await self.async_mock(all_cat_names)
-            _se = await self.async_mock({})
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock({}))
-            _rv2 = asyncio.ensure_future(self.async_mock(all_cat_names))
-            _se = asyncio.ensure_future(self.async_mock({}))
-
+        _rv1 = await self.async_mock({})
+        _rv2 = await self.async_mock(all_cat_names)
+        _se = await self.async_mock({})
         with patch.object(ConfigurationManager, '_validate_category_val', side_effect=[_se, _se]) as valpatch:
             with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv1) as readpatch:
                 with patch.object(ConfigurationManager, '_read_all_category_names', return_value=_rv2) as read_all_patch:
@@ -1820,22 +1788,12 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock({})
-            _rv2 = await self.async_mock(all_cat_names)
-            _rv3 = await self.async_mock({'bla': 'bla'})
-            _rv4 = await self.async_mock(None)
-            _se = await self.async_mock({})
-            _sr = await self.async_mock((False, None, None, None))
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock({}))
-            _rv2 = asyncio.ensure_future(self.async_mock(all_cat_names))
-            _rv3 = asyncio.ensure_future(self.async_mock({'bla': 'bla'}))
-            _rv4 = asyncio.ensure_future(self.async_mock(None))
-            _se = asyncio.ensure_future(self.async_mock({}))
-            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
-
+        _rv1 = await self.async_mock({})
+        _rv2 = await self.async_mock(all_cat_names)
+        _rv3 = await self.async_mock({'bla': 'bla'})
+        _rv4 = await self.async_mock(None)
+        _se = await self.async_mock({})
+        _sr = await self.async_mock((False, None, None, None))
         with patch.object(ConfigurationManager, '_validate_category_val', side_effect=[_se, _se]) as valpatch:
             with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv1) as readpatch:
                 with patch.object(ConfigurationManager, '_read_all_category_names',
@@ -1867,18 +1825,10 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock({})
-            _rv2 = await self.async_mock(all_cat_names)
-            _rv4 = await self.async_mock(None)
-            _se = await self.async_mock({})
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock({}))
-            _rv2 = asyncio.ensure_future(self.async_mock(all_cat_names))
-            _rv4 = asyncio.ensure_future(self.async_mock(None))
-            _se = asyncio.ensure_future(self.async_mock({}))
-        
+        _rv1 = await self.async_mock({})
+        _rv2 = await self.async_mock(all_cat_names)
+        _rv4 = await self.async_mock(None)
+        _se = await self.async_mock({})
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_validate_category_val', side_effect=[_se, _se]) as valpatch:
                 with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv1) as readpatch:
@@ -1901,16 +1851,9 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock({})
-            _rv2 = await self.async_mock(None)
-            _sr = await self.async_mock((False, None, None, None))
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock({}))
-            _rv2 = asyncio.ensure_future(self.async_mock(None))
-            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
-
+        _rv1 = await self.async_mock({})
+        _rv2 = await self.async_mock(None)
+        _sr = await self.async_mock((False, None, None, None))
         with patch.object(ConfigurationManager, '_validate_category_val', return_value=_rv1) as valpatch:
             with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv2) as readpatch:
                 with patch.object(ConfigurationManager, '_create_new_category', return_value=_rv2) as createpatch:
@@ -1928,14 +1871,8 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock({})
-            _rv2 = await self.async_mock(None)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock({}))
-            _rv2 = asyncio.ensure_future(self.async_mock(None))
-        
+        _rv1 = await self.async_mock({})
+        _rv2 = await self.async_mock(None)
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_validate_category_val', return_value=_rv1) as valpatch:
                 with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv2) as readpatch:
@@ -1954,14 +1891,8 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock({})
-            _rv2 = await self.async_mock(None)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock({}))
-            _rv2 = asyncio.ensure_future(self.async_mock(None))
-        
+        _rv1 = await self.async_mock({})
+        _rv2 = await self.async_mock(None)
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_validate_category_val', return_value=_rv1) as valpatch:
                 with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv2) as readpatch:
@@ -2002,14 +1933,8 @@ class TestConfigurationManager:
         storage_value_entry = {'value': 'test', 'description': 'Test desc', 'type': 'string', 'default': 'test'}
         c_mgr._cacheManager.update(category_name, "desc", {item_name: storage_value_entry})
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(storage_value_entry)
-            _rv2 = await self.async_mock(None)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(storage_value_entry))
-            _rv2 = asyncio.ensure_future(self.async_mock(None))
-
+        _rv1 = await self.async_mock(storage_value_entry)
+        _rv2 = await self.async_mock(None)
         with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv1) as readpatch:
             with patch.object(ConfigurationManager, '_update_value_val', return_value=_rv2) as updatepatch:
                 with patch.object(ConfigurationManager, '_run_callbacks', return_value=_rv2) as callbackpatch:
@@ -2043,12 +1968,7 @@ class TestConfigurationManager:
         category_name = 'catname'
         item_name = 'itemname'
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(storage_result)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(storage_result))
-        
+        _rv = await self.async_mock(storage_result)
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
                 with patch.object(ConfigurationManager, '_run_callbacks') as callbackpatch:
@@ -2069,12 +1989,7 @@ class TestConfigurationManager:
         item_name = 'itemname'
         new_value_entry = 'newvalentry'
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-        
+        _rv = await self.async_mock(None)
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
                 with patch.object(ConfigurationManager, '_update_value_val') as updatepatch:
@@ -2096,12 +2011,7 @@ class TestConfigurationManager:
         item_name = 'itemname'
         new_value_entry = 'newvalentry'
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(new_value_entry)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(new_value_entry))
-
+        _rv = await self.async_mock(new_value_entry)
         with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
             with patch.object(ConfigurationManager, '_update_value_val') as updatepatch:
                 with patch.object(ConfigurationManager, '_run_callbacks') as callbackpatch:
@@ -2117,12 +2027,7 @@ class TestConfigurationManager:
         item_name = 'itemname'
         new_value_entry = 'newvalentry'
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock({'value': 'test', 'description': 'Test desc', 'type': 'boolean', 'default': 'test'})
-        else:
-            _rv = asyncio.ensure_future(self.async_mock({'value': 'test', 'description': 'Test desc', 'type': 'boolean', 'default': 'test'}))
-        
+        _rv = await self.async_mock({'value': 'test', 'description': 'Test desc', 'type': 'boolean', 'default': 'test'})
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
                 with pytest.raises(Exception) as excinfo:
@@ -2142,14 +2047,8 @@ class TestConfigurationManager:
         storage_value_entry = {"value": "woo", "default": "woo", "description": "enum types", "type": "enumeration", "options": ["foo", "woo"]}
         c_mgr._cacheManager.update(category_name, "desc", {item_name: storage_value_entry})
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(storage_value_entry)
-            _rv2 = await self.async_mock(None)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(storage_value_entry))
-            _rv2 = asyncio.ensure_future(self.async_mock(None))
-
+        _rv1 = await self.async_mock(storage_value_entry)
+        _rv2 = await self.async_mock(None)
         with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv1) as readpatch:
             with patch.object(ConfigurationManager, '_update_value_val', return_value=_rv2) as updatepatch:
                 with patch.object(ConfigurationManager, '_run_callbacks', return_value=_rv2) as callbackpatch:
@@ -2169,12 +2068,7 @@ class TestConfigurationManager:
         category_name = 'catname'
         item_name = 'itemname'
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(cat)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(cat))
-        
+        _rv = await self.async_mock(cat)
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
                 with pytest.raises(Exception) as excinfo:
@@ -2192,12 +2086,7 @@ class TestConfigurationManager:
         item_name = 'info'
         new_value_entry = '13'
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(cat)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(cat))
-        
+        _rv = await self.async_mock(cat)
         with patch.object(_logger, 'exception') as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
                 with pytest.raises(Exception) as excinfo:
@@ -2218,14 +2107,8 @@ class TestConfigurationManager:
                                         'value': '{"items": ["C", "D"]}'}
         modified_new_value_entry = json.dumps({storage_value_entry['listName']: json.loads(new_value_entry)})
         c_mgr._cacheManager.update(category_name, "desc", {item_name: storage_value_entry})
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(storage_value_entry)
-            _rv2 = await self.async_mock(None)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(storage_value_entry))
-            _rv2 = asyncio.ensure_future(self.async_mock(None))
-
+        _rv1 = await self.async_mock(storage_value_entry)
+        _rv2 = await self.async_mock(None)
         with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv1) as patch_read:
             with patch.object(ConfigurationManager, '_update_value_val', return_value=_rv2) as patch_update:
                 with patch.object(ConfigurationManager, '_run_callbacks', return_value=_rv2) as patch_callback:
@@ -2238,12 +2121,7 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock('bla')
-        else:
-            _rv = asyncio.ensure_future(self.async_mock('bla'))
-
+        _rv = await self.async_mock('bla')
         with patch.object(ConfigurationManager, '_read_all_category_names', return_value=_rv) as readpatch:
             ret_val = await c_mgr.get_all_category_names()
             assert 'bla' == ret_val
@@ -2256,12 +2134,7 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock('bla')
-        else:
-            _rv = asyncio.ensure_future(self.async_mock('bla'))
-
+        _rv = await self.async_mock('bla')
         with patch.object(ConfigurationManager, '_read_all_groups', return_value=_rv) as readpatch:
             ret_val = await c_mgr.get_all_category_names(root=value)
             assert 'bla' == ret_val
@@ -2285,12 +2158,7 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(cat_info)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(cat_info))
-
+        _rv = await self.async_mock(cat_info)
         with patch.object(ConfigurationManager, '_read_category', return_value=_rv) as readpatch:
             ret_val = await c_mgr.get_category_all_items(category_name)
             assert cat_value == ret_val
@@ -2314,14 +2182,8 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock('bla')
-            _rv2 = await self.async_mock(None)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock('bla'))
-            _rv2 = asyncio.ensure_future(self.async_mock(None))
-
+        _rv1 = await self.async_mock('bla')
+        _rv2 = await self.async_mock(None)
         with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv1) as read_item_patch:
             with patch.object(ConfigurationManager, '_read_category', return_value=_rv2) as read_cat_patch:
                 ret_val = await c_mgr.get_category_item(category_name, item_name)
@@ -2348,12 +2210,7 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock('bla')
-        else:
-            _rv = asyncio.ensure_future(self.async_mock('bla'))
-
+        _rv = await self.async_mock('bla')
         with patch.object(ConfigurationManager, '_read_value_val', return_value=_rv) as readpatch:
             ret_val = await c_mgr.get_category_item_value_entry(category_name, item_name)
             assert 'bla' == ret_val
@@ -2378,14 +2235,8 @@ class TestConfigurationManager:
         category_description = 'catdesc'
         category_response = {'response': [{'display_name': 'catname', 'category_name': 'catname',
                                            'category_val': 'catval', 'description': 'catdesc'}]}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-            _attr = await self.async_mock(category_response)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-            _attr = asyncio.ensure_future(self.async_mock(category_response))
-
+        _rv = await self.async_mock(None)
+        _attr = await self.async_mock(category_response)
         attrs = {"insert_into_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)      
@@ -2431,13 +2282,8 @@ class TestConfigurationManager:
         category_response = {'response': [
             {'category_name': 'catname', 'category_val': 'catval', 'description': 'catdesc'}]}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-            _attr = await self.async_mock(category_response)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-            _attr = asyncio.ensure_future(self.async_mock(category_response))
+        _rv = await self.async_mock(None)
+        _attr = await self.async_mock(category_response)
         attrs = {"insert_into_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2469,14 +2315,8 @@ class TestConfigurationManager:
         category_description = 'catdesc'
         category_response = {'response': [
             {'category_name': 'catname', 'category_val': 'catval', 'description': 'catdesc'}]}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-            _attr = await self.async_mock(category_response)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-            _attr = asyncio.ensure_future(self.async_mock(category_response))
-
+        _rv = await self.async_mock(None)
+        _attr = await self.async_mock(category_response)
         attrs = {"insert_into_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2496,12 +2336,7 @@ class TestConfigurationManager:
 
     async def test__read_all_category_names_1_row(self, reset_singleton):
         rows = {'rows': [{'key': 'key1', 'description': 'description1', 'display_name': 'display key'}]}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
 
@@ -2516,12 +2351,7 @@ class TestConfigurationManager:
     async def test__read_all_category_names_2_row(self, reset_singleton):
         rows = {'rows': [{'key': 'key1', 'description': 'description1', 'display_name': 'display key1'},
                          {'key': 'key2', 'description': 'description2', 'display_name': 'display key2'}]}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2534,12 +2364,7 @@ class TestConfigurationManager:
 
     async def test__read_all_category_names_0_row(self, reset_singleton):
         rows = {'rows': []}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr }
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2552,12 +2377,7 @@ class TestConfigurationManager:
 
     async def test__read_category_0_row(self, reset_singleton):
         rows = {"rows": []}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2575,12 +2395,7 @@ class TestConfigurationManager:
                            'value': {'config_item': {'default': 'blah', 'value': 'blah', 'description': 'Des',
                                                      'type': 'string'}}}]
         rows = {"rows": storage_result, "count": 1}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2619,12 +2434,7 @@ class TestConfigurationManager:
     async def test__read_category_val_1_row(self, reset_singleton):
         rows = {'rows': [{'value': 'value1'}]}
         category_name = 'catname'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2644,12 +2454,7 @@ class TestConfigurationManager:
     async def test__read_category_val_0_row(self, reset_singleton):
         rows = {'rows': []}
         category_name = 'catname'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2670,12 +2475,7 @@ class TestConfigurationManager:
         rows = {'rows': []}
         category_name = 'catname'
         item_name = 'itemname'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2686,12 +2486,7 @@ class TestConfigurationManager:
         rows = {'rows': [{'value': 'value1'}]}
         category_name = 'catname'
         item_name = 'itemname'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2702,12 +2497,7 @@ class TestConfigurationManager:
         rows = {'rows': []}
         category_name = 'catname'
         item_name = 'itemname'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2718,12 +2508,7 @@ class TestConfigurationManager:
         rows = {'rows': [{'value': 'value1'}]}
         category_name = 'catname'
         item_name = 'itemname'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2735,14 +2520,8 @@ class TestConfigurationManager:
         category_name = 'catname'
         item_name = 'itemname'
         new_value_val = 'newval'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-            _rv = await self.async_mock(None)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-            _rv = asyncio.ensure_future(self.async_mock(None))
-
+        _attr = await self.async_mock(rows)
+        _rv = await self.async_mock(None)
         attrs = {"query_tbl_with_payload.return_value": _attr, "update_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2759,12 +2538,7 @@ class TestConfigurationManager:
         category_name = 'catname'
         item_name = 'itemname'
         new_value_val = 'newval'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr, "update_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2784,12 +2558,7 @@ class TestConfigurationManager:
         category_name = 'catname'
         item_name = 'itemname'
         new_value_val = 'newval'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr, "update_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2809,14 +2578,8 @@ class TestConfigurationManager:
         category_name = 'catname'
         category_description = 'catdesc'
         category_val = 'catval'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(response)
-            _rv1 = await self.async_mock(category_val)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(response))
-            _rv1 = asyncio.ensure_future(self.async_mock(category_val))
-
+        _attr = await self.async_mock(response)
+        _rv1 = await self.async_mock(category_val)
         attrs = {"update_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2838,12 +2601,7 @@ class TestConfigurationManager:
         category_name = 'catname'
         category_description = 'catdesc'
         category_val = 'catval'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(response)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(response))
-
+        _attr = await self.async_mock(response)
         attrs = {"update_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2867,12 +2625,7 @@ class TestConfigurationManager:
         category_name = 'catname'
         category_description = 'catdesc'
         category_val = 'catval'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(response)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(response))
-
+        _attr = await self.async_mock(response)
         attrs = {"update_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -2896,16 +2649,9 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock('bla')
-            _rv2 = await self.async_mock(all_child_ret_val)
-            _rv3 = await self.async_mock(child_info_ret_val)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock('bla'))
-            _rv2 = asyncio.ensure_future(self.async_mock(all_child_ret_val))
-            _rv3 = asyncio.ensure_future(self.async_mock(child_info_ret_val))
-
+        _rv1 = await self.async_mock('bla')
+        _rv2 = await self.async_mock(all_child_ret_val)
+        _rv3 = await self.async_mock(child_info_ret_val)
         with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv1) as patch_read_cat_val:
             with patch.object(ConfigurationManager, '_read_all_child_category_names', return_value=_rv2) as patch_read_all_child:
                 with patch.object(ConfigurationManager, '_read_child_info', return_value=_rv3) as patch_read_child_info:
@@ -2920,12 +2666,7 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-
+        _rv = await self.async_mock(None)
         with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv) as patch_read_cat_val:
             with pytest.raises(ValueError) as excinfo:
                 await c_mgr.get_category_child(category_name)
@@ -2977,16 +2718,9 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock('inserted')
-            _rv2 = await self.async_mock(all_child_ret_val)
-            _sr = await self.async_mock((False, None, None, None))
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock('inserted'))
-            _rv2 = asyncio.ensure_future(self.async_mock(all_child_ret_val))
-            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
-        
+        _rv1 = await self.async_mock('inserted')
+        _rv2 = await self.async_mock(all_child_ret_val)
+        _sr = await self.async_mock((False, None, None, None))
         with patch.object(ConfigurationManager, '_read_category_val', side_effect=q_result):
             with patch.object(ConfigurationManager, '_read_all_child_category_names',
                               return_value=_rv2) as patch_readall_child:
@@ -3014,14 +2748,8 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(all_child_ret_val)
-            _sr = await self.async_mock((False, None, None, None))
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(all_child_ret_val))
-            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
-        
+        _rv = await self.async_mock(all_child_ret_val)
+        _sr = await self.async_mock((False, None, None, None))
         with patch.object(ConfigurationManager, '_read_category_val', side_effect=q_result):
             with patch.object(ConfigurationManager, '_read_all_child_category_names',
                               return_value=_rv) as patch_readall_child:
@@ -3075,14 +2803,8 @@ class TestConfigurationManager:
         child_name = 'coap'
         all_child_ret_val = [{'parent': cat_name, 'child': child_name}]
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(expected_result)
-            _rv = await self.async_mock(all_child_ret_val)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(expected_result))
-            _rv = asyncio.ensure_future(self.async_mock(all_child_ret_val))
-        
+        _attr = await self.async_mock(expected_result)
+        _rv = await self.async_mock(all_child_ret_val)
         attrs = {"delete_from_tbl.return_value": _attr}
         payload = {"where": {"column": "parent", "condition": "=", "value": "south", "and": {"column": "child", "condition": "=", "value": "coap"}}}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
@@ -3105,12 +2827,7 @@ class TestConfigurationManager:
                 return await self.async_mock('blah2')
 
         expected_result = {"message": "blah"}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(expected_result)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(expected_result))
-
+        _attr = await self.async_mock(expected_result)
         attrs = {"delete_from_tbl.return_value": _attr}
         cat_name = 'south'
         child_name = 'coap'
@@ -3142,14 +2859,8 @@ class TestConfigurationManager:
 
     async def test_delete_parent_category(self, reset_singleton):
         expected_result = {"response": "deleted", "rows_affected": 1}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(expected_result)
-            _rv = await self.async_mock('bla')
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(expected_result))
-            _rv = asyncio.ensure_future(self.async_mock('bla'))
-
+        _attr = await self.async_mock(expected_result)
+        _rv = await self.async_mock('bla')
         attrs = {"delete_from_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -3173,12 +2884,7 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-
+        _rv = await self.async_mock(None)
         with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv) as patch_read_cat_val:
             with pytest.raises(ValueError) as excinfo:
                 await c_mgr.delete_parent_category(category_name)
@@ -3187,14 +2893,8 @@ class TestConfigurationManager:
 
     async def test_delete_parent_category_key_error(self, reset_singleton):
         rows = {"message": "blah"}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-            _rv = await self.async_mock('blah')
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-            _rv = asyncio.ensure_future(self.async_mock('blah'))
-
+        _attr = await self.async_mock(rows)
+        _rv = await self.async_mock('blah')
         attrs = {"delete_from_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -3210,12 +2910,7 @@ class TestConfigurationManager:
         c_mgr = ConfigurationManager(storage_client_mock)
         msg = {"entryPoint": "delete", "message": "failed"}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock('blah')
-        else:
-            _rv = asyncio.ensure_future(self.async_mock('blah'))
-
+        _rv = await self.async_mock('blah')
         with patch.object(ConfigurationManager, '_read_category_val', return_value=_rv) as patch_read_cat_val:
             with patch.object(storage_client_mock, 'delete_from_tbl', side_effect=
             StorageServerError(code=400, reason="blah", error=msg)):
@@ -3283,14 +2978,8 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         patch_delete_from_tbl = mocker.patch.object(storage_client_mock, 'delete_from_tbl', side_effect=mock_coro)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock('bla')
-            _sr = await self.async_mock((False, None, None, None))
-        else:
-            _rv = asyncio.ensure_future(self.async_mock('bla'))
-            _sr = asyncio.ensure_future(self.async_mock((False, None, None, None)))
-        
+        _rv = await self.async_mock('bla')
+        _sr = await self.async_mock((False, None, None, None))
         c_mgr = ConfigurationManager(storage_client_mock)
         patch_read_cat_val = mocker.patch.object(ConfigurationManager, '_read_category_val',
                                                  return_value=_rv)
@@ -3421,12 +3110,7 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         mocker.patch.object(storage_client_mock, 'delete_from_tbl', side_effect=mock_coro)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock('bla')
-        else:
-            _rv = asyncio.ensure_future(self.async_mock('bla'))
-        
+        _rv = await self.async_mock('bla')
         c_mgr = ConfigurationManager(storage_client_mock)
         mocker.patch.object(ConfigurationManager, '_read_category_val', return_value=_rv)
         mocker.patch.object(ConfigurationManager, '_read_all_child_category_names',
@@ -3443,12 +3127,7 @@ class TestConfigurationManager:
 
     async def test__read_all_child_category_names(self, reset_singleton):
         rows = {'rows': [{'parent': 'south', 'child': 'http'}], 'count': 1}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -3461,12 +3140,7 @@ class TestConfigurationManager:
 
     async def test__read_child_info(self, reset_singleton):
         rows = {'rows': [{'description': 'HTTP South Plugin', 'key': 'HTTP SOUTH'}], 'count': 1}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"query_tbl_with_payload.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         child_cat_names = [{'child': 'HTTP SOUTH', 'parent': 'south'}]
@@ -3481,12 +3155,7 @@ class TestConfigurationManager:
 
     async def test__create_child(self):
         response = {"response": "inserted", "rows_affected": 1}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(response)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(response))
-
+        _attr = await self.async_mock(response)
         attrs = {"insert_into_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -3501,12 +3170,7 @@ class TestConfigurationManager:
 
     async def test__create_child_key_error(self, reset_singleton):
         rows = {"message": "blah"}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _attr = await self.async_mock(rows)
-        else:
-            _attr = asyncio.ensure_future(self.async_mock(rows))
-
+        _attr = await self.async_mock(rows)
         attrs = {"insert_into_tbl.return_value": _attr}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
 
@@ -3687,15 +3351,8 @@ class TestConfigurationManager:
                                                              category_name='testcat'):
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            rv1 = await self.async_mock(cat_info)
-            rv2 = await self.async_mock("")
-        else:
-            rv1 = asyncio.ensure_future(self.async_mock(cat_info))
-            rv2 = asyncio.ensure_future(self.async_mock(""))
-
+        rv1 = await self.async_mock(cat_info)
+        rv2 = await self.async_mock("")
         with patch.object(c_mgr, 'get_category_all_items', return_value=rv1) as patch_get_all_items:
             with patch.object(c_mgr, '_check_updates_by_role', return_value=rv2):
                 with patch.object(_logger, 'exception') as patch_log_exc:
@@ -3719,18 +3376,10 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(cat_info)
-            _rv2 = await self.async_mock(update_result)
-            _rv3 = await self.async_mock(read_val)
-            _rv4 = await self.async_mock(None)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(cat_info))
-            _rv2 = asyncio.ensure_future(self.async_mock(update_result))
-            _rv3 = asyncio.ensure_future(self.async_mock(read_val))
-            _rv4 = asyncio.ensure_future(self.async_mock(None))
-
+        _rv1 = await self.async_mock(cat_info)
+        _rv2 = await self.async_mock(update_result)
+        _rv3 = await self.async_mock(read_val)
+        _rv4 = await self.async_mock(None)
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_all_items:
             with patch.object(c_mgr._storage, 'update_tbl', return_value=_rv2) as patch_update:
                 with patch.object(c_mgr, '_read_category_val', return_value=_rv3) as patch_read_val:
@@ -3753,12 +3402,7 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(cat_info)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(cat_info))
-
+        _rv = await self.async_mock(cat_info)
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_all_items:
             with patch.object(c_mgr._storage, 'update_tbl') as patch_update:
                 with patch.object(AuditLogger, 'information') as patch_audit:
@@ -3777,12 +3421,7 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(cat_info)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(cat_info))
-
+        _rv = await self.async_mock(cat_info)
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_all_items:
             with patch.object(c_mgr._storage, 'update_tbl') as patch_update:
                 with patch.object(AuditLogger, 'information') as patch_audit:
@@ -3808,19 +3447,10 @@ class TestConfigurationManager:
         audit_details = {'items': {'enableHttp': {'oldValue': 'true', 'newValue': 'false'}}, 'category': category_name}
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(cat_info)
-            _rv2 = await self.async_mock(update_result)
-            _rv3 = await self.async_mock(read_val)
-            _rv4 = await self.async_mock(None)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(cat_info))
-            _rv2 = asyncio.ensure_future(self.async_mock(update_result))
-            _rv3 = asyncio.ensure_future(self.async_mock(read_val))
-            _rv4 = asyncio.ensure_future(self.async_mock(None))
-
+        _rv1 = await self.async_mock(cat_info)
+        _rv2 = await self.async_mock(update_result)
+        _rv3 = await self.async_mock(read_val)
+        _rv4 = await self.async_mock(None)
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_all_items:
             with patch.object(c_mgr._storage, 'update_tbl', return_value=_rv2) as patch_update:
                 with patch.object(c_mgr, '_read_category_val', return_value=_rv3) as patch_read_val:
@@ -3844,13 +3474,7 @@ class TestConfigurationManager:
                                                            'type': 'integer'}}
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(cat_info)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(cat_info))
-
+        _rv = await self.async_mock(cat_info)
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_all_items:
             with patch.object(_logger, 'exception') as patch_log_exc:
                 with pytest.raises(Exception) as exc_info:
@@ -3882,10 +3506,7 @@ class TestConfigurationManager:
 
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await self.async_mock(cat_info) if sys.version_info.major == 3 and sys.version_info.minor >= 8 else (
-            asyncio.ensure_future(self.async_mock(cat_info)))
-
+        _rv = await self.async_mock(cat_info)
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_all_items:
             with patch.object(_logger, 'exception') as patch_log_exc:
                 with pytest.raises(Exception) as exc_info:
@@ -3912,19 +3533,10 @@ class TestConfigurationManager:
 
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(cat_info)
-            _rv2 = await self.async_mock(update_result)
-            _rv3 = await self.async_mock(read_val)
-            _rv4 = await self.async_mock(None)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(cat_info))
-            _rv2 = asyncio.ensure_future(self.async_mock(update_result))
-            _rv3 = asyncio.ensure_future(self.async_mock(read_val))
-            _rv4 = asyncio.ensure_future(self.async_mock(None))
-
+        _rv1 = await self.async_mock(cat_info)
+        _rv2 = await self.async_mock(update_result)
+        _rv3 = await self.async_mock(read_val)
+        _rv4 = await self.async_mock(None)
         with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_all_items:
             with patch.object(c_mgr._storage, 'update_tbl', return_value=_rv2) as patch_update:
                 with patch.object(c_mgr, '_read_category_val', return_value=_rv3) as patch_read_val:
@@ -3952,15 +3564,8 @@ class TestConfigurationManager:
         new_storage_value_entry = {'readonly': 'true', 'type': 'string', 'order': '4', 'description': 'Test Optional', 'minimum': '2', 'value': '13', 'maximum': new_value_entry, 'default': '13'}
         payload = {"return": ["key", "description", {"column": "ts", "format": "YYYY-MM-DD HH24:MI:SS.MS"}, "value"], "json_properties": [{"column": "value", "path": [item_name, optional_key_name], "value": new_value_entry}], "where": {"column": "key", "condition": "=", "value": category_name}}
         update_result = {"response": "updated", "rows_affected": 1}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _se = await self.async_mock(storage_value_entry)
-            _rv = await self.async_mock(update_result)
-        else:
-            _se = asyncio.ensure_future(self.async_mock(storage_value_entry))
-            _rv = asyncio.ensure_future(self.async_mock(update_result))
-        
+        _se = await self.async_mock(storage_value_entry)
+        _rv = await self.async_mock(update_result)
         with patch.object(ConfigurationManager, '_read_item_val', side_effect=[_se, _se]) as readpatch:
             with patch.object(c_mgr._storage, 'update_tbl', return_value=_rv) as patch_update:
                 await c_mgr.set_optional_value_entry(category_name, item_name, optional_key_name, new_value_entry)
@@ -4021,13 +3626,7 @@ class TestConfigurationManager:
                                'description': 'Test Optional', 'minimum': minimum, 'value': '13', 'maximum': maximum,
                                'default': '13', 'validity': 'field X is set', 'mandatory': 'false', 'group': 'Security',
                                'properties': {"key": "model"}}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(storage_value_entry)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(storage_value_entry))
-        
+        _rv = await self.async_mock(storage_value_entry)
         with patch.object(_logger, "exception") as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=_rv) as readpatch:
                 with pytest.raises(Exception) as excinfo:

--- a/tests/unit/python/fledge/common/test_statistics.py
+++ b/tests/unit/python/fledge/common/test_statistics.py
@@ -6,8 +6,6 @@
 
 import asyncio
 import json
-import sys
-
 from unittest.mock import MagicMock, patch
 import pytest
 
@@ -36,12 +34,7 @@ class TestStatistics:
             await asyncio.sleep(0)
             return ""
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(statistics.Statistics, '_load_keys', return_value=_rv):
             s = await statistics.create_statistics(storage_client_mock)
             assert isinstance(s, statistics.Statistics)
@@ -54,12 +47,7 @@ class TestStatistics:
         async def mock_coro():
             return ""
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(statistics.Statistics, '_load_keys', return_value=_rv):
             storageMock1 = MagicMock(spec=StorageClientAsync)
             s1 = await statistics.create_statistics(storageMock1)
@@ -78,12 +66,7 @@ class TestStatistics:
             await asyncio.sleep(0)
             return {"response": "updated", "rows_affected": 1}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(stats, '_load_keys', return_value=_rv):
             with patch.object(stats._storage, 'insert_into_tbl', return_value=_rv) as stat_update:
                 await stats.register('T1Stat', 'Test stat')
@@ -105,12 +88,7 @@ class TestStatistics:
         async def mock_coro():
             return {"response": "updated", "rows_affected": 1}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(stats, '_load_keys', return_value=_rv):
             with patch.object(stats._storage, 'insert_into_tbl', return_value=_rv) as stat_insert:
                 await stats.register('T2Stat', 'Test stat')
@@ -139,12 +117,8 @@ class TestStatistics:
         async def mock_coro():
             return {'rows': [{"previous_value": 0, "value": 1,
                               "key": "K1", "description": "desc1"}]}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        
+        _rv = await mock_coro()
         with patch.object(s._storage, 'query_tbl_with_payload', return_value=_rv) as patch_query_tbl:
             await s._load_keys()
             assert "K1" in s._registered_keys
@@ -159,12 +133,7 @@ class TestStatistics:
         async def mock_coro():
             return Exception
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(statistics._logger, 'exception') as logger_exception:
             with patch.object(s._storage, 'query_tbl_with_payload', return_value=_rv):
                 await s._load_keys()
@@ -178,12 +147,7 @@ class TestStatistics:
         async def mock_coro():
             return {"response": "updated", "rows_affected": 1}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         payload = '{"where": {"column": "key", "condition": "=", "value": "READING"}, ' \
                   '"expressions": [{"column": "value", "operator": "+", "value": 5}]}'
         expected_result = {"response": "updated", "rows_affected": 1}
@@ -228,12 +192,7 @@ class TestStatistics:
         async def mock_coro():
             return {"response": "updated", "rows_affected": 1}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(s._storage, 'update_tbl', return_value=_rv) as stat_update:
             await s.add_update(stat_dict)
         stat_update.assert_called_once_with('statistics', payload)
@@ -246,12 +205,7 @@ class TestStatistics:
         async def mock_coro():
             return {"response": "not updated", "rows_affected": 0}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(s._storage, 'update_tbl', return_value=_rv) as stat_update:
             with patch.object(statistics._logger, 'exception') as logger_exception:
                 with pytest.raises(KeyError):

--- a/tests/unit/python/fledge/services/core/api/control_service/test_acl_management.py
+++ b/tests/unit/python/fledge/services/core/api/control_service/test_acl_management.py
@@ -1,6 +1,4 @@
-import asyncio
 import json
-import sys
 from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
@@ -38,7 +36,7 @@ class TestACLManagement:
              'url': [{'url': '/fledge/south/operation', 'acl': [{'type': 'Southbound'}]}]},
             {'name': 'testACL', 'service': [], 'url': []}]}
         payload = {"return": ["name", "service", "url"]}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=value) as patch_query_tbl:
                 resp = await client.get('/fledge/ACL')
@@ -55,7 +53,7 @@ class TestACLManagement:
         result = {"count": 0, "rows": []}
         payload = {"return": ["name", "service", "url"], "where": {"column": "name", "condition": "=",
                                                                    "value": acl_name}}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         message = "ACL with name {} is not found.".format(acl_name)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=value) as patch_query_tbl:
@@ -77,7 +75,7 @@ class TestACLManagement:
              'url': [{'url': '/fledge/south/operation', 'acl': [{'type': 'Southbound'}]}]}]}
         payload = {"return": ["name", "service", "url"], "where": {"column": "name", "condition": "=",
                                                                    "value": acl_name}}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=value) as patch_query_tbl:
                 resp = await client.get('/fledge/ACL/{}'.format(acl_name))
@@ -142,7 +140,7 @@ class TestACLManagement:
         result = {'count': 1, 'rows': [
             {'name': acl_name, 'service': [{'name': 'Fledge Storage'}, {'type': 'Southbound'}],
              'url': [{'url': '/fledge/south/operation', 'acl': [{'type': 'Southbound'}]}]}]}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": acl_name}}
         message = "ACL with name {} already exists.".format(acl_name)
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -164,14 +162,9 @@ class TestACLManagement:
         result = {"count": 0, "rows": []}
         insert_result = {"response": "inserted", "rows_affected": 1}
         acl_query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": acl_name}}
-        if sys.version_info >= (3, 8):
-            value = await mock_coro(result)
-            insert_value = await mock_coro(insert_result)
-            _rv = await mock_coro(None)
-        else:
-            value = asyncio.ensure_future(mock_coro(result))
-            insert_value = asyncio.ensure_future(mock_coro(insert_result))
-            _rv = asyncio.ensure_future(mock_coro(None))
+        value = await mock_coro(result)
+        insert_value = await mock_coro(insert_result)
+        _rv = await mock_coro(None)
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=value) as query_tbl_patch:
@@ -249,7 +242,7 @@ class TestACLManagement:
         acl_name = "testACL"
         req_payload = {"service": [{"type": "Notification"}]}
         result = {"count": 0, "rows": []}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         query_payload = {"return": ["name", "service", "url"], "where": {
             "column": "name", "condition": "=", "value": acl_name}}
         message = "ACL with name {} is not found.".format(acl_name)
@@ -280,12 +273,8 @@ class TestACLManagement:
         update_result = {"response": "updated", "rows_affected": 1}
         query_tbl_result = {"count": 1, "rows": [{"name": acl_name, "service": [], "url": []}]}
         query_payload = {"return": ["name", "service", "url"], "where": {"column": "name", "condition": "=", "value": acl_name}}
-        if sys.version_info >= (3, 8):
-            arv = await mock_coro(None)
-            update_value = await mock_coro(update_result)
-        else:
-            arv = asyncio.ensure_future(mock_coro(None))
-            update_value = asyncio.ensure_future(mock_coro(update_result))
+        arv = await mock_coro(None)
+        update_value = await mock_coro(update_result)
         storage_client_mock = MagicMock(StorageClientAsync)
         acl_query_payload_service = {"return": ["entity_name"],
                                      "where": {"column": "entity_type", "condition": "=", "value": "service",
@@ -326,7 +315,7 @@ class TestACLManagement:
     async def test_delete_acl_not_found(self, client):
         acl_name = "test"
         result = {"count": 0, "rows": []}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": acl_name}}
         message = "ACL with name {} is not found.".format(acl_name)
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -352,13 +341,8 @@ class TestACLManagement:
         delete_payload = {"where": {"column": "name", "condition": "=", "value": acl_name}}
         delete_result = {"response": "deleted", "rows_affected": 1}
         message = '{} ACL deleted successfully.'.format(acl_name)
-        if sys.version_info >= (3, 8):
-            del_value = await mock_coro(delete_result)
-            arv = await mock_coro(None)
-        else:
-            del_value = asyncio.ensure_future(mock_coro(delete_result))
-            arv = asyncio.ensure_future(mock_coro(None))
-
+        del_value = await mock_coro(delete_result)
+        arv = await mock_coro(None)
         acl_query_payload_service = {"return": ["entity_name"], "where": {"column": "entity_type",
                                                                           "condition": "=",
                                                                           "value": "service",
@@ -408,7 +392,7 @@ class TestACLManagement:
         svc_name = 'foo'
         result = {"count": 0, "rows": []}
         payload = {"acl_name": "testACL"}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         storage_client_mock = MagicMock(StorageClientAsync)
         message = "Schedule with name {} is not found.".format(svc_name)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -431,7 +415,7 @@ class TestACLManagement:
     async def test_bad_attach_acl_to_service(self, client, payload, message):
         svc_name = 'foo'
         result = {"count": 1, "rows": [{"id": "3e84f179-874d-4a91-a524-15512172f8a2", "enabled": "true"}]}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=value) as query_tbl_patch:
@@ -508,8 +492,7 @@ class TestACLManagement:
                             "displayName": "Service ACL", "default": "[]", "value": "[]"
                         }
                 }
-        cat_value = await mock_coro(cat_info) if sys.version_info >= (3, 8) else \
-            asyncio.ensure_future(mock_coro(cat_info))
+        cat_value = await mock_coro(cat_info)
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -549,15 +532,9 @@ class TestACLManagement:
             else:
                 return {}
 
-        if sys.version_info >= (3, 8):
-            cat_value = await mock_coro(None)
-            cat_child_value = await mock_coro(cat_child_result)
-            update_bulk_value = await mock_coro(None)
-        else:
-            cat_value = asyncio.ensure_future(mock_coro(None))
-            cat_child_value = asyncio.ensure_future(mock_coro(cat_child_result))
-            update_bulk_value = asyncio.ensure_future(mock_coro(None))
-
+        cat_value = await mock_coro(None)
+        cat_child_value = await mock_coro(cat_child_result)
+        update_bulk_value = await mock_coro(None)
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -583,7 +560,7 @@ class TestACLManagement:
         svc_name = 'foo'
         result = {"count": 0, "rows": []}
         payload = {"acl_name": "testACL"}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         storage_client_mock = MagicMock(StorageClientAsync)
         message = "Schedule with name {} is not found.".format(svc_name)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -603,12 +580,8 @@ class TestACLManagement:
         sch_query_payload = {"where": {"column": "schedule_name", "condition": "=", "value": svc_name}}
         sch_result = {"count": 1, "rows": [{"id": "3e84f179-874d-4a91-a524-15512172f8a2", "enabled": "true"}]}
         message = "Nothing to delete as there is no ACL attached with {} service.".format(svc_name)
-        if sys.version_info >= (3, 8):
-            cat_value = await mock_coro(None)
-            sch_value = await mock_coro(sch_result)
-        else:
-            cat_value = asyncio.ensure_future(mock_coro(None))
-            sch_value = asyncio.ensure_future(mock_coro(sch_result))
+        cat_value = await mock_coro(None)
+        sch_value = await mock_coro(sch_result)
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -646,15 +619,9 @@ class TestACLManagement:
         cat_result = {"a": 1}
         message = "ACL is detached from {} service successfully.".format(svc_name)
         acl_dict = {'ACL': ''}
-
-        if sys.version_info >= (3, 8):
-            cat_value = await mock_coro(cat_result)
-            sch_value = await mock_coro(sch_result)
-            update_bulk_value = await mock_coro(None)
-        else:
-            cat_value = asyncio.ensure_future(mock_coro(cat_result))
-            sch_value = asyncio.ensure_future(mock_coro(sch_result))
-            update_bulk_value = asyncio.ensure_future(mock_coro(None))
+        cat_value = await mock_coro(cat_result)
+        sch_value = await mock_coro(sch_result)
+        update_bulk_value = await mock_coro(None)
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):

--- a/tests/unit/python/fledge/services/core/api/control_service/test_entrypoint.py
+++ b/tests/unit/python/fledge/services/core/api/control_service/test_entrypoint.py
@@ -1,6 +1,4 @@
-import asyncio
 import json
-import sys
 
 from unittest.mock import MagicMock, patch
 import pytest
@@ -44,8 +42,7 @@ class TestEntrypoint:
         expected_api_response = {"controls": [{"name": "EP1", "description": "EP1", "permitted": True},
                                               {"name": "EP2", "description": "Ep2", "permitted": True},
                                               {"name": "EP3", "description": "EP3", "permitted": True}]}
-        rv = await mock_coro(storage_result) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(storage_result))
+        rv = await mock_coro(storage_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=rv) as patch_query_tbl:
                 resp = await client.get('/fledge/control/manage')
@@ -79,12 +76,8 @@ class TestEntrypoint:
         storage_result = {'name': ep_name, 'description': 'EP1', 'type': 'operation', 'operation_name': 'OP1',
                           'destination': 'broadcast', 'anonymous': True, 'constants': {'x': '640', 'y': '480'},
                           'variables': {'rpm': '800', 'distance': '138'}, 'allow': ['admin', 'user']}
-        if sys.version_info >= (3, 8):
-            rv1 = await mock_coro(storage_result)
-            rv2 = await mock_coro(True)
-        else:
-            rv1 = asyncio.ensure_future(mock_coro(storage_result))
-            rv2 = asyncio.ensure_future(mock_coro(True))
+        rv1 = await mock_coro(storage_result)
+        rv2 = await mock_coro(True)
         with patch.object(entrypoint, '_get_entrypoint', return_value=rv1) as patch_entrypoint:
             with patch.object(entrypoint, '_get_permitted', return_value=rv2) as patch_permitted:
                 resp = await client.get('/fledge/control/manage/{}'.format(ep_name))
@@ -102,8 +95,7 @@ class TestEntrypoint:
                    "variables": {"rpm": "100"}, "allow": [], "anonymous": False}
         storage_client_mock = MagicMock(StorageClientAsync)
         storage_result = {"count": 1, "rows": [{"name": ep_name}]}
-        rv = await mock_coro(storage_result) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(storage_result))
+        rv = await mock_coro(storage_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=rv) as patch_query_tbl:
                 resp = await client.post('/fledge/control/manage', data=json.dumps(payload))
@@ -141,12 +133,8 @@ class TestEntrypoint:
                 pass
             return insert_result
 
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(storage_result)
-            arv = await mock_coro(None)
-        else:
-            rv = asyncio.ensure_future(mock_coro(storage_result))
-            arv = asyncio.ensure_future(mock_coro(None))
+        rv = await mock_coro(storage_result)
+        arv = await mock_coro(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=rv) as patch_query_tbl:
                 with patch.object(storage_client_mock, 'insert_into_tbl', side_effect=i_result
@@ -169,8 +157,7 @@ class TestEntrypoint:
         payload = {"where": {"column": "name", "condition": "=", "value": ep_name}}
         storage_client_mock = MagicMock(StorageClientAsync)
         storage_result = {"count": 0, "rows": []}
-        rv = await mock_coro(storage_result) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(storage_result))
+        rv = await mock_coro(storage_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=rv
                               ) as patch_query_tbl:
@@ -201,18 +188,11 @@ class TestEntrypoint:
         update_payload = ('{"values": {"description": "Updated"}, '
                           '"where": {"column": "name", "condition": "=", "value": "SetLatheSpeed"}}')
         update_result = {"response": "updated", "rows_affected": 1}
-        if sys.version_info >= (3, 8):
-            rv1 = await mock_coro(storage_result)
-            rv2 = await mock_coro(ep_info)
-            rv3 = await mock_coro(new_ep_info)
-            rv4 = await mock_coro(update_result)
-            arv = await mock_coro(None)
-        else:
-            rv1 = asyncio.ensure_future(mock_coro(storage_result))
-            arv = asyncio.ensure_future(mock_coro(None))
-            rv2 = asyncio.ensure_future(mock_coro(ep_info))
-            rv3 = asyncio.ensure_future(mock_coro(new_ep_info))
-            rv4 = asyncio.ensure_future(mock_coro(update_result))
+        rv1 = await mock_coro(storage_result)
+        rv2 = await mock_coro(ep_info)
+        rv3 = await mock_coro(new_ep_info)
+        rv4 = await mock_coro(update_result)
+        arv = await mock_coro(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=rv1
                               ) as patch_query_tbl:
@@ -240,8 +220,7 @@ class TestEntrypoint:
         payload = {"where": {"column": "name", "condition": "=", "value": ep_name}}
         storage_client_mock = MagicMock(StorageClientAsync)
         storage_result = {"count": 0, "rows": []}
-        rv = await mock_coro(storage_result) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(storage_result))
+        rv = await mock_coro(storage_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=rv
                               ) as patch_query_tbl:
@@ -263,14 +242,9 @@ class TestEntrypoint:
              'destination': 'broadcast', 'anonymous': True, 'constants': {'x': '640', 'y': '480'},
              'variables': {'rpm': '800', 'distance': '138'}, 'allow': ['admin', 'user']}]}
         message = "{} control entrypoint has been deleted successfully.".format(ep_name)
-        if sys.version_info >= (3, 8):
-            rv1 = await mock_coro(storage_result)
-            rv2 = await mock_coro(None)
-            arv = await mock_coro(None)
-        else:
-            rv1 = asyncio.ensure_future(mock_coro(storage_result))
-            rv2 = asyncio.ensure_future(mock_coro(None))
-            arv = asyncio.ensure_future(mock_coro(None))
+        rv1 = await mock_coro(storage_result)
+        rv2 = await mock_coro(None)
+        arv = await mock_coro(None)
         storage_client_mock = MagicMock(StorageClientAsync)
         del_payload = {"where": {"column": "name", "condition": "=", "value": ep_name}}
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -334,15 +308,9 @@ class TestEntrypoint:
         svc_info = (ServiceRecord("d607c5be-792f-4993-96b7-b513674e7d3b",
                                   ep_name, "Dispatcher", "http", "127.0.0.1", "8118", "8118"), "Token")
 
-        if sys.version_info >= (3, 8):
-            rv1 = await mock_coro(storage_result)
-            rv2 = await mock_coro(svc_info)
-            rv3 = await mock_coro(None)
-        else:
-            rv1 = asyncio.ensure_future(mock_coro(storage_result))
-            rv2 = asyncio.ensure_future(mock_coro(svc_info))
-            rv3 = asyncio.ensure_future(mock_coro(None))
-
+        rv1 = await mock_coro(storage_result)
+        rv2 = await mock_coro(svc_info)
+        rv3 = await mock_coro(None)
         with patch.object(entrypoint, '_get_entrypoint', return_value=rv1):
             with patch.object(entrypoint, '_get_service_record_info_along_with_bearer_token',
                               return_value=rv2) as patch_service:
@@ -398,8 +366,7 @@ class TestEntrypoint:
         is_constant = 't'
         storage_client_mock = MagicMock(StorageClientAsync)
         rows_affected = {"response": "updated", "rows_affected": 1}
-        rv = await mock_coro(rows_affected) if sys.version_info >= (3, 8) else (
-            asyncio.ensure_future(mock_coro(rows_affected)))
+        rv = await mock_coro(rows_affected)
         tbl_name = 'control_api_parameters'
         delete_payload = {"where": {"column": "name", "condition": "=", "value": ep_name,
                                     "and": {"column": "constant", "condition": "=", "value": "t",
@@ -433,14 +400,9 @@ class TestEntrypoint:
              'constants': {}, 'variables': {},
              'allow': []}]}
         storage_result2 = {"count": 0, "rows": []}
-        if sys.version_info >= (3, 8):
-            rv1 = await mock_coro(storage_result1)
-            rv2 = await mock_coro(storage_result2)
-            rv3 = await mock_coro(storage_result2)
-        else:
-            rv1 = asyncio.ensure_future(mock_coro(storage_result1))
-            rv2 = asyncio.ensure_future(mock_coro(storage_result2))
-            rv3 = asyncio.ensure_future(mock_coro(storage_result2))
+        rv1 = await mock_coro(storage_result1)
+        rv2 = await mock_coro(storage_result2)
+        rv3 = await mock_coro(storage_result2)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', side_effect=[rv1, rv2, rv3]
                               ) as patch_query_tbl:

--- a/tests/unit/python/fledge/services/core/api/control_service/test_pipeline.py
+++ b/tests/unit/python/fledge/services/core/api/control_service/test_pipeline.py
@@ -1,6 +1,4 @@
-import asyncio
 import json
-import sys
 
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
@@ -60,8 +58,7 @@ class TestPipeline:
     ])
     async def test_get_lookup(self, client, request_param):
         storage_result = {"controlLookup": {"source": [], "destination": []}}
-        rv = await mock_coro(storage_result) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(storage_result))
+        rv = await mock_coro(storage_result)
         with patch.object(pipeline, '_get_all_lookups', return_value=rv) as patch_lookup:
             resp = await client.get('/fledge/control/lookup{}'.format(request_param))
             assert 200 == resp.status
@@ -90,14 +87,9 @@ class TestPipeline:
         storage_client_mock = MagicMock(StorageClientAsync)
         storage_result = {'count': 0, 'rows': []}
         expected_api_response = {"pipelines": []}
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(storage_result)
-            source_lookup = await mock_coro([])
-            dest_lookup = await mock_coro([])
-        else:
-            rv = asyncio.ensure_future(mock_coro(storage_result))
-            source_lookup = asyncio.ensure_future(mock_coro([]))
-            dest_lookup = asyncio.ensure_future(mock_coro([]))
+        rv = await mock_coro(storage_result)
+        source_lookup = await mock_coro([])
+        dest_lookup = await mock_coro([])
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=rv) as patch_query_tbl:
                 with patch.object(pipeline, '_get_all_lookups', side_effect=[source_lookup, dest_lookup]):
@@ -122,17 +114,10 @@ class TestPipeline:
                                                 'execution': 'Exclusive', 'filters': []}]}
 
         filters_storage_result = {'count': 0, 'rows': []}
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(storage_result)
-            source_lookup = await mock_coro(SOURCE_LOOKUP)
-            dest_lookup = await mock_coro(DESTINATION_LOOKUP)
-            filters = await mock_coro(filters_storage_result)
-        else:
-            rv = asyncio.ensure_future(mock_coro(storage_result))
-            source_lookup = asyncio.ensure_future(mock_coro(SOURCE_LOOKUP))
-            dest_lookup = asyncio.ensure_future(mock_coro(DESTINATION_LOOKUP))
-            filters = asyncio.ensure_future(mock_coro(filters_storage_result))
-
+        rv = await mock_coro(storage_result)
+        source_lookup = await mock_coro(SOURCE_LOOKUP)
+        dest_lookup = await mock_coro(DESTINATION_LOOKUP)
+        filters = await mock_coro(filters_storage_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=rv) as patch_query_tbl:
                 with patch.object(pipeline, '_get_all_lookups', side_effect=[source_lookup, dest_lookup]):
@@ -171,8 +156,7 @@ class TestPipeline:
         cpid = 1
         storage_result = {'id': cpid, 'name': 'Cp1', 'source': {'type': 'Any', 'name': ''}, 'destination': {
             'type': 'Broadcast', 'name': ''}, 'enabled': True, 'execution': 'Shared', 'filters': []}
-        rv = await mock_coro(storage_result) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(storage_result))
+        rv = await mock_coro(storage_result)
         with patch.object(pipeline, '_get_pipeline', return_value=rv) as patch_pipeline:
             resp = await client.get('/fledge/control/pipeline/{}'.format(cpid))
             assert 200 == resp.status
@@ -216,20 +200,12 @@ class TestPipeline:
                              'source': {'type': 'Any', 'name': ''}, 'destination': {'type': 'Any', 'name': ''},
                              'filters': []}
         storage_client_mock = MagicMock(StorageClientAsync)
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(columns)
-            rv2 = await mock_coro(insert_result)
-            rv3 = await mock_coro(in_use)
-            rv4 = await mock_coro("Any")
-            rv5 = await mock_coro("Any")
-            rv6 = await mock_coro(None)
-        else:
-            rv = asyncio.ensure_future(mock_coro(columns))
-            rv2 = asyncio.ensure_future(mock_coro(insert_result))
-            rv3 = asyncio.ensure_future(mock_coro(in_use))
-            rv4 = asyncio.ensure_future(mock_coro("Any"))
-            rv5 = asyncio.ensure_future(mock_coro("Any"))
-            rv6 = asyncio.ensure_future(mock_coro(None))
+        rv = await mock_coro(columns)
+        rv2 = await mock_coro(insert_result)
+        rv3 = await mock_coro(in_use)
+        rv4 = await mock_coro("Any")
+        rv5 = await mock_coro("Any")
+        rv6 = await mock_coro(None)
         with patch.object(pipeline, '_check_parameters', return_value=rv) as patch_params:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(storage_client_mock, 'insert_into_tbl', return_value=rv2) as patch_insert_tbl:
@@ -283,18 +259,11 @@ class TestPipeline:
         rows_affected = {"response": "updated", "rows_affected": 1}
         update_pipeline = {'id': cpid, 'name': 'Cp1', 'source': {'type': 'API', 'name': ''}, 'destination': {
             'type': 'Any', 'name': ''}, 'enabled': True, 'execution': 'Shared', 'filters': []}
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(storage_result)
-            rv2 = await mock_coro(columns)
-            rv3 = await mock_coro(rows_affected)
-            rv4 = await mock_coro(None)
-            rv5 = await mock_coro(update_pipeline)
-        else:
-            rv = asyncio.ensure_future(mock_coro(storage_result))
-            rv2 = asyncio.ensure_future(mock_coro(columns))
-            rv3 = asyncio.ensure_future(mock_coro(rows_affected))
-            rv4 = asyncio.ensure_future(mock_coro(None))
-            rv5 = asyncio.ensure_future(mock_coro(update_pipeline))
+        rv = await mock_coro(storage_result)
+        rv2 = await mock_coro(columns)
+        rv3 = await mock_coro(rows_affected)
+        rv4 = await mock_coro(None)
+        rv5 = await mock_coro(update_pipeline)
         with patch.object(pipeline, '_get_pipeline', side_effect=[rv, rv5]) as patch_pipeline:
             with patch.object(pipeline, '_check_parameters', return_value=rv2) as patch_params:
                 with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -346,14 +315,9 @@ class TestPipeline:
         rows_affected = {"response": "deleted", "rows_affected": 1}
         message = {'message': 'Control Pipeline with ID:<{}> has been deleted successfully.'.format(cpid),
                    'name': storage_result['name']}
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(storage_result)
-            rv2 = await mock_coro(None)
-            rv3 = await mock_coro(rows_affected)
-        else:
-            rv = asyncio.ensure_future(mock_coro(storage_result))
-            rv2 = asyncio.ensure_future(mock_coro(None))
-            rv3 = asyncio.ensure_future(mock_coro(rows_affected))
+        rv = await mock_coro(storage_result)
+        rv2 = await mock_coro(None)
+        rv3 = await mock_coro(rows_affected)
         with patch.object(pipeline, '_get_pipeline', return_value=rv) as patch_pipeline:
             with patch.object(pipeline, '_remove_filters', return_value=rv2) as patch_filters:
                 with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -395,12 +359,8 @@ class TestPipeline:
 
     async def test__get_all_lookups(self):
         storage_client_mock = MagicMock(StorageClientAsync)
-        if sys.version_info >= (3, 8):
-            source_lookup = await mock_coro({"rows": SOURCE_LOOKUP})
-            dest_lookup = await mock_coro({"rows": DESTINATION_LOOKUP})
-        else:
-            source_lookup = asyncio.ensure_future(mock_coro({"rows": SOURCE_LOOKUP}))
-            dest_lookup = asyncio.ensure_future(mock_coro({"rows": DESTINATION_LOOKUP}))
+        source_lookup = await mock_coro({"rows": SOURCE_LOOKUP})
+        dest_lookup = await mock_coro({"rows": DESTINATION_LOOKUP})
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl',
                               side_effect=[source_lookup, dest_lookup]) as patch_query:
@@ -420,8 +380,7 @@ class TestPipeline:
     async def test__get_all_lookups_by_table(self, name):
         storage_client_mock = MagicMock(StorageClientAsync)
         storage_result = {"rows": SOURCE_LOOKUP} if name == "control_source" else {"rows": DESTINATION_LOOKUP}
-        lookup = await mock_coro(storage_result) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(storage_result))
+        lookup = await mock_coro(storage_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=lookup) as patch_query:
                 res = await pipeline._get_all_lookups(name)
@@ -438,8 +397,7 @@ class TestPipeline:
     ])
     async def test__get_table_column_by_value(self, tbl_name, column_name, column_value, limit):
         storage_client_mock = MagicMock(StorageClientAsync)
-        lookup = await mock_coro({"rows": []}) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro({"rows": []}))
+        lookup = await mock_coro({"rows": []})
         payload = {"where": {"column": column_name, "condition": "=", "value": column_value}}
         if tbl_name == "control_filters":
             payload["sort"] = {"column": "forder", "direction": "asc"}
@@ -459,8 +417,7 @@ class TestPipeline:
 
     async def test_bad__get_pipeline(self):
         cpid = 3
-        rv = await mock_coro({"rows": []}) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro({"rows": []}))
+        rv = await mock_coro({"rows": []})
         with pytest.raises(Exception) as exc_info:
             with patch.object(pipeline, '_get_table_column_by_value', return_value=rv):
                 await pipeline._get_pipeline(cpid, False)
@@ -471,12 +428,8 @@ class TestPipeline:
         cpid = 3
         result = {"rows": [{"cpid": cpid, "name": "CP-3", "stype": 1, "sname": "", "dtype": 5, "dname": "",
                             "enabled": "t", "execution": "Shared"}]}
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(result)
-            rv2 = await mock_coro("Any")
-        else:
-            rv = asyncio.ensure_future(mock_coro(result))
-            rv2 = asyncio.ensure_future(mock_coro("Any"))
+        rv = await mock_coro(result)
+        rv2 = await mock_coro("Any")
         with patch.object(pipeline, '_get_table_column_by_value', return_value=rv) as patch_tbl:
             with patch.object(pipeline, '_get_lookup_value', return_value=rv2) as patch_lookup:
                 res = await pipeline._get_pipeline(cpid, False)
@@ -510,7 +463,7 @@ class TestPipeline:
         name = "Modbus"
         result = {"rows": [{"cpid": 2, "name": name, "stype": 1, "sname": "", "dtype": 5, "dname": "",
                             "enabled": "t", "execution": "Shared"}]}
-        rv = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        rv = await mock_coro(result)
         with patch.object(pipeline, '_get_table_column_by_value', return_value=rv) as patch_tbl:
             res = await pipeline._pipeline_in_use(name, source, dest, info)
             assert res == result['rows'][0] if info_output else res == info_output if info else res is matched
@@ -524,8 +477,7 @@ class TestPipeline:
     ])
     async def test__get_lookup_value(self, _type, value, name):
         storage_result = SOURCE_LOOKUP if _type == "source" else DESTINATION_LOOKUP
-        lookup = await mock_coro(storage_result) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(storage_result))
+        lookup = await mock_coro(storage_result)
         with patch.object(pipeline, '_get_all_lookups', return_value=lookup) as patch_lookup:
             res = await pipeline._get_lookup_value(_type, value)
             assert name == res
@@ -578,12 +530,8 @@ class TestPipeline:
         req_mock = MagicMock(web.Request)
         storage_result = {"count": 0, "rows": []}
         res = "" if error_msg.endswith("type found.") else "Any"
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(storage_result)
-            rv2 = await mock_coro(res)
-        else:
-            rv = asyncio.ensure_future(mock_coro(storage_result))
-            rv2 = asyncio.ensure_future(mock_coro(res))
+        rv = await mock_coro(storage_result)
+        rv2 = await mock_coro(res)
         with pytest.raises(Exception) as exc_info:
             with patch.object(pipeline, '_check_unique_pipeline', return_value=rv) as patch_unique_pipeline:
                 with patch.object(pipeline, '_get_lookup_value', return_value=rv2) as patch_lookup_value:
@@ -634,14 +582,9 @@ class TestPipeline:
         server.Server.scheduler = Scheduler(None, None)
         req_mock = MagicMock(web.Request)
         storage_result = {"count": 0, "rows": []}
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(storage_result)
-            rv2 = await mock_coro("service")
-            rv3 = await mock_schedule(service_name)
-        else:
-            rv = asyncio.ensure_future(mock_coro(storage_result))
-            rv2 = asyncio.ensure_future(mock_coro("service"))
-            rv3 = asyncio.ensure_future(mock_schedule(service_name))
+        rv = await mock_coro(storage_result)
+        rv2 = await mock_coro("service")
+        rv3 = await mock_schedule(service_name)
         with pytest.raises(Exception) as exc_info:
             with patch.object(pipeline, '_check_unique_pipeline', return_value=rv) as patch_unique_pipeline:
                 with patch.object(pipeline, '_get_lookup_value', return_value=rv2) as patch_lookup_value:
@@ -663,8 +606,7 @@ class TestPipeline:
     async def test__validate_lookup_name_script(self, lookup, _type, value):
         storage_client_mock = MagicMock(StorageClientAsync)
         storage_result = {"rows": [{"name": "S1"}, {"name": "S2"}]}
-        rv = await mock_coro(storage_result) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(storage_result))
+        rv = await mock_coro(storage_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=rv) as patch_query:
                 with pytest.raises(Exception) as exc_info:
@@ -676,8 +618,7 @@ class TestPipeline:
     async def test__validate_lookup_name_asset(self, lookup="destination", _type=3, value="sinusoid"):
         storage_client_mock = MagicMock(StorageClientAsync)
         storage_result = {"rows": [{"asset": "S1", "event": "Ingest"}, {"asset": "S2", "event": "Egress"}]}
-        rv = await mock_coro(storage_result) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(storage_result))
+        rv = await mock_coro(storage_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=rv) as patch_query:
                 with pytest.raises(Exception) as exc_info:
@@ -690,8 +631,7 @@ class TestPipeline:
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         storage_result = [{"child": ["N"]}]
-        rv = await mock_coro(storage_result) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(storage_result))
+        rv = await mock_coro(storage_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, '_read_all_child_category_names', return_value=rv) as patch_get_all_items:
                 with pytest.raises(Exception) as exc_info:
@@ -724,7 +664,7 @@ class TestPipeline:
 
         server.Server.scheduler = Scheduler(None, None)
         storage_client_mock = MagicMock(StorageClientAsync)
-        get_sch = await mock_schedule() if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_schedule())
+        get_sch = await mock_schedule()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(server.Server.scheduler, 'get_schedules', return_value=get_sch
                               ) as patch_get_schedules:
@@ -737,8 +677,7 @@ class TestPipeline:
 
     async def test__check_unique_pipeline(self):
         name = "Cp"
-        rv = await mock_coro({"rows": [1]}) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro({"rows": [1]}))
+        rv = await mock_coro({"rows": [1]})
         with patch.object(pipeline, '_get_table_column_by_value', return_value=rv) as patch_tbl_col:
             with pytest.raises(Exception) as exc_info:
                 await pipeline._check_unique_pipeline(name)
@@ -770,24 +709,14 @@ class TestPipelineFilters:
                              'source': {'type': 'Any', 'name': ''}, 'destination': {'type': 'Any', 'name': ''},
                              'filters': ["Filter1"]}
         storage_client_mock = MagicMock(StorageClientAsync)
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(columns)
-            rv2 = await mock_coro(insert_result)
-            rv3 = await mock_coro(in_use)
-            rv4 = await mock_coro("Any")
-            rv5 = await mock_coro("Any")
-            rv6 = await mock_coro(None)
-            rv7 = await mock_coro(True)
-            rv8 = await mock_coro(["Filter1"])
-        else:
-            rv = asyncio.ensure_future(mock_coro(columns))
-            rv2 = asyncio.ensure_future(mock_coro(insert_result))
-            rv3 = asyncio.ensure_future(mock_coro(in_use))
-            rv4 = asyncio.ensure_future(mock_coro("Any"))
-            rv5 = asyncio.ensure_future(mock_coro("Any"))
-            rv6 = asyncio.ensure_future(mock_coro(None))
-            rv7 = asyncio.ensure_future(mock_coro(True))
-            rv8 = asyncio.ensure_future(mock_coro(["Filter1"]))
+        rv = await mock_coro(columns)
+        rv2 = await mock_coro(insert_result)
+        rv3 = await mock_coro(in_use)
+        rv4 = await mock_coro("Any")
+        rv5 = await mock_coro("Any")
+        rv6 = await mock_coro(None)
+        rv7 = await mock_coro(True)
+        rv8 = await mock_coro(["Filter1"])
         with patch.object(pipeline, '_check_parameters', return_value=rv) as patch_params:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(storage_client_mock, 'insert_into_tbl', return_value=rv2) as patch_insert_tbl:
@@ -830,22 +759,13 @@ class TestPipelineFilters:
         update_pipeline = {'id': cpid, 'name': 'Cp1', 'source': {'type': 'API', 'name': ''}, 'destination': {
             'type': 'Any', 'name': ''}, 'enabled': True, 'execution': 'Shared', 'filters': []}
         filters = {"rows": [{"fname": "Filter1"}]}
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(storage_result)
-            rv2 = await mock_coro(columns)
-            rv3 = await mock_coro(rows_affected)
-            rv4 = await mock_coro(None)
-            rv5 = await mock_coro(update_pipeline)
-            rv6 = await mock_coro(True)
-            rv7 = await mock_coro(filters)
-        else:
-            rv = asyncio.ensure_future(mock_coro(storage_result))
-            rv2 = asyncio.ensure_future(mock_coro(columns))
-            rv3 = asyncio.ensure_future(mock_coro(rows_affected))
-            rv4 = asyncio.ensure_future(mock_coro(None))
-            rv5 = asyncio.ensure_future(mock_coro(update_pipeline))
-            rv6 = asyncio.ensure_future(mock_coro(True))
-            rv7 = asyncio.ensure_future(mock_coro(filters))
+        rv = await mock_coro(storage_result)
+        rv2 = await mock_coro(columns)
+        rv3 = await mock_coro(rows_affected)
+        rv4 = await mock_coro(None)
+        rv5 = await mock_coro(update_pipeline)
+        rv6 = await mock_coro(True)
+        rv7 = await mock_coro(filters)
         with patch.object(pipeline, '_get_pipeline', side_effect=[rv, rv5]) as patch_pipeline:
             with patch.object(pipeline, '_check_parameters', return_value=rv2) as patch_params:
                 with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -889,16 +809,10 @@ class TestPipelineFilters:
         storage_client_mock = MagicMock(StorageClientAsync)
         rows_affected = {"response": "updated", "rows_affected": 1}
         error_message = "Filters do not exist as per the given list ['Filter1']"
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(storage_result)
-            rv2 = await mock_coro(columns)
-            rv3 = await mock_coro(rows_affected)
-            rv4 = await mock_coro(False)
-        else:
-            rv = asyncio.ensure_future(mock_coro(storage_result))
-            rv2 = asyncio.ensure_future(mock_coro(columns))
-            rv3 = asyncio.ensure_future(mock_coro(rows_affected))
-            rv4 = asyncio.ensure_future(mock_coro(False))
+        rv = await mock_coro(storage_result)
+        rv2 = await mock_coro(columns)
+        rv3 = await mock_coro(rows_affected)
+        rv4 = await mock_coro(False)
         with patch.object(pipeline, '_get_pipeline', return_value=rv) as patch_pipeline:
             with patch.object(pipeline, '_check_parameters', return_value=rv2) as patch_params:
                 with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -922,14 +836,9 @@ class TestPipelineFilters:
         cpid = 3
         result = {"rows": [{"cpid": cpid, "name": "CP-3", "stype": 1, "sname": "", "dtype": 5, "dname": "",
                             "enabled": "t", "execution": "Shared", "filters": ["Filter1"]}]}
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(result)
-            rv2 = await mock_coro("Any")
-            rv3 = await mock_coro({"rows": [{"fname": "Filter1"}]})
-        else:
-            rv = asyncio.ensure_future(mock_coro(result))
-            rv2 = asyncio.ensure_future(mock_coro("Any"))
-            rv3 = asyncio.ensure_future(mock_coro({"rows": [{"fname": "Filter1"}]}))
+        rv = await mock_coro(result)
+        rv2 = await mock_coro("Any")
+        rv3 = await mock_coro({"rows": [{"fname": "Filter1"}]})
         with patch.object(pipeline, '_get_table_column_by_value', side_effect=[rv, rv3]):
             with patch.object(pipeline, '_get_lookup_value', return_value=rv2) as patch_lookup:
                 res = await pipeline._get_pipeline(cpid, True)
@@ -955,8 +864,7 @@ class TestPipelineFilters:
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         delete_result = {'response': 'deleted', 'rows_affected': 1}
-        rv = await mock_coro(delete_result) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(delete_result))
+        rv = await mock_coro(delete_result)
         with patch.object(storage_client_mock, 'delete_from_tbl', return_value=rv) as patch_delete_tbl:
             with patch.object(c_mgr, 'delete_category_and_children_recursively', return_value=rv) as patch_mgr:
                 await pipeline._remove_filters(storage_client_mock, filters, 1)
@@ -980,7 +888,7 @@ class TestPipelineFilters:
     ])
     async def test__check_filters(self, filters, is_exists):
         res = {"rows": [{"name": "Scale"}, {"name": "REN1"}]}
-        rv = await mock_coro(res) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(res))
+        rv = await mock_coro(res)
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(storage_client_mock, 'query_tbl', return_value=rv) as patch_query_tbl:
             with patch.object(pipeline._logger, 'warning') as patch_logger:
@@ -1003,12 +911,8 @@ class TestPipelineFilters:
                               'value': '[{"order": 0, "service": "mod", "values": {"humidity": "12"}}]'}}
         insert_result = {"rows_affected": 1, "response": "inserted"}
         payload = {"cpid": 1, "forder": 1, "fname": "ctrl_{}_{}".format(name, filter_name)}
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(cat_info)
-            rv2 = await mock_coro(insert_result)
-        else:
-            rv = asyncio.ensure_future(mock_coro(cat_info))
-            rv2 = asyncio.ensure_future(mock_coro(insert_result))
+        rv = await mock_coro(cat_info)
+        rv2 = await mock_coro(insert_result)
         with patch.object(c_mgr, 'get_category_all_items', side_effect=[rv, rv]):
             with patch.object(c_mgr, 'create_category', return_value=rv) as patch_create_cat:
                 with patch.object(storage_client_mock, 'insert_into_tbl', return_value=rv2) as patch_tbl:
@@ -1030,7 +934,7 @@ class TestPipelineFilters:
         payload = {"values": {"forder": 1}, "where": {"column": "fname", "condition": "=",
                                                       "value": "ctrl_{}_{}".format(name, filter2),
                                                       "and": {"column": "cpid", "condition": "=", "value": 1}}}
-        rv = await mock_coro(None) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(None))
+        rv = await mock_coro(None)
         with patch.object(storage_client_mock, 'update_tbl', return_value=rv) as patch_tbl:
             with patch.object(pipeline, '_remove_filters', return_value=rv) as patch_filters:
                 await pipeline._update_filters(storage_client_mock, 1, name, [filter2], [filter1, filter2])
@@ -1046,7 +950,7 @@ class TestPipelineFilters:
         filter2 = "Filter2"
         name = "Cp"
         storage_client_mock = MagicMock(StorageClientAsync)
-        rv = await mock_coro(None) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(None))
+        rv = await mock_coro(None)
         with patch.object(pipeline, '_remove_filters', return_value=rv) as patch_filters:
             await pipeline._update_filters(storage_client_mock, 1, name, [], [filter1, filter2])
         patch_filters.assert_called_once_with(
@@ -1060,12 +964,8 @@ class TestPipelineFilters:
     async def test__check_unique_pipeline(self, cf_data, cp_data, error_msg, func_call_count):
         name = "Cp"
         cpid = 1
-        if sys.version_info >= (3, 8):
-            rv = await mock_coro(cf_data)
-            rv2 = await mock_coro(cp_data)
-        else:
-            rv = asyncio.ensure_future(mock_coro(cf_data))
-            rv2 = asyncio.ensure_future(mock_coro(cp_data))
+        rv = await mock_coro(cf_data)
+        rv2 = await mock_coro(cp_data)
         with patch.object(pipeline, '_get_table_column_by_value', side_effect=[rv, rv2]) as patch_tbl_col:
             with pytest.raises(Exception) as exc_info:
                 await pipeline._check_unique_pipeline(name, cpid=cpid)

--- a/tests/unit/python/fledge/services/core/api/control_service/test_script_management.py
+++ b/tests/unit/python/fledge/services/core/api/control_service/test_script_management.py
@@ -1,7 +1,5 @@
-import asyncio
 import copy
 import json
-import sys
 import uuid
 
 from unittest.mock import MagicMock, patch
@@ -67,14 +65,9 @@ class TestScriptManagement:
         cat_info = {'write': {'default': '[{"order": 0, "service": "mod", "values": {"humidity": "12"}}]',
                               'description': 'Dispatcher write operation using automation script', 'type': 'string',
                               'value': '[{"order": 0, "service": "mod", "values": {"humidity": "12"}}]'}}
-        if sys.version_info >= (3, 8):
-            value = await mock_coro(result)
-            get_sch = await mock_schedule(script_name)
-            get_cat = await mock_coro(cat_info)
-        else:
-            value = asyncio.ensure_future(mock_coro(result))
-            get_sch = asyncio.ensure_future(mock_schedule(script_name))
-            get_cat = asyncio.ensure_future(mock_coro(cat_info))
+        value = await mock_coro(result)
+        get_sch = await mock_schedule(script_name)
+        get_cat = await mock_coro(cat_info)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=value) as patch_query_tbl:
                 with patch.object(server.Server.scheduler, 'get_schedules',
@@ -106,7 +99,7 @@ class TestScriptManagement:
         storage_client_mock = MagicMock(StorageClientAsync)
         result = {"count": 0, "rows": []}
         payload = {"return": ["name", "steps", "acl"], "where": {"column": "name", "condition": "=", "value": "blah"}}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         message = "Script with name {} is not found.".format(script_name)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=value) as patch_query_tbl:
@@ -146,15 +139,9 @@ class TestScriptManagement:
             schedule.process_name = "automation_script"
             return schedule
 
-        if sys.version_info >= (3, 8):
-            value = await mock_coro(result)
-            get_cat = await mock_coro(cat_info)
-            get_sch = await mock_manual_schedule(script_name)
-        else:
-            value = asyncio.ensure_future(mock_coro(result))
-            get_cat = asyncio.ensure_future(mock_coro(cat_info))
-            get_sch = asyncio.ensure_future(mock_manual_schedule(script_name))
-
+        value = await mock_coro(result)
+        get_cat = await mock_coro(cat_info)
+        get_sch = await mock_manual_schedule(script_name)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=value) as patch_query_tbl:
                 with patch.object(c_mgr, 'get_category_all_items', return_value=get_cat) as patch_get_all_items:
@@ -212,7 +199,7 @@ class TestScriptManagement:
         script_name = "test"
         request_payload = {"name": script_name, "steps": []}
         result = {"count": 1, "rows": [{"name": script_name, "steps": [{"write": {"order": 1, "speed": 420}}]}]}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": script_name}}
         message = "Script with name {} already exists.".format(script_name)
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -266,14 +253,9 @@ class TestScriptManagement:
         result = {"count": 0, "rows": []}
         insert_result = {"response": "inserted", "rows_affected": 1}
         script_query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": script_name}}
-        if sys.version_info >= (3, 8):
-            value = await mock_coro(result)
-            insert_value = await mock_coro(insert_result)
-            arv = await mock_coro(None)
-        else:
-            value = asyncio.ensure_future(mock_coro(result))
-            insert_value = asyncio.ensure_future(mock_coro(insert_result))
-            arv = asyncio.ensure_future(mock_coro(None))
+        value = await mock_coro(result)
+        insert_value = await mock_coro(insert_result)
+        arv = await mock_coro(None)
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=value
@@ -306,7 +288,7 @@ class TestScriptManagement:
         insert_result = {"response": "inserted", "rows_affected": 1}
         script_query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": script_name}}
         acl_query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": acl_name}}
-        arv = await mock_coro(None) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(None))
+        arv = await mock_coro(None)
 
         async def q_result(*args):
             table = args[0]
@@ -373,7 +355,7 @@ class TestScriptManagement:
         script_name = "test"
         req_payload = {"steps": []}
         result = {"count": 0, "rows": []}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         query_payload = {"return": ["name", "steps", "acl"],
                          "where": {"column": "name", "condition": "=", "value": script_name}}
         message = "No such {} script found.".format(script_name)
@@ -433,8 +415,7 @@ class TestScriptManagement:
         script_result = {"count": 1, "rows": [{"steps": [{"write": {"order": 1, "speed": 420}}]}]}
         update_result = {"response": "updated", "rows_affected": 1}
         steps_payload = payload["steps"]
-        update_value = await mock_coro(update_result) if sys.version_info >= (3, 8) else \
-            asyncio.ensure_future(mock_coro(update_result))
+        update_value = await mock_coro(update_result)
         script_query_payload = {"return": ["name", "steps", "acl"],
                                 "where": {"column": "name", "condition": "=", "value": script_name}}
         acl_query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": acl_name}}
@@ -462,7 +443,7 @@ class TestScriptManagement:
                         'entity_name': script_name} == json.loads(payload_ins)
                 return insert_result
 
-        arv = await mock_coro(None) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(None))
+        arv = await mock_coro(None)
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', side_effect=q_result):
@@ -491,7 +472,7 @@ class TestScriptManagement:
         script_name = "test"
         req_payload = {"steps": []}
         result = {"count": 0, "rows": []}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         query_payload = {"return": ["name"], "where": {"column": "name", "condition": "=", "value": script_name}}
         message = "No such {} script found.".format(script_name)
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -545,19 +526,11 @@ class TestScriptManagement:
             elif table == "acl_usage":
                 return delete_result
 
-        if sys.version_info >= (3, 8):
-            del_cat_and_child = await mock_coro(delete_result)
-            get_sch = await mock_schedule(script_name)
-            disable_sch = await mock_coro(disable_sch_result)
-            delete_sch = await mock_coro(delete_sch_result)
-            arv = await mock_coro(None)
-        else:
-            del_cat_and_child = asyncio.ensure_future(mock_coro(delete_result))
-            get_sch = asyncio.ensure_future(mock_schedule(script_name))
-            disable_sch = asyncio.ensure_future(mock_coro(disable_sch_result))
-            delete_sch = asyncio.ensure_future(mock_coro(delete_sch_result))
-            arv = asyncio.ensure_future(mock_coro(None))
-
+        del_cat_and_child = await mock_coro(delete_result)
+        get_sch = await mock_schedule(script_name)
+        disable_sch = await mock_coro(disable_sch_result)
+        delete_sch = await mock_coro(delete_sch_result)
+        arv = await mock_coro(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'delete_category_and_children_recursively',
                               return_value=del_cat_and_child) as patch_delete_cat_and_child:
@@ -624,8 +597,7 @@ class TestScriptManagement:
             elif table == "acl_usage":
                 return delete_result
 
-        arv = await mock_coro(None) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(None))
-
+        arv = await mock_coro(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'delete_category_and_children_recursively', side_effect=Exception):
                 with patch.object(storage_client_mock, 'query_tbl_with_payload',
@@ -691,8 +663,7 @@ class TestScriptManagement:
     ])
     async def test_schedule_script_not_found(self, client, code, message, get_script_result, payload):
         script_name = "test"
-        value = await mock_coro(get_script_result) if sys.version_info >= (3, 8) else \
-            asyncio.ensure_future(mock_coro(get_script_result))
+        value = await mock_coro(get_script_result)
         query_payload = {"return": ["name", "steps", "acl"], "where": {"column": "name", "condition": "=",
                                                                        "value": script_name}}
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -714,13 +685,8 @@ class TestScriptManagement:
         result = {"count": 1, "rows": [{"name": script_name, "steps": [
             {"write": {"order": 0, "service": "sine", "values": {"sinusoid": "1.2"}}}], "acl": ""}]}
         server.Server.scheduler = Scheduler(None, None)
-        if sys.version_info >= (3, 8):
-            value = await mock_coro(result)
-            get_sch = await mock_schedule(script_name)
-        else:
-            value = asyncio.ensure_future(mock_coro(result))
-            get_sch = asyncio.ensure_future(mock_schedule(script_name))
-
+        value = await mock_coro(result)
+        get_sch = await mock_schedule(script_name)
         query_payload = {"return": ["name", "steps", "acl"], "where": {"column": "name", "condition": "=",
                                                                        "value": script_name}}
         message = "{} schedule already exists.".format(script_name)
@@ -748,21 +714,12 @@ class TestScriptManagement:
             {"write": {"order": 0, "service": "sine", "values": {"sinusoid": "1.2"}}}], "acl": ""}]}
         cat_child_result = {'children': ['dispatcherAdvanced', schedule_cat_name]}
         server.Server.scheduler = Scheduler(None, None)
-        if sys.version_info >= (3, 8):
-            value = await mock_coro(result)
-            sch = await mock_coro("")
-            queue = await mock_coro(True)
-            cat = await mock_coro(None)
-            child = await mock_coro(cat_child_result)
-            get_sch = await mock_schedule(sch_name)
-        else:
-            value = asyncio.ensure_future(mock_coro(result))
-            sch = asyncio.ensure_future(mock_coro(""))
-            queue = asyncio.ensure_future(mock_coro(True))
-            cat = asyncio.ensure_future(mock_coro(None))
-            child = asyncio.ensure_future(mock_coro(cat_child_result))
-            get_sch = asyncio.ensure_future(mock_schedule(sch_name))
-
+        value = await mock_coro(result)
+        sch = await mock_coro("")
+        queue = await mock_coro(True)
+        cat = await mock_coro(None)
+        child = await mock_coro(cat_child_result)
+        get_sch = await mock_schedule(sch_name)
         query_payload = {"return": ["name", "steps", "acl"], "where": {"column": "name", "condition": "=",
                                                                        "value": script_name}}
         message = "Schedule and configuration is created for control script {}".format(script_name)

--- a/tests/unit/python/fledge/services/core/api/plugins/test_discovery.py
+++ b/tests/unit/python/fledge/services/core/api/plugins/test_discovery.py
@@ -8,9 +8,6 @@ import json
 from unittest.mock import patch
 import pytest
 from aiohttp import web
-import sys
-import asyncio
-
 from fledge.services.core import routes
 from fledge.common.plugin_discovery import PluginDiscovery
 from fledge.services.core.api.plugins import common
@@ -145,12 +142,7 @@ class TestPluginDiscoveryApi:
             return return_value
 
         log_path = 'log/190801-12-01-05.log'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock((output, log_path))
-        else:
-            _rv = asyncio.ensure_future(async_mock((output, log_path)))
-
+        _rv = await async_mock((output, log_path))
         with patch.object(common, 'fetch_available_packages', return_value=(_rv)) as patch_fetch_available_package:
             resp = await client.get('/fledge/plugins/available{}'.format(param))
             assert 200 == resp.status

--- a/tests/unit/python/fledge/services/core/api/plugins/test_install.py
+++ b/tests/unit/python/fledge/services/core/api/plugins/test_install.py
@@ -7,9 +7,6 @@
 import json
 from unittest.mock import patch, MagicMock
 import pytest
-import sys
-import asyncio
-
 from aiohttp import web
 
 from fledge.services.core import routes
@@ -76,13 +73,7 @@ class TestPluginInstall:
         checksum_value = "4015c2dea1cc71dbf70a23f6a203eeb6"
         url_value = "http://10.2.5.26:5000//download/c/{}".format(tar_file_name)
         param = {"url": url_value, "format": "tar", "type": "south", "checksum": checksum_value, "compressed": "true"}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-
+        _rv = await async_mock()
         with patch.object(plugins_install, 'download', return_value=_rv) as download_patch:
             with patch.object(plugins_install, 'validate_checksum', return_value=False) as checksum_patch:
                 resp = await client.post('/fledge/plugins', data=json.dumps(param))
@@ -109,13 +100,7 @@ class TestPluginInstall:
         url_value = "http://10.2.5.26:5000/download/{}".format(tar_file_name)
         msg = 'Could not find a version that satisfies the requirement pt==1.4.0'
         param = {"url": url_value, "format": "tar", "type": "south", "checksum": checksum_value}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock([tar_file_name])
-        else:
-            _rv = asyncio.ensure_future(async_mock([tar_file_name]))
-
+        _rv = await async_mock([tar_file_name])
         with patch.object(plugins_install, 'download', return_value=_rv) as download_patch:
             with patch.object(plugins_install, 'validate_checksum', return_value=True) as checksum_patch:
                 with patch.object(plugins_install, 'extract_file', return_value=sync_mock(files)) as extract_patch:
@@ -143,13 +128,7 @@ class TestPluginInstall:
         checksum_value = "4015c2dea1cc71dbf70a23f6a203eeb6"
         url_value = "http://10.2.5.26:5000/download/{}".format(tar_file_name)
         param = {"url": url_value, "format": "tar", "type": "south", "checksum": checksum_value}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock([tar_file_name])
-        else:
-            _rv = asyncio.ensure_future(async_mock([tar_file_name]))
-
+        _rv = await async_mock([tar_file_name])
         with patch.object(plugins_install, 'download', return_value=_rv) as download_patch:
             with patch.object(plugins_install, 'validate_checksum', return_value=True) as checksum_patch:
                 with patch.object(plugins_install, 'extract_file', return_value=sync_mock(files)) as extract_patch:
@@ -179,13 +158,7 @@ class TestPluginInstall:
         checksum_value = "2019c2dea1cc71dbf70a23f6a203fdgh"
         url_value = "http://10.2.5.26:5000/filter/download/{}".format(tar_file_name)
         param = {"url": url_value, "format": "tar", "type": "filter", "checksum": checksum_value, "compressed": "true"}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock([tar_file_name])
-        else:
-            _rv = asyncio.ensure_future(async_mock([tar_file_name]))
-
+        _rv = await async_mock([tar_file_name])
         with patch.object(plugins_install, 'download', return_value=_rv) as download_patch:
             with patch.object(plugins_install, 'validate_checksum', return_value=True) as checksum_patch:
                 with patch.object(plugins_install, 'extract_file', return_value=sync_mock(files)) as extract_patch:
@@ -213,13 +186,7 @@ class TestPluginInstall:
         url_value = "http://10.2.5.26:5000/download/fledge-south-{}-1.6.0.{}".format(plugin_name, file_format)
         param = {"url": url_value, "format": file_format, "type": "south", "checksum": checksum}
         pkg_mgt = 'yum' if file_format == 'rpm' else 'apt'
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())        
-
+        _rv = await async_mock()
         with patch.object(plugins_install, 'download', return_value=_rv) as download_patch:
             with patch.object(plugins_install, 'validate_checksum', return_value=True) as checksum_patch:
                 with patch.object(plugins_install, 'install_package', return_value=(0, 'Success')) \
@@ -261,12 +228,7 @@ class TestPluginInstall:
                   'fledge:armhf (>= 1.6) but it is not installableE: Unable to correct problems, ' \
                   'you have held broken packages.'
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())        
-
+        _rv = await async_mock()
         with patch.object(plugins_install, 'download', return_value=_rv) as download_patch:
             with patch.object(plugins_install, 'validate_checksum', return_value=True) as checksum_patch:
                 with patch.object(plugins_install, 'install_package', return_value=(256, msg)) as install_package_patch:
@@ -290,15 +252,8 @@ class TestPluginInstall:
                         'packageName': 'fledge-south-randomwalk'}]
 
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock({'count': 0, 'rows': []})
-            _rv2 = await async_mock(([], 'log/190801-12-41-13.log'))
-        else:
-            _rv1 = asyncio.ensure_future(async_mock({'count': 0, 'rows': []}))
-            _rv2 = asyncio.ensure_future(async_mock(([], 'log/190801-12-41-13.log')))      
-        
+        _rv1 = await async_mock({'count': 0, 'rows': []})
+        _rv2 = await async_mock(([], 'log/190801-12-41-13.log'))
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               return_value=_rv1) as query_tbl_patch:
@@ -338,20 +293,11 @@ class TestPluginInstall:
                                                              "and": {"column": "name", "condition": "=",
                                                                      "value": plugin_name}}}
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(([plugin_name, "fledge-north-http", "fledge-service-notification"],
+        _rv1 = await async_mock(([plugin_name, "fledge-north-http", "fledge-service-notification"],
                                     'log/190801-12-41-13.log'))
-            _rv2 = await async_mock({"response": "inserted", "rows_affected": 1})
-            _se1 = await async_mock({'count': 0, 'rows': []})
-            _se2 = await async_mock(insert_row_resp)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock(([plugin_name, "fledge-north-http", "fledge-service-notification"],
-                                    'log/190801-12-41-13.log')))
-            _rv2 = asyncio.ensure_future(async_mock({"response": "inserted", "rows_affected": 1}))
-            _se1 = asyncio.ensure_future(async_mock({'count': 0, 'rows': []}))
-            _se2 = asyncio.ensure_future(async_mock(insert_row_resp))
-        
+        _rv2 = await async_mock({"response": "inserted", "rows_affected": 1})
+        _se1 = await async_mock({'count': 0, 'rows': []})
+        _se2 = await async_mock(insert_row_resp)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               side_effect=[_se1, _se2]) as query_tbl_patch:
@@ -399,13 +345,7 @@ class TestPluginInstall:
         }]}
         msg = '{} package installation already in progress'.format(plugin_name)
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(select_row_resp)
-        else:
-            _rv = asyncio.ensure_future(async_mock(select_row_resp))
-        
+        _rv = await async_mock(select_row_resp)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               return_value=_rv) as query_tbl_patch:
@@ -431,13 +371,7 @@ class TestPluginInstall:
                         "version": "1.8.1", "installedDirectory": "south/ModbusC", "packageName": plugin_name}]
         msg = '{} package is already installed'.format(plugin_name)
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock({'count': 0, 'rows': []})
-        else:
-            _rv = asyncio.ensure_future(async_mock({'count': 0, 'rows': []}))
-        
+        _rv = await async_mock({'count': 0, 'rows': []})
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               return_value=_rv) as query_tbl_patch:

--- a/tests/unit/python/fledge/services/core/api/plugins/test_remove.py
+++ b/tests/unit/python/fledge/services/core/api/plugins/test_remove.py
@@ -7,9 +7,6 @@
 import json
 from unittest.mock import patch, MagicMock
 import pytest
-import sys
-import asyncio
-
 from aiohttp import web
 
 from fledge.common.plugin_discovery import PluginDiscovery
@@ -91,12 +88,7 @@ class TestPluginRemove:
                              "packageName": "fledge-{}-http-south".format(_type)}
                             ]
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock([{'service_list': svc_list}])
-        else:
-            _rv = asyncio.ensure_future(async_mock([{'service_list': svc_list}]))
-        
+        _rv = await async_mock([{'service_list': svc_list}])
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value=plugin_installed
                           ) as plugin_installed_patch:
             with patch.object(plugins_remove, '_check_plugin_usage', return_value=_rv) as plugin_usage_patch:
@@ -128,13 +120,7 @@ class TestPluginRemove:
                              "version": "1.8.1", "installedDirectory": "{}/{}".format(plugin_type_installed_dir,
                                                                                       plugin_installed_dirname),
                              "packageName": pkg_name}]
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(notify_instances_list)
-        else:
-            _rv = asyncio.ensure_future(async_mock(notify_instances_list))
-        
+        _rv = await async_mock(notify_instances_list)
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value=plugin_installed
                           ) as plugin_installed_patch:
             with patch.object(plugins_remove, '_check_plugin_usage_in_notification_instances', return_value=_rv) as plugin_usage_patch:
@@ -180,14 +166,8 @@ class TestPluginRemove:
                              "packageName": pkg_name}
                             ]
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock([])
-            _rv2 = await async_mock(select_row_resp)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock([]))
-            _rv2 = asyncio.ensure_future(async_mock(select_row_resp))
-        
+        _rv1 = await async_mock([])
+        _rv2 = await async_mock(select_row_resp)
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value=plugin_installed
                           ) as plugin_installed_patch:
             with patch.object(plugins_remove, '_check_plugin_usage', return_value=_rv1) as plugin_usage_patch:
@@ -249,20 +229,11 @@ class TestPluginRemove:
                              "packageName": pkg_name}
                             ]
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock([])
-            _rv2 = await async_mock(delete)
-            _rv3 = await async_mock(insert)
-            _se1 = await async_mock(select_row_resp)
-            _se2 = await async_mock(insert_row)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock([]))
-            _rv2 = asyncio.ensure_future(async_mock(delete))
-            _rv3 = asyncio.ensure_future(async_mock(insert))
-            _se1 = asyncio.ensure_future(async_mock(select_row_resp))
-            _se2 = asyncio.ensure_future(async_mock(insert_row))
-        
+        _rv1 = await async_mock([])
+        _rv2 = await async_mock(delete)
+        _rv3 = await async_mock(insert)
+        _se1 = await async_mock(select_row_resp)
+        _se2 = await async_mock(insert_row)
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value=plugin_installed
                           ) as plugin_installed_patch:
             with patch.object(plugins_remove, '_check_plugin_usage', return_value=_rv1) as plugin_usage_patch:

--- a/tests/unit/python/fledge/services/core/api/plugins/test_update.py
+++ b/tests/unit/python/fledge/services/core/api/plugins/test_update.py
@@ -8,9 +8,6 @@ import json
 import uuid
 from unittest.mock import patch, MagicMock
 import pytest
-import sys
-import asyncio
-
 from aiohttp import web
 
 from fledge.common.configuration_manager import ConfigurationManager
@@ -76,13 +73,7 @@ class TestPluginUpdate:
         }]}
         msg = '{} package update already in progress.'.format(pkg_name)
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(select_row_resp)
-        else:
-            _rv = asyncio.ensure_future(async_mock(select_row_resp))
-
+        _rv = await async_mock(select_row_resp)
         plugin_installed = [{"name": plugin_installed_dirname, "type": _type, "description": "{} plugin".format(_type),
                              "version": "2.1.0", "installedDirectory": "{}/{}".format(_type, plugin_installed_dirname),
                              "packageName": pkg_name}]
@@ -151,21 +142,11 @@ class TestPluginUpdate:
                            {'plugin': 'http_north', 'service': svc_name}]
         sch_info = [{'id': '6637c9ff-7090-4774-abca-07dee59a0610', 'enabled': 'f'}]
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(tracked_plugins)
-            _rv2 = await async_mock(sch_info)
-            _rv3 = await async_mock(insert)
-            _se1 = await async_mock({'count': 0, 'rows': []})
-            _se2 = await async_mock(insert_row)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock(tracked_plugins))
-            _rv2 = asyncio.ensure_future(async_mock(sch_info))
-            _rv3 = asyncio.ensure_future(async_mock(insert))
-            _se1 = asyncio.ensure_future(async_mock({'count': 0, 'rows': []}))
-            _se2 = asyncio.ensure_future(async_mock(insert_row))           
-        
+        _rv1 = await async_mock(tracked_plugins)
+        _rv2 = await async_mock(sch_info)
+        _rv3 = await async_mock(insert)
+        _se1 = await async_mock({'count': 0, 'rows': []})
+        _se2 = await async_mock(insert_row)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               side_effect=[_se1, _se2]) as query_tbl_patch:
@@ -237,25 +218,13 @@ class TestPluginUpdate:
         sch_info = [{'id': '6637c9ff-7090-4774-abca-07dee59a0610', 'enabled': 't'}]
         server.Server.scheduler = Scheduler(None, None)
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(tracked_plugins)
-            _rv2 = await async_mock(sch_info)
-            _rv3 = await async_mock(insert)
-            _rv4 = await async_mock(delete)
-            _rv5 = await async_mock((True, "Schedule successfully disabled"))
-            _se1 = await async_mock(select_row_resp)
-            _se2 = await async_mock(insert_row)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock(tracked_plugins))
-            _rv2 = asyncio.ensure_future(async_mock(sch_info))
-            _rv3 = asyncio.ensure_future(async_mock(insert))
-            _rv4 = asyncio.ensure_future(async_mock(delete))
-            _rv5 = asyncio.ensure_future(async_mock((True, "Schedule successfully disabled")))
-            _se1 = asyncio.ensure_future(async_mock(select_row_resp))
-            _se2 = asyncio.ensure_future(async_mock(insert_row))    
-
+        _rv1 = await async_mock(tracked_plugins)
+        _rv2 = await async_mock(sch_info)
+        _rv3 = await async_mock(insert)
+        _rv4 = await async_mock(delete)
+        _rv5 = await async_mock((True, "Schedule successfully disabled"))
+        _se1 = await async_mock(select_row_resp)
+        _se2 = await async_mock(insert_row)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               side_effect=[_se1, _se2]) as query_tbl_patch:
@@ -332,23 +301,12 @@ class TestPluginUpdate:
                                                                            'service': svc_name}]
         sch_info = [{'id': '6637c9ff-7090-4774-abca-07dee59a0610', 'enabled': 'f'}]
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(tracked_plugins)
-            _rv2 = await async_mock(sch_info)
-            _rv3 = await async_mock(insert)
-            _se1 = await async_mock({'count': 0, 'rows': []})
-            _se2 = await async_mock(insert_row)
-            _se3 = await async_mock(filter_row)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock(tracked_plugins))
-            _rv2 = asyncio.ensure_future(async_mock(sch_info))
-            _rv3 = asyncio.ensure_future(async_mock(insert))
-            _se1 = asyncio.ensure_future(async_mock({'count': 0, 'rows': []}))
-            _se2 = asyncio.ensure_future(async_mock(insert_row))
-            _se3 = asyncio.ensure_future(async_mock(filter_row))
-        
+        _rv1 = await async_mock(tracked_plugins)
+        _rv2 = await async_mock(sch_info)
+        _rv3 = await async_mock(insert)
+        _se1 = await async_mock({'count': 0, 'rows': []})
+        _se2 = await async_mock(insert_row)
+        _se3 = await async_mock(filter_row)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               side_effect=[_se1, _se3, _se2]) as query_tbl_patch:
@@ -418,27 +376,14 @@ class TestPluginUpdate:
         sch_info = [{'id': '6637c9ff-7090-4774-abca-07dee59a0610', 'enabled': 't'}]
         server.Server.scheduler = Scheduler(None, None)
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(tracked_plugins)
-            _rv2 = await async_mock(sch_info)
-            _rv3 = await async_mock(insert)
-            _rv4 = await async_mock(delete)
-            _rv5 = await async_mock((True, "Schedule successfully disabled"))
-            _se1 = await async_mock(select_row_resp)
-            _se2 = await async_mock(insert_row)
-            _se3 = await async_mock(filter_row)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock(tracked_plugins))
-            _rv2 = asyncio.ensure_future(async_mock(sch_info))
-            _rv3 = asyncio.ensure_future(async_mock(insert))
-            _rv4 = asyncio.ensure_future(async_mock(delete))
-            _rv5 = asyncio.ensure_future(async_mock((True, "Schedule successfully disabled")))
-            _se1 = asyncio.ensure_future(async_mock(select_row_resp))
-            _se2 = asyncio.ensure_future(async_mock(insert_row))
-            _se3 = asyncio.ensure_future(async_mock(filter_row))
-        
+        _rv1 = await async_mock(tracked_plugins)
+        _rv2 = await async_mock(sch_info)
+        _rv3 = await async_mock(insert)
+        _rv4 = await async_mock(delete)
+        _rv5 = await async_mock((True, "Schedule successfully disabled"))
+        _se1 = await async_mock(select_row_resp)
+        _se2 = await async_mock(insert_row)
+        _se3 = await async_mock(filter_row)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               side_effect=[_se1, _se3, _se2]) as query_tbl_patch:
@@ -515,20 +460,11 @@ class TestPluginUpdate:
                 "log_file_uri": ""
             }]}
         sch_info = {'count': 1, 'rows': [{'id': '6637c9ff-7090-4774-abca-07dee59a0610', 'enabled': 'f'}]}
-        storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(insert)
-            _se1 = await async_mock({'count': 0, 'rows': []})
-            _se2 = await async_mock(insert_row)
-            _se3 = await async_mock(sch_info)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock(insert))
-            _se1 = asyncio.ensure_future(async_mock({'count': 0, 'rows': []}))
-            _se2 = asyncio.ensure_future(async_mock(insert_row))
-            _se3 = asyncio.ensure_future(async_mock(sch_info))
-        
+        storage_client_mock = MagicMock(StorageClientAsync)        
+        _rv1 = await async_mock(insert)
+        _se1 = await async_mock({'count': 0, 'rows': []})
+        _se2 = await async_mock(insert_row)
+        _se3 = await async_mock(sch_info)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               side_effect=[_se1, _se3, _se2]) as query_tbl_patch:
@@ -603,25 +539,13 @@ class TestPluginUpdate:
                                                                                "value": "true"}}
         disable_notification = {"description": "Enabled", "type": "boolean", "default": "true", "value": "false"}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(read_all_child_category_names)
-            _rv2 = await async_mock(read_cat_val)
-            _rv3 = await async_mock(disable_notification)
-            _rv4 = await async_mock(insert)
-            _se1 = await async_mock({'count': 0, 'rows': []})
-            _se2 = await async_mock(insert_row)
-            _se3 = await async_mock(sch_info)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock(read_all_child_category_names))
-            _rv2 = asyncio.ensure_future(async_mock(read_cat_val))
-            _rv3 = asyncio.ensure_future(async_mock(disable_notification))
-            _rv4 = asyncio.ensure_future(async_mock(insert))
-            _se1 = asyncio.ensure_future(async_mock({'count': 0, 'rows': []}))
-            _se2 = asyncio.ensure_future(async_mock(insert_row))
-            _se3 = asyncio.ensure_future(async_mock(sch_info))        
-        
+        _rv1 = await async_mock(read_all_child_category_names)
+        _rv2 = await async_mock(read_cat_val)
+        _rv3 = await async_mock(disable_notification)
+        _rv4 = await async_mock(insert)
+        _se1 = await async_mock({'count': 0, 'rows': []})
+        _se2 = await async_mock(insert_row)
+        _se3 = await async_mock(sch_info)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               side_effect=[_se1, _se3, _se2]) as query_tbl_patch:

--- a/tests/unit/python/fledge/services/core/api/test_alerts.py
+++ b/tests/unit/python/fledge/services/core/api/test_alerts.py
@@ -1,6 +1,4 @@
-import asyncio
 import json
-import sys
 from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
@@ -36,9 +34,7 @@ class TestAlerts:
         server.Server._alert_manager = None
 
     async def test_get_all(self, client):
-        rv = await self.async_mock([]) if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(self.async_mock([]))
-
+        rv = await self.async_mock([])
         with patch.object(server.Server._alert_manager, 'get_all', return_value=rv):
             resp = await client.get('/fledge/alert')
             assert 200 == resp.status
@@ -58,9 +54,7 @@ class TestAlerts:
             assert 1 == patch_logger.call_count
 
     async def test_delete(self, client):
-        rv = await self.async_mock("Nothing to delete.") \
-            if sys.version_info.major == 3 and sys.version_info.minor >= 8 else (
-            asyncio.ensure_future(self.async_mock("Nothing to delete.")))
+        rv = await self.async_mock("Nothing to delete.")
         with patch.object(server.Server._alert_manager, 'delete', return_value=rv):
             resp = await client.delete('/fledge/alert')
             assert 200 == resp.status

--- a/tests/unit/python/fledge/services/core/api/test_asset_tracker_api.py
+++ b/tests/unit/python/fledge/services/core/api/test_asset_tracker_api.py
@@ -4,13 +4,11 @@
 # See: http://fledge-iot.readthedocs.io/
 # FLEDGE_END
 
-
 import asyncio
 import json
 from unittest.mock import MagicMock, patch
 from aiohttp import web
 import pytest
-import sys
 
 from fledge.common.audit_logger import AuditLogger
 from fledge.common.storage_client.storage_client import StorageClientAsync
@@ -54,10 +52,7 @@ class TestAssetTracker:
                               {'alias': 'deprecatedTimestamp', 'column': 'deprecated_ts'}, 'data'
                               ]
                    }
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await async_mock() if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv) as patch_query_payload:
                 resp = await client.get('/fledge/track')
@@ -80,7 +75,7 @@ class TestAssetTracker:
 
     async def test_bad_deprecate_entry(self, client):
         result = {"message": "failed"}
-        _rv = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        _rv = await mock_coro(result)
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv):
@@ -91,7 +86,7 @@ class TestAssetTracker:
 
     async def test_deprecate_entry_not_found(self, client):
         result = {"count": 0, "rows": []}
-        _rv = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        _rv = await mock_coro(result)
         storage_client_mock = MagicMock(StorageClientAsync)
         asset = "blah"
         service = "Test"
@@ -116,7 +111,7 @@ class TestAssetTracker:
 
     async def test_already_deprecated_entry(self, client):
         result = {'count': 1, 'rows': [{'deprecated_ts': '2022-11-18 06:11:13.657'}]}
-        _rv = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        _rv = await mock_coro(result)
         storage_client_mock = MagicMock(StorageClientAsync)
         asset = "Airtake"
         service = "Sparkplug"
@@ -161,14 +156,9 @@ class TestAssetTracker:
         query_result = {'count': 1, 'rows': [{'deprecated_ts': ''}]}
         update_result = {"response": "updated", "rows_affected": 1}
         message = "For {} event, {} asset record entry has been deprecated.".format(event, asset)
-        if sys.version_info >= (3, 8):
-            _rv = await mock_coro(query_result)
-            _rv2 = await mock_coro(update_result)
-            _rv3 = await mock_coro(None)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(query_result))
-            _rv2 = asyncio.ensure_future(mock_coro(update_result))
-            _rv3 = asyncio.ensure_future(mock_coro(None))
+        _rv = await mock_coro(query_result)
+        _rv2 = await mock_coro(update_result)
+        _rv3 = await mock_coro(None)
 
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):

--- a/tests/unit/python/fledge/services/core/api/test_audit.py
+++ b/tests/unit/python/fledge/services/core/api/test_audit.py
@@ -5,14 +5,11 @@
 # FLEDGE_END
 
 
-import asyncio
 import json
 from unittest.mock import MagicMock, patch
 from collections import Counter
 from aiohttp import web
 import pytest
-import sys
-
 from fledge.services.core import routes
 from fledge.services.core import connect
 from fledge.common.storage_client.storage_client import StorageClientAsync
@@ -80,13 +77,7 @@ class TestAudit:
     async def test_audit_log_codes(self, client, get_log_codes):
         async def get_log_codes_async():
             return get_log_codes
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await get_log_codes_async()
-        else:
-            _rv = asyncio.ensure_future(get_log_codes_async())
-        
+        _rv = await get_log_codes_async()
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=_rv) as log_code_patch:
@@ -126,14 +117,8 @@ class TestAudit:
         async def async_mock_log():
             return get_log_codes
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock_log()
-            _rv2 = await async_mock()
-        else:
-            _rv1 = asyncio.ensure_future(async_mock_log())
-            _rv2 = asyncio.ensure_future(async_mock())
-        
+        _rv1 = await async_mock_log()
+        _rv2 = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=_rv1):
                 with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv2) as log_code_patch:
@@ -162,12 +147,7 @@ class TestAudit:
         async def async_mock_log():
             return get_log_codes
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock_log()
-        else:
-            _rv = asyncio.ensure_future(async_mock_log())
-        
+        _rv = await async_mock_log()
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=_rv):
@@ -192,12 +172,7 @@ class TestAudit:
         async def async_mock():
             return response
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         storage_mock = MagicMock(spec=StorageClientAsync)
         AuditLogger(storage_mock)
         with patch.object(storage_mock, 'insert_into_tbl', return_value=_rv) as insert_tbl_patch:

--- a/tests/unit/python/fledge/services/core/api/test_auth_mandatory.py
+++ b/tests/unit/python/fledge/services/core/api/test_auth_mandatory.py
@@ -9,7 +9,6 @@ import json
 from unittest.mock import MagicMock, patch
 from aiohttp import web
 import pytest
-import sys
 
 from fledge.common.audit_logger import AuditLogger
 from fledge.common.configuration_manager import ConfigurationManager
@@ -47,15 +46,9 @@ class TestAuthMandatory:
 
     async def auth_token_fixture(self, mocker, is_admin=True):
         user = {'id': 1, 'uname': 'admin', 'role_id': '1'} if is_admin else {'id': 2, 'uname': 'user', 'role_id': '2'}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro(user['id'])
-            _rv2 = await mock_coro(None)
-            _rv3 = await mock_coro(user)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro(user['id']))
-            _rv2 = asyncio.ensure_future(mock_coro(None))
-            _rv3 = asyncio.ensure_future(mock_coro(user))
+        _rv1 = await mock_coro(user['id'])
+        _rv2 = await mock_coro(None)
+        _rv3 = await mock_coro(user)
         patch_logger_debug = mocker.patch.object(middleware._logger, 'debug')
         patch_validate_token = mocker.patch.object(User.Objects, 'validate_token', return_value=_rv1)
         patch_refresh_token = mocker.patch.object(User.Objects, 'refresh_token_expiry', return_value=_rv2)
@@ -89,13 +82,8 @@ class TestAuthMandatory:
         ret_val = [{'id': '1'}]
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info >= (3, 8):
-            rv1 = await mock_coro(msg)
-            rv2 = await mock_coro(ret_val)
-        else:
-            rv1 = asyncio.ensure_future(mock_coro(msg))
-            rv2 = asyncio.ensure_future(mock_coro(ret_val))
+        rv1 = await mock_coro(msg)
+        rv2 = await mock_coro(ret_val)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=rv2) as patch_role_id:
             with patch.object(auth, 'validate_password', return_value=rv1):
                 resp = await client.post('/fledge/admin/user', data=json.dumps(payload), headers=ADMIN_USER_HEADER)
@@ -118,15 +106,9 @@ class TestAuthMandatory:
         msg = "Invalid role ID."
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro([{'id': '1'}])
-            _rv2 = await mock_coro(False)
-            _rv3 = await mock_coro("")
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv2 = asyncio.ensure_future(mock_coro(False))
-            _rv3 = asyncio.ensure_future(mock_coro(""))
+        _rv1 = await mock_coro([{'id': '1'}])
+        _rv2 = await mock_coro(False)
+        _rv3 = await mock_coro("")
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv1) as patch_role_id:
             with patch.object(auth, 'validate_password', return_value=_rv3):
                 with patch.object(auth, 'is_valid_role', return_value=_rv2) as patch_role:
@@ -153,24 +135,13 @@ class TestAuthMandatory:
                   'enabled': 'f', 'access_method': 'any'},
                  {'id': 3, 'uname': 'dviewer', 'real_name': 'Data Viewer', 'role_id': 4, 'description': 'Test',
                   'enabled': 'f', 'access_method': 'any'}]
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro(valid_user['id'])
-            _rv2 = await mock_coro(None)
-            _rv3 = await mock_coro([{'id': '1'}])
-            _rv4 = await mock_coro(True)
-            _rv5 = await mock_coro(valid_user)
-            _rv6 = await mock_coro(users)
-            _rv7 = await mock_coro("")
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro(valid_user['id']))
-            _rv2 = asyncio.ensure_future(mock_coro(None))
-            _rv3 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv4 = asyncio.ensure_future(mock_coro(True))
-            _rv5 = asyncio.ensure_future(mock_coro(valid_user))
-            _rv6 = asyncio.ensure_future(mock_coro(users))
-            _rv7 = asyncio.ensure_future(mock_coro(""))
-
+        _rv1 = await mock_coro(valid_user['id'])
+        _rv2 = await mock_coro(None)
+        _rv3 = await mock_coro([{'id': '1'}])
+        _rv4 = await mock_coro(True)
+        _rv5 = await mock_coro(valid_user)
+        _rv6 = await mock_coro(users)
+        _rv7 = await mock_coro("")
         with patch.object(middleware._logger, 'debug') as patch_logger_debug:
             with patch.object(User.Objects, 'validate_token', return_value=_rv1) as patch_validate_token:
                 with patch.object(User.Objects, 'refresh_token_expiry', return_value=_rv2
@@ -213,27 +184,15 @@ class TestAuthMandatory:
         ret_val = {"response": "inserted", "rows_affected": 1}
         msg = '{} user has been created successfully.'.format(request_data['username'])
         valid_user = {'id': 1, 'uname': 'admin', 'role_id': '1'}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro(valid_user['id'])
-            _rv2 = await mock_coro(None)
-            _rv3 = await mock_coro([{'id': '1'}])
-            _rv4 = await mock_coro(True)
-            _rv5 = await mock_coro(ret_val)
-            _rv6 = await mock_coro(users)
-            _rv7 = await mock_coro("")
-            _se1 = await mock_coro(valid_user)
-            _se2 = await mock_coro(data)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro(valid_user['id']))
-            _rv2 = asyncio.ensure_future(mock_coro(None))
-            _rv3 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv4 = asyncio.ensure_future(mock_coro(True))
-            _rv5 = asyncio.ensure_future(mock_coro(ret_val))
-            _rv6 = asyncio.ensure_future(mock_coro(users))
-            _rv7 = asyncio.ensure_future(mock_coro(""))
-            _se1 = asyncio.ensure_future(mock_coro(valid_user))
-            _se2 = asyncio.ensure_future(mock_coro(data))
+        _rv1 = await mock_coro(valid_user['id'])
+        _rv2 = await mock_coro(None)
+        _rv3 = await mock_coro([{'id': '1'}])
+        _rv4 = await mock_coro(True)
+        _rv5 = await mock_coro(ret_val)
+        _rv6 = await mock_coro(users)
+        _rv7 = await mock_coro("")
+        _se1 = await mock_coro(valid_user)
+        _se2 = await mock_coro(data)
         with patch.object(middleware._logger, 'debug') as patch_logger_debug:
             with patch.object(User.Objects, 'validate_token', return_value=_rv1) as patch_validate_token:
                 with patch.object(User.Objects, 'refresh_token_expiry', return_value=_rv2) as patch_refresh_token:
@@ -278,23 +237,13 @@ class TestAuthMandatory:
         valid_user = {'id': 1, 'uname': 'admin', 'role_id': '1'}
         users = [{'id': 1, 'uname': 'admin', 'real_name': 'Admin user', 'role_id': 1, 'description': 'admin user',
                   'enabled': 't', 'access_method': 'any'}]
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro(valid_user['id'])
-            _rv2 = await mock_coro(None)
-            _rv3 = await mock_coro([{'id': '1'}])
-            _rv4 = await mock_coro(True)
-            _rv5 = await mock_coro(valid_user)
-            _rv6 = await mock_coro(users)
-            _rv7 = await mock_coro("")
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro(valid_user['id']))
-            _rv2 = asyncio.ensure_future(mock_coro(None))
-            _rv3 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv4 = asyncio.ensure_future(mock_coro(True))
-            _rv5 = asyncio.ensure_future(mock_coro(valid_user))
-            _rv6 = asyncio.ensure_future(mock_coro(users))
-            _rv7 = asyncio.ensure_future(mock_coro(""))
+        _rv1 = await mock_coro(valid_user['id'])
+        _rv2 = await mock_coro(None)
+        _rv3 = await mock_coro([{'id': '1'}])
+        _rv4 = await mock_coro(True)
+        _rv5 = await mock_coro(valid_user)
+        _rv6 = await mock_coro(users)
+        _rv7 = await mock_coro("")
         with patch.object(middleware._logger, 'debug') as patch_logger_debug:
             with patch.object(User.Objects, 'validate_token', return_value=_rv1) as patch_validate_token:
                 with patch.object(User.Objects, 'refresh_token_expiry', return_value=_rv2
@@ -334,23 +283,13 @@ class TestAuthMandatory:
         exc_msg = "Value Error occurred"
         users = [{'id': 1, 'uname': 'admin', 'real_name': 'Admin user', 'role_id': 1, 'description': 'admin user',
                   'enabled': 't', 'access_method': 'any'}]
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro(valid_user['id'])
-            _rv2 = await mock_coro(None)
-            _rv3 = await mock_coro([{'id': '1'}])
-            _rv4 = await mock_coro(True)
-            _rv5 = await mock_coro(valid_user)
-            _rv6 = await mock_coro(users)
-            _rv7 = await mock_coro("")
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro(valid_user['id']))
-            _rv2 = asyncio.ensure_future(mock_coro(None))
-            _rv3 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv4 = asyncio.ensure_future(mock_coro(True))
-            _rv5 = asyncio.ensure_future(mock_coro(valid_user))
-            _rv6 = asyncio.ensure_future(mock_coro(users))
-            _rv7 = asyncio.ensure_future(mock_coro(""))
+        _rv1 = await mock_coro(valid_user['id'])
+        _rv2 = await mock_coro(None)
+        _rv3 = await mock_coro([{'id': '1'}])
+        _rv4 = await mock_coro(True)
+        _rv5 = await mock_coro(valid_user)
+        _rv6 = await mock_coro(users)
+        _rv7 = await mock_coro("")
         with patch.object(middleware._logger, 'debug') as patch_logger_debug:
             with patch.object(User.Objects, 'validate_token', return_value=_rv1) as patch_validate_token:
                 with patch.object(User.Objects, 'refresh_token_expiry', return_value=_rv2
@@ -390,7 +329,7 @@ class TestAuthMandatory:
             mocker)
         user_info = {'role_id': '1', 'id': '2', 'uname': 'user', 'access_method': 'any',
                      'real_name': 'Sat', 'description': 'Normal User'}
-        rv = await mock_coro(user_info) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(user_info))
+        rv = await mock_coro(user_info)
         with patch.object(User.Objects, 'get', return_value=rv) as patch_get_user:
             resp = await client.put('/fledge/user', data=json.dumps(payload), headers=ADMIN_USER_HEADER)
             assert 400 == resp.status
@@ -413,15 +352,9 @@ class TestAuthMandatory:
         user_record = {'rows': [{'user_id': 2}], 'count': 1}
         update_result = {"rows_affected": 1, "response": "updated"}
         storage_client_mock = MagicMock(StorageClientAsync)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info >= (3, 8):
-            rv1 = await mock_coro(user_info)
-            rv2 = await mock_coro(user_record)
-            rv3 = await mock_coro(update_result)
-        else:
-            rv1 = asyncio.ensure_future(mock_coro(user_info))
-            rv2 = asyncio.ensure_future(mock_coro(user_record))
-            rv3 = asyncio.ensure_future(mock_coro(update_result))
+        rv1 = await mock_coro(user_info)
+        rv2 = await mock_coro(user_record)
+        rv3 = await mock_coro(update_result)
         with patch.object(User.Objects, 'get', return_value=rv1) as patch_get_user:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=rv2) as q_tbl_patch:
@@ -455,13 +388,8 @@ class TestAuthMandatory:
         user_info = {'role_id': '1', 'id': str(uid), 'uname': 'user', 'access_method': 'any',
                      'real_name': 'Sat', 'description': 'Normal User'}
         ret_val = [{'id': '1'}]
-        if sys.version_info >= (3, 8):
-            _rv = await mock_coro(ret_val)
-            _se = await mock_coro(user_info)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(ret_val))
-            _se = asyncio.ensure_future(mock_coro(user_info))
-
+        _rv = await mock_coro(ret_val)
+        _se = await mock_coro(user_info)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv) as patch_role_id:
             with patch.object(User.Objects, 'get', return_value=_se) as patch_get_user:
                 resp = await client.put('/fledge/admin/{}'.format(uid), data=json.dumps(payload),
@@ -492,16 +420,9 @@ class TestAuthMandatory:
         uid = 2
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro([{'id': '2'}])
-            _rv2 = await mock_coro(True)
-            _se = await mock_coro(exp_result)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro([{'id': '2'}]))
-            _rv2 = asyncio.ensure_future(mock_coro(True))
-            _se = asyncio.ensure_future(mock_coro(exp_result))
-
+        _rv1 = await mock_coro([{'id': '2'}])
+        _rv2 = await mock_coro(True)
+        _se = await mock_coro(exp_result)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv1) as patch_role_id:
             with patch.object(User.Objects, 'update', return_value=_rv2) as patch_update:
                 with patch.object(User.Objects, 'get', return_value=_se):
@@ -534,8 +455,7 @@ class TestAuthMandatory:
         uid = 2
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker, is_admin=False)
-        rv1 = await mock_coro(msg) if sys.version_info.major == 3 and sys.version_info.minor >= 8 else (
-            asyncio.ensure_future(mock_coro(msg)))
+        rv1 = await mock_coro(msg) 
         with patch.object(auth, 'validate_password', return_value=rv1):
             resp = await client.put('/fledge/user/{}/password'.format(uid), data=json.dumps(request_data),
                                     headers=NORMAL_USER_HEADER)
@@ -568,13 +488,8 @@ class TestAuthMandatory:
         msg = 'Invalid current password.'
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker, is_admin=False)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info >= (3, 8):
-            rv1 = await mock_coro("")
-            rv2 = await mock_coro(None)
-        else:
-            rv1 = asyncio.ensure_future(mock_coro(""))
-            rv2 = asyncio.ensure_future(mock_coro(None))
+        rv1 = await mock_coro("")
+        rv2 = await mock_coro(None)
         with patch.object(auth, 'validate_password', return_value=rv1):
             with patch.object(User.Objects, 'is_user_exists', return_value=rv2) as patch_user_exists:
                 resp = await client.put('/fledge/user/{}/password'.format(uid), data=json.dumps(request_data),
@@ -598,13 +513,8 @@ class TestAuthMandatory:
         uid = 2
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker, is_admin=False)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info >= (3, 8):
-            rv1 = await mock_coro("")
-            rv2 = await mock_coro(uid)
-        else:
-            rv1 = asyncio.ensure_future(mock_coro(""))
-            rv2 = asyncio.ensure_future(mock_coro(uid))
+        rv1 = await mock_coro("")
+        rv2 = await mock_coro(uid)
         with patch.object(auth, 'validate_password', return_value=rv1):
             with patch.object(User.Objects, 'is_user_exists', return_value=rv2) as patch_user_exists:
                 with patch.object(User.Objects, 'update', side_effect=exception_name(msg)) as patch_update:
@@ -627,13 +537,8 @@ class TestAuthMandatory:
         logger_msg = 'Failed to update the user ID:<{}>.'.format(uid)
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker, is_admin=False)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info >= (3, 8):
-            rv1 = await mock_coro("")
-            rv2 = await mock_coro(uid)
-        else:
-            rv1 = asyncio.ensure_future(mock_coro(""))
-            rv2 = asyncio.ensure_future(mock_coro(uid))
+        rv1 = await mock_coro("")
+        rv2 = await mock_coro(uid)
         with patch.object(auth, 'validate_password', return_value=rv1):
             with patch.object(User.Objects, 'is_user_exists', return_value=rv2) as patch_user_exists:
                 with patch.object(User.Objects, 'update', side_effect=Exception(msg)) as patch_update:
@@ -659,16 +564,9 @@ class TestAuthMandatory:
         msg = "Password has been updated successfully for user ID:<{}>.".format(user_id)
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker, is_admin=False)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            rv1 = await mock_coro("")
-            rv2 = await mock_coro(user_id)
-            rv3 = await mock_coro(ret_val)
-        else:
-            rv1 = asyncio.ensure_future(mock_coro(""))
-            rv2 = asyncio.ensure_future(mock_coro(user_id))
-            rv3 = asyncio.ensure_future(mock_coro(ret_val))
-        
+        rv1 = await mock_coro("")
+        rv2 = await mock_coro(user_id)
+        rv3 = await mock_coro(ret_val)
         with patch.object(auth, 'validate_password', return_value=rv1):
             with patch.object(User.Objects, 'is_user_exists', return_value=rv2) as patch_user_exists:
                 with patch.object(User.Objects, 'update', return_value=rv3) as patch_update:
@@ -693,8 +591,7 @@ class TestAuthMandatory:
         ret_val = [{'id': '1'}]
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(ret_val) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv) as patch_role_id:
             resp = await client.delete('/fledge/admin/{}/delete'.format(request_data), headers=ADMIN_USER_HEADER)
             assert 400 == resp.status
@@ -711,8 +608,7 @@ class TestAuthMandatory:
         ret_val = [{'id': '1'}]
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(ret_val) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv) as patch_role_id:
             with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
                 resp = await client.delete('/fledge/admin/1/delete', headers=ADMIN_USER_HEADER)
@@ -730,8 +626,7 @@ class TestAuthMandatory:
         ret_val = [{'id': '2'}]
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker, is_admin=False)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(ret_val) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv) as patch_role_id:
             with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
                 resp = await client.delete('/fledge/admin/2/delete', headers=NORMAL_USER_HEADER)
@@ -749,14 +644,8 @@ class TestAuthMandatory:
         msg = 'User with ID:<2> does not exist.'
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro([{'id': '1'}])
-            _rv2 = await mock_coro(ret_val)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv2 = asyncio.ensure_future(mock_coro(ret_val))
-
+        _rv1 = await mock_coro([{'id': '1'}])
+        _rv2 = await mock_coro(ret_val)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv1) as patch_role_id:
             with patch.object(User.Objects, 'delete', return_value=_rv2) as patch_user_delete:
                 resp = await client.delete('/fledge/admin/2/delete', headers=ADMIN_USER_HEADER)
@@ -773,14 +662,8 @@ class TestAuthMandatory:
         ret_val = {"response": "deleted", "rows_affected": 1}
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro([{'id': '1'}])
-            _rv2 = await mock_coro(ret_val)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv2 = asyncio.ensure_future(mock_coro(ret_val))
-
+        _rv1 = await mock_coro([{'id': '1'}])
+        _rv2 = await mock_coro(ret_val)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv1) as patch_role_id:
             with patch.object(auth._logger, 'info') as patch_auth_logger_info:
                 with patch.object(User.Objects, 'delete', return_value=_rv2) as patch_user_delete:
@@ -804,8 +687,7 @@ class TestAuthMandatory:
         ret_val = [{'id': '1'}]
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(ret_val) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv) as patch_role_id:
             with patch.object(User.Objects, 'delete', side_effect=exception_name(msg)) as patch_user_delete:
                 resp = await client.delete('/fledge/admin/2/delete', headers=ADMIN_USER_HEADER)
@@ -823,8 +705,7 @@ class TestAuthMandatory:
         ret_val = [{'id': '1'}]
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(ret_val) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv) as patch_role_id:
             with patch.object(auth._logger, 'error') as patch_logger:
                 with patch.object(User.Objects, 'delete', side_effect=Exception(msg)) as patch_user_delete:
@@ -844,8 +725,7 @@ class TestAuthMandatory:
         ret_val = {'response': 'deleted', 'rows_affected': 1}
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(ret_val) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(auth._logger, 'info') as patch_auth_logger_info:
             with patch.object(User.Objects, 'delete_user_tokens', return_value=_rv) as patch_delete_user_token:
                 resp = await client.put('/fledge/2/logout', headers=ADMIN_USER_HEADER)
@@ -864,8 +744,7 @@ class TestAuthMandatory:
         user_id = 111
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(ret_val) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(User.Objects, 'delete_user_tokens', return_value=_rv) as patch_delete_user_token:
             resp = await client.put('/fledge/{}/logout'.format(user_id), headers=ADMIN_USER_HEADER)
             assert 404 == resp.status
@@ -879,8 +758,7 @@ class TestAuthMandatory:
         ret_val = {'response': 'deleted', 'rows_affected': 1}
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(ret_val) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(auth._logger, 'info') as patch_auth_logger_info:
             with patch.object(User.Objects, 'delete_token', return_value=_rv) as patch_delete_token:
                 resp = await client.put('/fledge/logout', headers=ADMIN_USER_HEADER)
@@ -898,8 +776,7 @@ class TestAuthMandatory:
         ret_val = {'response': 'deleted', 'rows_affected': 0}
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(ret_val) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(auth._logger, 'error') as patch_auth_logger:
             with patch.object(User.Objects, 'delete_token', return_value=_rv) as patch_delete_token:
                 resp = await client.put('/fledge/logout', headers=ADMIN_USER_HEADER)
@@ -915,8 +792,7 @@ class TestAuthMandatory:
         ret_val = [{'id': '1'}]
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(ret_val) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv) as patch_role_id:
             with patch.object(auth._logger, 'warning') as patch_logger_warning:
                 resp = await client.put('/fledge/admin/1/enable', data=json.dumps({'role_id': 2}),
@@ -941,8 +817,7 @@ class TestAuthMandatory:
         ret_val = [{'id': '1'}]
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(ret_val) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv) as patch_role_id:
             resp = await client.put('/fledge/admin/2/enable', data=json.dumps(request_data),
                                     headers=ADMIN_USER_HEADER)
@@ -981,20 +856,11 @@ class TestAuthMandatory:
                          'new_value': {'enabled': _modified_enabled_val},
                          'message': "'AJ' user has been {}.".format(_text)}
         storage_client_mock = MagicMock(StorageClientAsync)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro([{'id': '1'}])
-            _rv2 = await mock_coro(update_result)
-            _rv3 = await mock_coro(None)
-            _se1 = await mock_coro(user_record)
-            _se2 = await mock_coro(update_user_record)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv2 = asyncio.ensure_future(mock_coro(update_result))
-            _rv3 = asyncio.ensure_future(mock_coro(None))
-            _se1 = asyncio.ensure_future(mock_coro(user_record))
-            _se2 = asyncio.ensure_future(mock_coro(update_user_record))
-
+        _rv1 = await mock_coro([{'id': '1'}])
+        _rv2 = await mock_coro(update_result)
+        _rv3 = await mock_coro(None)
+        _se1 = await mock_coro(user_record)
+        _se2 = await mock_coro(update_user_record)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv1) as patch_role_id:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(storage_client_mock, 'query_tbl_with_payload',
@@ -1029,8 +895,7 @@ class TestAuthMandatory:
         ret_val = [{'id': '1'}]
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(ret_val) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv) as patch_role_id:
             with patch.object(auth._logger, 'warning') as patch_logger_warning:
                 resp = await client.put('/fledge/admin/1/reset', data=json.dumps({'role_id': 2}),
@@ -1054,13 +919,8 @@ class TestAuthMandatory:
         ret_val = [{'id': '1'}]
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info >= (3, 8):
-            rv1 = await mock_coro(ret_val)
-            rv2 = await mock_coro(msg)
-        else:
-            rv1 = asyncio.ensure_future(mock_coro(ret_val))
-            rv2 = asyncio.ensure_future(mock_coro(msg))
+        rv1 = await mock_coro(ret_val)
+        rv2 = await mock_coro(msg)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=rv1) as patch_role_id:
             with patch.object(auth, 'validate_password', return_value=rv2):
                 resp = await client.put('/fledge/admin/2/reset', data=json.dumps(request_data),
@@ -1078,14 +938,8 @@ class TestAuthMandatory:
         msg = "Invalid or bad role id."
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro([{'id': '1'}])
-            _rv2 = await mock_coro(False)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv2 = asyncio.ensure_future(mock_coro(False))
-
+        _rv1 = await mock_coro([{'id': '1'}])
+        _rv2 = await mock_coro(False)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv1) as patch_role_id:
             with patch.object(auth, 'is_valid_role', return_value=_rv2) as patch_role:
                 resp = await client.put('/fledge/admin/2/reset', data=json.dumps(request_data),
@@ -1109,15 +963,9 @@ class TestAuthMandatory:
         user_id = 2
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            rv1 = await mock_coro([{'id': '1'}])
-            rv2 = await mock_coro(True)
-            rv3 = await mock_coro("")
-        else:
-            rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            rv2 = asyncio.ensure_future(mock_coro(True))
-            rv3 = asyncio.ensure_future(mock_coro(""))
+        rv1 = await mock_coro([{'id': '1'}])
+        rv2 = await mock_coro(True)
+        rv3 = await mock_coro("")
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=rv1) as patch_role_id:
             with patch.object(auth, 'is_valid_role', return_value=rv2) as patch_role:
                 with patch.object(auth, 'validate_password', return_value=rv3):
@@ -1145,16 +993,9 @@ class TestAuthMandatory:
 
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            rv1 = await mock_coro([{'id': '1'}])
-            rv2 = await mock_coro(True)
-            rv3 = await mock_coro("")
-        else:
-            rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            rv2 = asyncio.ensure_future(mock_coro(True))
-            rv3 = asyncio.ensure_future(mock_coro(""))
-
+        rv1 = await mock_coro([{'id': '1'}])
+        rv2 = await mock_coro(True)
+        rv3 = await mock_coro("")
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=rv1) as patch_role_id:
             with patch.object(auth, 'is_valid_role', return_value=rv2) as patch_role:
                 with patch.object(auth, 'validate_password', return_value=rv3):
@@ -1182,18 +1023,10 @@ class TestAuthMandatory:
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            rv1 = await mock_coro([{'id': '1'}])
-            rv2 = await mock_coro(True)
-            rv3 = await mock_coro(ret_val)
-            rv4 = await mock_coro("")
-        else:
-            rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            rv2 = asyncio.ensure_future(mock_coro(True))
-            rv3 = asyncio.ensure_future(mock_coro(ret_val))
-            rv4 = asyncio.ensure_future(mock_coro(""))
-
+        rv1 = await mock_coro([{'id': '1'}])
+        rv2 = await mock_coro(True)
+        rv3 = await mock_coro(ret_val)
+        rv4 = await mock_coro("")
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=rv1) as patch_role_id:
             with patch.object(auth, 'is_valid_role', return_value=rv2) as patch_role:
                 with patch.object(auth, 'validate_password', return_value=rv4):
@@ -1221,12 +1054,7 @@ class TestAuthMandatory:
         async def async_mock():
             return ret_val
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-
+        _rv = await async_mock()
         with patch.object(middleware._logger, 'debug') as patch_logger:
             with patch.object(User.Objects, 'login', return_value=_rv) as patch_user_login:
                 with patch.object(auth._logger, 'info') as patch_auth_logger:
@@ -1279,15 +1107,9 @@ class TestAuthMandatory:
         async def async_get_user():
             return {'role_id': '2', 'id': '2', 'uname': 'user'}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await asyncio.sleep(.1)
-            _rv2 = await async_mock()
-            _rv3 = await async_get_user()
-        else:
-            _rv1 = asyncio.ensure_future(asyncio.sleep(.1))
-            _rv2 = asyncio.ensure_future(async_mock())
-            _rv3 = asyncio.ensure_future(async_get_user())
+        _rv1 = await asyncio.sleep(.1)
+        _rv2 = await async_mock()
+        _rv3 = await async_get_user()
         with patch.object(middleware._logger, 'info'):
             with patch.object(server.Server, "auth_method", auth_method):
                 with patch.object(SSLVerifier, 'get_subject', return_value={"commonName": "user"}):
@@ -1381,8 +1203,7 @@ class TestAuthMandatory:
                 "value": "0"
             }
         }
-        rv = await mock_cat() if sys.version_info.major == 3 and sys.version_info.minor >= 8 else (
-            asyncio.ensure_future(mock_cat()))
+        rv = await mock_cat() 
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_all_items", return_value=rv) as patch_get_cat:
@@ -1439,8 +1260,8 @@ class TestAuthMandatory:
                 "value": "0"
             }
         }
-        rv = await mock_cat() if sys.version_info.major == 3 and sys.version_info.minor >= 8 else (
-            asyncio.ensure_future(mock_cat()))
+        rv = await mock_cat() 
+
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_all_items", return_value=rv) as patch_get_cat:
@@ -1458,17 +1279,10 @@ class TestAuthMandatory:
     async def test_bad_certificate(self, client, data, error_message):
         payload = {"expiration_days": data}
         valid_user = {'id': 1, 'uname': 'admin', 'role_id': '1'}
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro(valid_user['id'])
-            _rv2 = await mock_coro(None)
-            _rv3 = await mock_coro(valid_user)
-            _rv4 = await mock_coro([{'id': '1'}])
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro(valid_user['id']))
-            _rv2 = asyncio.ensure_future(mock_coro(None))
-            _rv3 = asyncio.ensure_future(mock_coro(valid_user))
-            _rv4 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-
+        _rv1 = await mock_coro(valid_user['id'])
+        _rv2 = await mock_coro(None)
+        _rv3 = await mock_coro(valid_user)
+        _rv4 = await mock_coro([{'id': '1'}])
         with patch.object(middleware._logger, 'debug') as patch_logger_debug:
             with patch.object(User.Objects, 'validate_token', return_value=_rv1) as patch_validate_token:
                 with patch.object(User.Objects, 'refresh_token_expiry', return_value=_rv2
@@ -1493,19 +1307,11 @@ class TestAuthMandatory:
         get_user = {'id': 3, 'uname': 'dviewer', 'real_name': 'Data Viewer', 'role_id': 4, 'description': 'Test',
                     'enabled': 'f', 'access_method': 'any'}
         msg = "An Authentication certificate has been created for user '{}'.".format(get_user['uname'])
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro(valid_user['id'])
-            _rv2 = await mock_coro(None)
-            _rv3 = await mock_coro([{'id': '1'}])
-            _se1 = await mock_coro(valid_user)
-            _se2 = await mock_coro(get_user)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro(valid_user['id']))
-            _rv2 = asyncio.ensure_future(mock_coro(None))
-            _rv3 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _se1 = asyncio.ensure_future(mock_coro(valid_user))
-            _se2 = asyncio.ensure_future(mock_coro(get_user))
-
+        _rv1 = await mock_coro(valid_user['id'])
+        _rv2 = await mock_coro(None)
+        _rv3 = await mock_coro([{'id': '1'}])
+        _se1 = await mock_coro(valid_user)
+        _se2 = await mock_coro(get_user)
         with patch.object(middleware._logger, 'debug') as patch_logger_debug:
             with patch.object(User.Objects, 'validate_token', return_value=_rv1) as patch_validate_token:
                 with patch.object(User.Objects, 'refresh_token_expiry', return_value=_rv2

--- a/tests/unit/python/fledge/services/core/api/test_auth_optional.py
+++ b/tests/unit/python/fledge/services/core/api/test_auth_optional.py
@@ -4,12 +4,10 @@
 # See: http://fledge-iot.readthedocs.io/
 # FLEDGE_END
 
-import asyncio
 import json
 from unittest.mock import patch
 from aiohttp import web
 import pytest
-import sys
 
 from fledge.common.web import middleware
 from fledge.services.core import routes
@@ -43,13 +41,7 @@ class TestAuthOptional:
         return client
 
     async def test_get_roles(self, client):
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro([])
-        else:
-            _rv = asyncio.ensure_future(mock_coro([]))
-        
+        _rv = await mock_coro([])
         with patch.object(middleware._logger, 'debug') as patch_logger:
             with patch.object(User.Objects, 'get_roles', return_value=_rv) as patch_user_obj:
                 resp = await client.get('/fledge/user/role')
@@ -74,11 +66,7 @@ class TestAuthOptional:
            "description": "Normal user"}])
     ])
     async def test_get_all_users(self, client, ret_val, exp_result):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(ret_val)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(ret_val))
+        _rv = await mock_coro(ret_val)
         with patch.object(middleware._logger, 'debug') as patch_logger:
             with patch.object(User.Objects, 'all', return_value=_rv) as patch_user_obj:
                 resp = await client.get('/fledge/user')
@@ -98,13 +86,7 @@ class TestAuthOptional:
     async def test_get_user_by_param(self, client, request_params, exp_result, arg1, arg2):
         result = {}
         result.update(exp_result)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(result)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(result))
-        
+        _rv = await mock_coro(result)
         with patch.object(middleware._logger, 'debug') as patch_logger:
             with patch.object(User.Objects, 'get', return_value=_rv) as patch_user_obj:
                 resp = await client.get('/fledge/user{}'.format(request_params))
@@ -170,13 +152,7 @@ class TestAuthOptional:
 
     ])
     async def test_login_exception(self, client, request_data, status_code, exception_name, msg):
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro([])
-        else:
-            _rv = asyncio.ensure_future(mock_coro([]))
-        
+        _rv = await mock_coro([])
         with patch.object(middleware._logger, 'debug') as patch_logger:
             with patch.object(User.Objects, 'login', side_effect=exception_name(msg)) as patch_user_login:
                 with patch.object(User.Objects, 'delete_user_tokens', return_value=_rv) as patch_delete_token:
@@ -203,12 +179,7 @@ class TestAuthOptional:
         async def async_mock():
             return ret_val
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())        
-        
+        _rv = await async_mock()
         with patch.object(middleware._logger, 'debug') as patch_logger:
             with patch.object(User.Objects, 'login', return_value=_rv) as patch_user_login:
                 with patch.object(auth._logger, 'info') as patch_auth_logger:
@@ -308,13 +279,7 @@ class TestAuthOptional:
     ])
     async def test_valid_role(self, role_id, expected):
         ret_val = [{"id": "1", "description": "for the users having all CRUD privileges including other admin users", "name": "admin"}, {"id": "2", "description": "all CRUD operations and self profile management", "name": "user"}]
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(ret_val)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(ret_val))
-
+        _rv = await mock_coro(ret_val)
         with patch.object(User.Objects, 'get_roles', return_value=_rv) as patch_get_roles:
             actual = await auth.is_valid_role(role_id)
             assert expected is actual

--- a/tests/unit/python/fledge/services/core/api/test_backup_restore.py
+++ b/tests/unit/python/fledge/services/core/api/test_backup_restore.py
@@ -5,10 +5,7 @@
 # FLEDGE_END
 
 import os
-import asyncio
 import json
-import sys
-
 from unittest.mock import MagicMock, patch
 from collections import Counter
 from aiohttp import web
@@ -78,12 +75,7 @@ class TestBackup:
                      'ts': '2018-02-15 15:18:41.821978+05:30',
                      'exit_code': '0'}]
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(response)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(response))
-        
+        _rv = await mock_coro(response)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(Backup, 'get_all_backups', return_value=_rv) as patch_get_all_backups:
                 resp = await client.get('/fledge/backup{}'.format(request_params))
@@ -120,12 +112,7 @@ class TestBackup:
         async def mock_create():
             return "running_or_failed"
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_create()
-        else:
-            _rv = asyncio.ensure_future(mock_create())
-        
+        _rv = await mock_create()
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(Backup, 'create_backup', return_value=_rv):
@@ -146,13 +133,7 @@ class TestBackup:
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'id': 1, 'file_name': '1.dump', 'ts': '2018-02-15 15:18:41.821978+05:30',
                     'status': '2', 'type': '1', 'exit_code': '0'}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(response)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(response))
-        
+        _rv = await mock_coro(response)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(Backup, 'get_backup_details', return_value=_rv):
                 resp = await client.get('/fledge/backup/{}'.format(1))
@@ -184,13 +165,7 @@ class TestBackup:
 
     async def test_delete_backup(self, client):
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(None)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(None))
-        
+        _rv = await mock_coro(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(Backup, 'delete_backup', return_value=_rv):
                 resp = await client.delete('/fledge/backup/{}'.format(1))
@@ -262,13 +237,7 @@ class TestBackup:
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'id': 1, 'file_name': '/usr/local/fledge/data/backup/fledge.db', 'ts': '2018-02-15 15:18:41',
                     'status': '2', 'type': '1'}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(response)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(response))
-        
+        _rv = await mock_coro(response)
         with patch("aiohttp.web.FileResponse", return_value=web.FileResponse(path=os.path.realpath(__file__))) as file_res:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(Backup, 'get_backup_details', return_value=_rv) as patch_backup_detail:
@@ -295,12 +264,7 @@ class TestRestore:
         async def mock_restore():
             return "running"
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_restore()
-        else:
-            _rv = asyncio.ensure_future(mock_restore())
-        
+        _rv = await mock_restore()
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(Restore, 'restore_backup', return_value=_rv):

--- a/tests/unit/python/fledge/services/core/api/test_browser_assets.py
+++ b/tests/unit/python/fledge/services/core/api/test_browser_assets.py
@@ -5,10 +5,8 @@
 # FLEDGE_END
 
 
-import asyncio
 import json
 from unittest.mock import MagicMock, patch
-import sys
 
 from aiohttp import web
 from aiohttp.web_urldispatcher import PlainResource, DynamicResource
@@ -154,13 +152,7 @@ class TestBrowserAssets:
     @pytest.mark.parametrize("request_url, payload, result", FIXTURE_1)
     async def test_end_points(self, client, request_url, payload, result):
         readings_storage_client_mock = MagicMock(ReadingsStorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(result)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(result))
-        
+        _rv = await mock_coro(result)
         with patch.object(connect, 'get_readings_async', return_value=readings_storage_client_mock):
             with patch.object(readings_storage_client_mock, 'query', return_value=_rv) as query_patch:
                 resp = await client.get(request_url)
@@ -182,13 +174,7 @@ class TestBrowserAssets:
     async def test_bad_request(self, client, request_url, response_code, payload):
         readings_storage_client_mock = MagicMock(ReadingsStorageClientAsync) 
         result = {'message': 'ERROR: something went wrong', 'retryable': False, 'entryPoint': 'retrieve'}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(result)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(result))        
-        
+        _rv = await mock_coro(result)
         with patch.object(connect, 'get_readings_async', return_value=readings_storage_client_mock):
             with patch.object(readings_storage_client_mock, 'query', return_value=_rv) as query_patch:
                 resp = await client.get(request_url)
@@ -205,7 +191,7 @@ class TestBrowserAssets:
     async def test_http_exception(self, client, request_url):
         readings_storage_client_mock = MagicMock(ReadingsStorageClientAsync)
         result = {}
-        value = await mock_coro(result) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(result))
+        value = await mock_coro(result)
         with patch.object(connect, 'get_readings_async', return_value=readings_storage_client_mock):
             with patch.object(readings_storage_client_mock, 'query', return_value=value):
                 resp = await client.get(request_url)
@@ -227,13 +213,7 @@ class TestBrowserAssets:
     ])
     async def test_bad_summary(self, client, status_code, message, storage_result, payload):
         readings_storage_client_mock = MagicMock(ReadingsStorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(storage_result)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(storage_result))
-        
+        _rv = await mock_coro(storage_result)
         with patch.object(connect, 'get_readings_async', return_value=readings_storage_client_mock):
             with patch.object(readings_storage_client_mock, 'query', return_value=_rv) \
                     as query_patch:
@@ -259,15 +239,8 @@ class TestBrowserAssets:
         asset_payload = '{"return": ["reading"], "where": {"column": "asset_code", "condition": "=", ' \
             '"value": "fogbench/humidity"}, "limit": 1, "sort": {"column": "user_ts", "direction": "desc"}}'
         readings_storage_client_mock = MagicMock(ReadingsStorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _se1 = await mock_coro(result1)
-            _se2 = await mock_coro(result2)
-        else:
-            _se1 = asyncio.ensure_future(mock_coro(result1))
-            _se2 = asyncio.ensure_future(mock_coro(result2))
-        
+        _se1 = await mock_coro(result1)
+        _se2 = await mock_coro(result2)
         with patch.object(connect, 'get_readings_async', return_value=readings_storage_client_mock):
             with patch.object(readings_storage_client_mock, 'query', side_effect=[_se1, _se2]) as query_patch:
                 resp = await client.get('/fledge/asset/fogbench%2fhumidity/temperature/summary')
@@ -293,12 +266,7 @@ class TestBrowserAssets:
     ])
     async def test_asset_averages_with_valid_group_name(self, client, group_name, payload, result):
         readings_storage_client_mock = MagicMock(ReadingsStorageClientAsync)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(result)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(result))
-        
+        _rv = await mock_coro(result)
         with patch.object(connect, 'get_readings_async', return_value=readings_storage_client_mock):
             with patch.object(readings_storage_client_mock, 'query', return_value=_rv) as query_patch:
                 resp = await client.get('fledge/asset/fogbench%2Fhumidity/temperature/series?group={}'
@@ -344,13 +312,7 @@ class TestBrowserAssets:
     ])
     async def test_limit_skip_time_units_payload(self, client, request_params, payload):
         readings_storage_client_mock = MagicMock(ReadingsStorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro({'count': 0, 'rows': []})
-        else:
-            _rv = asyncio.ensure_future(mock_coro({'count': 0, 'rows': []}))
-        
+        _rv = await mock_coro({'count': 0, 'rows': []})
         with patch.object(connect, 'get_readings_async', return_value=readings_storage_client_mock):
             with patch.object(readings_storage_client_mock, 'query', return_value=_rv) \
                     as query_patch:
@@ -392,15 +354,8 @@ class TestBrowserAssets:
             "where": {"column": "asset_code", "condition": "=", "value": "fogbench_humidity"}, "limit": 20}
 
         readings_storage_client_mock = MagicMock(ReadingsStorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _se1 = await q_result(payload1)
-            _se2 = await q_result(payload2)
-        else:
-            _se1 = asyncio.ensure_future(q_result(payload1))
-            _se2 = asyncio.ensure_future(q_result(payload2))
-        
+        _se1 = await q_result(payload1)
+        _se2 = await q_result(payload2)
         with patch.object(connect, 'get_readings_async', return_value=readings_storage_client_mock):
             with patch.object(readings_storage_client_mock, 'query', side_effect=[_se1, _se2]) as patch_query:
                 resp = await client.get('fledge/asset/fogbench_humidity/summary')
@@ -554,13 +509,7 @@ class TestBrowserAssets:
     ])
     async def test_order_payload_good(self, client, request_params, payload):
         readings_storage_client_mock = MagicMock(ReadingsStorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro({'count': 0, 'rows': []})
-        else:
-            _rv = asyncio.ensure_future(mock_coro({'count': 0, 'rows': []}))
-        
+        _rv = await mock_coro({'count': 0, 'rows': []})
         with patch.object(connect, 'get_readings_async', return_value=readings_storage_client_mock):
             with patch.object(readings_storage_client_mock, 'query', return_value=_rv) \
                     as query_patch:
@@ -589,13 +538,8 @@ class TestBrowserAssets:
         readings_storage_client_mock = MagicMock(ReadingsStorageClientAsync)
         result_for_reading = {'rows': [{'reading': {'testcard': '__DPIMAGE:256,256,8_A'}}], 'count': 1}
         if request_url.endswith('summary'):
-            # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-            if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-                _se1 = await mock_coro(result_for_reading)
-                _se2 = await mock_coro(result)
-            else:
-                _se1 = asyncio.ensure_future(mock_coro(result_for_reading))
-                _se2 = asyncio.ensure_future(mock_coro(result))
+            _se1 = await mock_coro(result_for_reading)
+            _se2 = await mock_coro(result)
             with patch.object(connect, 'get_readings_async', return_value=readings_storage_client_mock):
                 with patch.object(readings_storage_client_mock, 'query', side_effect=[_se1, _se2]):
                     resp = await client.get(request_url)
@@ -606,8 +550,7 @@ class TestBrowserAssets:
                         [{'testcard': result['rows'][0]}]
                     assert expected_result == json_response
         else:
-            _rv = await mock_coro(result) if sys.version_info.major == 3 and sys.version_info.minor >= 8 else \
-                asyncio.ensure_future(mock_coro(result))
+            _rv = await mock_coro(result)
             with patch.object(connect, 'get_readings_async', return_value=readings_storage_client_mock):
                 with patch.object(readings_storage_client_mock, 'query', return_value=_rv) as query_patch:
                     resp = await client.get(request_url)
@@ -635,8 +578,7 @@ class TestBrowserAssets:
         storage_result = {'count': 1, 'rows': [{'reading': {'testcard': '__DPIMAGE:256,256,8_AA'}}]}
         image_placeholder_result = [{'reading': {'testcard': 'Data removed for brevity'}}]
         readings_storage_client_mock = MagicMock(ReadingsStorageClientAsync)
-        _rv = await mock_coro(storage_result) if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(mock_coro(storage_result))
+        _rv = await mock_coro(storage_result)
         with patch.object(connect, 'get_readings_async', return_value=readings_storage_client_mock):
             with patch.object(readings_storage_client_mock, 'query', return_value=_rv) as query_patch:
                 resp = await client.get(request_url)

--- a/tests/unit/python/fledge/services/core/api/test_certificate_store.py
+++ b/tests/unit/python/fledge/services/core/api/test_certificate_store.py
@@ -5,8 +5,6 @@
 # FLEDGE_END
 
 
-import sys
-import asyncio
 import json
 import pathlib
 
@@ -145,9 +143,8 @@ class TestCertificateStore:
     async def test_bad_delete_cert_with_invalid_filename(self, client, cert_name, actual_code, actual_reason):
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(REST_API_CAT_INFO) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(REST_API_CAT_INFO))
+        
+        _rv = await mock_coro(REST_API_CAT_INFO)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_cat_all_items:
                 resp = await client.delete('/fledge/certificate/{}'.format(cert_name))
@@ -185,9 +182,7 @@ class TestCertificateStore:
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         msg = 'Only cert and key are allowed for the value of type param'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(REST_API_CAT_INFO) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(REST_API_CAT_INFO))
+        _rv = await mock_coro(REST_API_CAT_INFO)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_cat_all_items:
                 resp = await client.delete('/fledge/certificate/server.cert?type=pem')
@@ -208,9 +203,9 @@ class TestCertificateStore:
     async def test_delete_cert_with_type(self, client, cert_name, param):
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
+        
         cat_info = {'certificateName': {'value': 'foo'}, 'authCertificateName': {'value': 'ca'}}
-        _rv = await mock_coro(cat_info) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(cat_info))
+        _rv = await mock_coro(cat_info)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_cat_all_items:
                 with patch('os.path.isfile', return_value=True):
@@ -226,9 +221,8 @@ class TestCertificateStore:
     async def test_delete_cert(self, client, certs_path, cert_name='server.cert'):
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_coro(REST_API_CAT_INFO) if sys.version_info >= (3, 8) else asyncio.ensure_future(
-            mock_coro(REST_API_CAT_INFO))
+        
+        _rv = await mock_coro(REST_API_CAT_INFO)
         with patch.object(certificate_store, '_get_certs_dir', return_value=str(certs_path / 'certs') + '/'):
             with patch('os.walk') as mockwalk:
                 mockwalk.return_value = [(str(certs_path / 'certs'), [], [cert_name])]
@@ -271,15 +265,10 @@ class TestUploadCertStoreIfAuthenticationIsMandatory:
 
     async def auth_token_fixture(self, mocker, is_admin=True):
         user = {'id': 1, 'uname': 'admin', 'role_id': '1'} if is_admin else {'id': 2, 'uname': 'user', 'role_id': '2'}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro(user['id'])
-            _rv2 = await mock_coro(None)
-            _rv3 = await mock_coro(user)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro(user['id']))
-            _rv2 = asyncio.ensure_future(mock_coro(None))
-            _rv3 = asyncio.ensure_future(mock_coro(user))
+        
+        _rv1 = await mock_coro(user['id'])
+        _rv2 = await mock_coro(None)
+        _rv3 = await mock_coro(user)
         patch_logger_debug = mocker.patch.object(middleware._logger, 'debug')
         patch_validate_token = mocker.patch.object(User.Objects, 'validate_token', return_value=_rv1)
         patch_refresh_token = mocker.patch.object(User.Objects, 'refresh_token_expiry', return_value=_rv2)
@@ -311,12 +300,12 @@ class TestUploadCertStoreIfAuthenticationIsMandatory:
             mocker, is_admin=False)
         msg = 'Certificate with name test.cer is configured to be used, ' \
               'An `admin` role permissions required to add/overwrite.'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
+        
         cat_info = {'certificateName':  {'value': 'test'},  'authCertificateName':  {'value': 'foo'}}
-        _rv = await mock_coro(cat_info) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(cat_info))
+        _rv = await mock_coro(cat_info)
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
+        
         with patch.object(certificate_store._logger, 'warning') as patch_logger:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_cat_all_items:
@@ -445,15 +434,10 @@ class TestDeleteCertStoreIfAuthenticationIsMandatory:
 
     async def auth_token_fixture(self, mocker, is_admin=True):
         user = {'id': 1, 'uname': 'admin', 'role_id': '1'} if is_admin else {'id': 2, 'uname': 'user', 'role_id': '2'}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro(user['id'])
-            _rv2 = await mock_coro(None)
-            _rv3 = await mock_coro(user)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro(user['id']))
-            _rv2 = asyncio.ensure_future(mock_coro(None))
-            _rv3 = asyncio.ensure_future(mock_coro(user))
+        
+        _rv1 = await mock_coro(user['id'])
+        _rv2 = await mock_coro(None)
+        _rv3 = await mock_coro(user)
         patch_logger_debug = mocker.patch.object(middleware._logger, 'debug')
         patch_validate_token = mocker.patch.object(User.Objects, 'validate_token', return_value=_rv1)
         patch_refresh_token = mocker.patch.object(User.Objects, 'refresh_token_expiry', return_value=_rv2)
@@ -469,13 +453,9 @@ class TestDeleteCertStoreIfAuthenticationIsMandatory:
         c_mgr = ConfigurationManager(storage_client_mock)
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro([{'id': '1'}])
-            _rv2 = await mock_coro(REST_API_CAT_INFO)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv2 = asyncio.ensure_future(mock_coro(REST_API_CAT_INFO))
+        
+        _rv1 = await mock_coro([{'id': '1'}])
+        _rv2 = await mock_coro(REST_API_CAT_INFO)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv1) as patch_role_id:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv2) as patch_get_cat_all_items:
@@ -500,9 +480,9 @@ class TestDeleteCertStoreIfAuthenticationIsMandatory:
     async def test_bad_delete_cert(self, client, mocker, cert_name, actual_code, actual_reason):
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
+        
         _payload = [{'id': '1'}]
-        _rv = await mock_coro(_payload) if sys.version_info >= (3, 8) else asyncio.ensure_future(mock_coro(_payload))
+        _rv = await mock_coro(_payload)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv):
             resp = await client.delete('/fledge/certificate/{}'.format(cert_name), headers=ADMIN_USER_HEADER)
             assert actual_code == resp.status
@@ -524,13 +504,9 @@ class TestDeleteCertStoreIfAuthenticationIsMandatory:
             cert_name)
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro([{'id': '1'}])
-            _rv2 = await mock_coro(REST_API_CAT_INFO)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv2 = asyncio.ensure_future(mock_coro(REST_API_CAT_INFO))
+        
+        _rv1 = await mock_coro([{'id': '1'}])
+        _rv2 = await mock_coro(REST_API_CAT_INFO)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv1) as patch_role_id:
             with patch('os.path.isfile', return_value=True):
                 with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -557,14 +533,9 @@ class TestDeleteCertStoreIfAuthenticationIsMandatory:
         msg = 'Only cert and key are allowed for the value of type param'
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro([{'id': '1'}])
-            _rv2 = await mock_coro(REST_API_CAT_INFO)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv2 = asyncio.ensure_future(mock_coro(REST_API_CAT_INFO))
         
+        _rv1 = await mock_coro([{'id': '1'}])
+        _rv2 = await mock_coro(REST_API_CAT_INFO)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv1) as patch_role_id:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv2) as patch_get_cat_all_items:
@@ -595,14 +566,10 @@ class TestDeleteCertStoreIfAuthenticationIsMandatory:
         c_mgr = ConfigurationManager(storage_client_mock)
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
+        
         cat_info = {'certificateName':  {'value': 'foo'},  'authCertificateName':  {'value': 'ca'}}
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro([{'id': '1'}])
-            _rv2 = await mock_coro(cat_info)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv2 = asyncio.ensure_future(mock_coro(cat_info))
+        _rv1 = await mock_coro([{'id': '1'}])
+        _rv2 = await mock_coro(cat_info)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv1) as patch_role_id:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv2) as patch_get_cat_all_items:
@@ -628,14 +595,9 @@ class TestDeleteCertStoreIfAuthenticationIsMandatory:
         c_mgr = ConfigurationManager(storage_client_mock)
         patch_logger_debug, patch_validate_token, patch_refresh_token, patch_user_get = await self.auth_token_fixture(
             mocker)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro([{'id': '1'}])
-            _rv2 = await mock_coro(REST_API_CAT_INFO)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro([{'id': '1'}]))
-            _rv2 = asyncio.ensure_future(mock_coro(REST_API_CAT_INFO))
         
+        _rv1 = await mock_coro([{'id': '1'}])
+        _rv2 = await mock_coro(REST_API_CAT_INFO)
         with patch.object(User.Objects, 'get_role_id_by_name', return_value=_rv1) as patch_role_id:
             with patch.object(certificate_store, '_get_certs_dir', return_value=str(certs_path / 'certs') + '/'):
                 with patch('os.walk') as mockwalk:

--- a/tests/unit/python/fledge/services/core/api/test_common_ping.py
+++ b/tests/unit/python/fledge/services/core/api/test_common_ping.py
@@ -13,7 +13,6 @@ This test file assumes those 2 units are tested
 """
 
 import re
-import asyncio
 import json
 import ssl
 import socket
@@ -22,8 +21,6 @@ import pathlib
 import time
 from unittest.mock import MagicMock, patch
 import pytest
-import sys
-
 import aiohttp
 from aiohttp import web
 
@@ -74,12 +71,7 @@ async def test_ping_http_allow_ping_true(aiohttp_server, aiohttp_client, loop, g
     async def mock_coro(*args, **kwargs):
         return result
     
-    # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-        _rv = await mock_coro()
-    else:
-        _rv = asyncio.ensure_future(mock_coro())
-    
+    _rv = await mock_coro()
     host_name, ip_addresses = get_machine_detail
     attrs = {"query_tbl_with_payload.return_value": await mock_coro()}
     mock_storage_client_async = MagicMock(spec=StorageClientAsync, **attrs)
@@ -134,12 +126,7 @@ async def test_ping_http_allow_ping_false(aiohttp_server, aiohttp_client, loop, 
         ]}
         return result
 
-    # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-        _rv = await mock_coro()
-    else:
-        _rv = asyncio.ensure_future(mock_coro())
-    
+    _rv = await mock_coro()
     host_name, ip_addresses = get_machine_detail
     mock_storage_client_async = MagicMock(StorageClientAsync)
     with patch.object(middleware._logger, 'debug') as logger_info:
@@ -193,14 +180,8 @@ async def test_ping_http_auth_required_allow_ping_true(aiohttp_server, aiohttp_c
     async def mock_get_category_item():
         return {"value": "true"}
 
-    # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-        _rv1 = await mock_coro()
-        _rv2 = await mock_get_category_item()
-    else:
-        _rv1 = asyncio.ensure_future(mock_coro())
-        _rv2 = asyncio.ensure_future(mock_get_category_item())
-    
+    _rv1 = await mock_coro()
+    _rv2 = await mock_get_category_item()
     host_name, ip_addresses = get_machine_detail
     mock_storage_client_async = MagicMock(StorageClientAsync)
     with patch.object(middleware._logger, 'debug') as logger_info:
@@ -255,14 +236,8 @@ async def test_ping_http_auth_required_allow_ping_false(aiohttp_server, aiohttp_
     async def mock_get_category_item():
         return {"value": "false"}
 
-    # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-        _rv1 = await mock_coro()
-        _rv2 = await mock_get_category_item()
-    else:
-        _rv1 = asyncio.ensure_future(mock_coro())
-        _rv2 = asyncio.ensure_future(mock_get_category_item())
-    
+    _rv1 = await mock_coro()
+    _rv2 = await mock_get_category_item()
     mock_storage_client_async = MagicMock(StorageClientAsync)
     with patch.object(middleware._logger, 'debug') as logger_info:
         with patch.object(connect, 'get_storage_async', return_value=mock_storage_client_async):
@@ -302,12 +277,7 @@ async def test_ping_https_allow_ping_true(aiohttp_server, ssl_ctx, aiohttp_clien
     async def mock_coro(*args, **kwargs):
         return result
 
-    # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-        _rv = await mock_coro()
-    else:
-        _rv = asyncio.ensure_future(mock_coro())
-    
+    _rv = await mock_coro()
     host_name, ip_addresses = get_machine_detail
     mock_storage_client_async = MagicMock(StorageClientAsync)
     with patch.object(middleware._logger, 'debug') as logger_info:
@@ -371,12 +341,7 @@ async def test_ping_https_allow_ping_false(aiohttp_server, ssl_ctx, aiohttp_clie
     async def mock_coro(*args, **kwargs):
         return result
 
-    # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-        _rv = await mock_coro()
-    else:
-        _rv = asyncio.ensure_future(mock_coro())
-    
+    _rv = await mock_coro()
     host_name, ip_addresses = get_machine_detail
     mock_storage_client_async = MagicMock(StorageClientAsync)
     with patch.object(middleware._logger, 'debug') as logger_info:
@@ -437,14 +402,8 @@ async def test_ping_https_auth_required_allow_ping_true(aiohttp_server, ssl_ctx,
     async def mock_get_category_item():
         return {"value": "true"}
 
-    # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-        _rv1 = await mock_coro()
-        _rv2 = await mock_get_category_item()
-    else:
-        _rv1 = asyncio.ensure_future(mock_coro())
-        _rv2 = asyncio.ensure_future(mock_get_category_item())    
-    
+    _rv1 = await mock_coro()
+    _rv2 = await mock_get_category_item()
     host_name, ip_addresses = get_machine_detail
     mock_storage_client_async = MagicMock(StorageClientAsync)
     with patch.object(middleware._logger, 'debug') as logger_info:
@@ -511,14 +470,8 @@ async def test_ping_https_auth_required_allow_ping_false(aiohttp_server, ssl_ctx
     async def mock_get_category_item():
         return {"value": "false"}
 
-    # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-        _rv1 = await mock_coro()
-        _rv2 = await mock_get_category_item()
-    else:
-        _rv1 = asyncio.ensure_future(mock_coro())
-        _rv2 = asyncio.ensure_future(mock_get_category_item())    
-    
+    _rv1 = await mock_coro()
+    _rv2 = await mock_get_category_item()
     mock_storage_client_async = MagicMock(StorageClientAsync)
     with patch.object(middleware._logger, 'debug') as logger_info:
         with patch.object(connect, 'get_storage_async', return_value=mock_storage_client_async):

--- a/tests/unit/python/fledge/services/core/api/test_configuration.py
+++ b/tests/unit/python/fledge/services/core/api/test_configuration.py
@@ -4,7 +4,6 @@
 # See: http://fledge-iot.readthedocs.io/
 # FLEDGE_END
 
-import sys
 import copy
 import asyncio
 import json
@@ -50,13 +49,7 @@ class TestConfiguration:
                                  {'key': 'service', 'description': 'Service configuration', 'displayName': 'SERV'}]}
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_all_category_names', return_value=_rv) as patch_get_all_items:
                 resp = await client.get('/fledge/category')
@@ -78,13 +71,7 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_all_category_names', return_value=_rv) as patch_get_all_items:
                 resp = await client.get('/fledge/category?root={}'.format(value))
@@ -110,11 +97,8 @@ class TestConfiguration:
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
+        
+        _rv = await async_mock()
         
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_all_category_names', return_value=_rv) as patch_get_all_items:
@@ -140,13 +124,7 @@ class TestConfiguration:
         result = {'categories': d}
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_all_category_names', return_value=_rv) as patch_get_all_items:
                 resp = await client.get('/fledge/category?root=true&children=true')
@@ -166,13 +144,7 @@ class TestConfiguration:
         result = {'categories': d}
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_all_category_names', return_value=_rv) as patch_get_all_items:
                 resp = await client.get('/fledge/category?root=false&children=true')
@@ -188,13 +160,7 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_all_items:
                 resp = await client.get('/fledge/category/{}'.format(category_name))
@@ -213,13 +179,7 @@ class TestConfiguration:
             return expected_result
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_all_items:
                 resp = await client.get('/fledge/category/{}'.format(category_name))
@@ -237,13 +197,7 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', return_value=_rv) as patch_get_cat_item:
                 resp = await client.get('/fledge/category/{}/{}'.format(category_name, item_name))
@@ -261,13 +215,7 @@ class TestConfiguration:
             return expected_result
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', return_value=_rv) as patch_get_cat_item:
                 resp = await client.get('/fledge/category/{}/{}'.format(category_name, item_name))
@@ -290,15 +238,8 @@ class TestConfiguration:
         payload = {"value": expected_result['value']}
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
-            _se = await async_mock(expected_result)
-        else:
-            _rv = asyncio.ensure_future(async_mock(None))
-            _se = asyncio.ensure_future(async_mock(expected_result))
-        
+        _rv = await async_mock(None)
+        _se = await async_mock(expected_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'set_category_item_value_entry', return_value=_rv) as patch_set_entry:
                 with patch.object(c_mgr, 'get_category_item', side_effect=[_se, _se]) as patch_get_cat_item:
@@ -348,17 +289,9 @@ class TestConfiguration:
         c_mgr = ConfigurationManager(storage_client_mock)
         storage_value_entry = {'value': '8082', 'type': 'integer', 'default': '8081',
                                'description': 'The port to accept HTTP connections on'}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
-            _se1 = await async_mock(storage_value_entry)
-            _se2 = await async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(async_mock(None))
-            _se1 = asyncio.ensure_future(async_mock(storage_value_entry))
-            _se2 = asyncio.ensure_future(async_mock(None))
-        
+        _rv = await async_mock(None)
+        _se1 = await async_mock(storage_value_entry)
+        _se2 = await async_mock(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'set_category_item_value_entry', return_value=_rv) as patch_set_entry:
                 with patch.object(c_mgr, 'get_category_item', side_effect=[_se1, _se2]) as patch_get_cat_item:
@@ -393,13 +326,7 @@ class TestConfiguration:
         c_mgr = ConfigurationManager(storage_client_mock)
         storage_value_entry = {'value': '8082', 'type': 'integer', 'default': '8081',
                                'description': 'The port to accept HTTP connections on', optional_item: 'true'}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(storage_value_entry)
-        else:
-            _rv = asyncio.ensure_future(async_mock(storage_value_entry))
-        
+        _rv = await async_mock(storage_value_entry)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', return_value=_rv) as patch_get_cat:
                 resp = await client.put('/fledge/category/{}/{}'.format(category_name, item_name), data=json.dumps(payload))
@@ -421,15 +348,8 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(None)
-            _rv2 = await async_mock(result)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock(None))
-            _rv2 = asyncio.ensure_future(async_mock(result))
-        
+        _rv1 = await async_mock(None)
+        _rv2 = await async_mock(result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'set_optional_value_entry', return_value=_rv1) as patch_set_entry:
                 with patch.object(c_mgr, 'get_category_item', return_value=_rv2) as patch_get_cat_item:
@@ -465,15 +385,8 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
-            _se = await async_mock(expected_result)
-        else:
-            _rv = asyncio.ensure_future(async_mock(None))
-            _se = asyncio.ensure_future(async_mock(expected_result))
-        
+        _rv = await async_mock(None)
+        _se = await async_mock(expected_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', side_effect=[_se, _se]) as patch_get_cat_item:
                 with patch.object(c_mgr, 'set_category_item_value_entry', return_value=_rv) as patch_set_entry:
@@ -499,13 +412,7 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _se = await async_mock()
-        else:
-            _se = asyncio.ensure_future(async_mock())
-        
+        _se = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', side_effect=[_se]) as patch_get_cat_item:
                 resp = await client.delete('/fledge/category/{}/{}/value'.format(category_name, item_name))
@@ -522,13 +429,7 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', return_value=_rv) as patch_get_cat_item:
                 resp = await client.delete('/fledge/category/{}/{}/value'.format(category_name, item_name))
@@ -548,17 +449,9 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
-            _se1 = await async_mock(result)
-            _se2 = await async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(async_mock(None))
-            _se1 = asyncio.ensure_future(async_mock(result))
-            _se2 = asyncio.ensure_future(async_mock(None))        
-        
+        _rv = await async_mock(None)
+        _se1 = await async_mock(result)
+        _se2 = await async_mock(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', side_effect=[_se1, _se2]) as patch_get_cat_item:
                 with patch.object(c_mgr, 'set_category_item_value_entry', return_value=_rv) as patch_set_entry:
@@ -621,15 +514,8 @@ class TestConfiguration:
             payload.update({'displayName': payload['key']})
 
         c_mgr._cacheManager.update(payload['key'], payload['description'], new_info, payload['displayName'])
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(None)
-            _rv2 = await async_mock(new_info)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock(None))
-            _rv2 = asyncio.ensure_future(async_mock(new_info))
-        
+        _rv1 = await async_mock(None)
+        _rv2 = await async_mock(new_info)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'create_category', return_value=_rv1) as patch_create_cat:
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv2) as patch_cat_all_item:
@@ -670,15 +556,8 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock_create_cat()
-            _rv2 = await async_mock()
-        else:
-            _rv1 = asyncio.ensure_future(async_mock_create_cat())
-            _rv2 = asyncio.ensure_future(async_mock())
-        
+        _rv1 = await async_mock_create_cat()
+        _rv2 = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'create_category', return_value=_rv1) as patch_create_cat:
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv2) as patch_cat_all_item:
@@ -733,13 +612,7 @@ class TestConfiguration:
         payload = {"default": "1", "description": "Test description", "type": "integer"}
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_all_items:
                 resp = await client.post('/fledge/category/{}/{}'.format(category_name, "info"), data=json.dumps(payload))
@@ -755,13 +628,7 @@ class TestConfiguration:
         payload = {"default": "1", "description": "Test description", "type": "integer"}
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_all_items:
                 resp = await client.post('/fledge/category/{}/{}'.format(category_name, "info"), data=json.dumps(payload))
@@ -788,18 +655,10 @@ class TestConfiguration:
         new_config_item = 'info1'
         result = {'message': '{} config item has been saved for {} category'.format(new_config_item, category_name)}
         storage_client_mock = MagicMock(StorageClientAsync)
-        c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock()
-            _rv2 = await async_mock_expected()
-            _rv3 = await async_audit_mock(None)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock())
-            _rv2 = asyncio.ensure_future(async_mock_expected())
-            _rv3 = asyncio.ensure_future(async_audit_mock(None))
-        
+        c_mgr = ConfigurationManager(storage_client_mock)        
+        _rv1 = await async_mock()
+        _rv2 = await async_mock_expected()
+        _rv3 = await async_audit_mock(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_all_items:
                 with patch.object(storage_client_mock, 'update_tbl', return_value=_rv2) as update_tbl_patch:
@@ -839,13 +698,7 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_child', return_value=_rv) as patch_get_child_cat:
                 resp = await client.get('/fledge/category/south/children')
@@ -864,13 +717,7 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()        
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'create_child_category', return_value=_rv) as patch_create_child_cat:
                 resp = await client.post('/fledge/category/{}/children'.format("south"), data=json.dumps(data))
@@ -886,13 +733,7 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()       
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'delete_child_category', return_value=_rv) as patch_delete_child_cat:
                 resp = await client.delete('/fledge/category/{}/children/{}'.format("south", "coap"))
@@ -908,13 +749,7 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()       
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'delete_parent_category', return_value=_rv) as patch_delete_parent_cat:
                 resp = await client.delete('/fledge/category/{}/parent'.format("south"))
@@ -941,17 +776,9 @@ class TestConfiguration:
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         c_mgr._cacheManager.update(name, desc, info, name)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock()
-            _rv2 = await async_mock2()
-            _rv3 = await async_mock_create_cat()
-        else:
-            _rv1 = asyncio.ensure_future(async_mock())
-            _rv2 = asyncio.ensure_future(async_mock2())
-            _rv3 = asyncio.ensure_future(async_mock_create_cat())
-        
+        _rv1 = await async_mock()
+        _rv2 = await async_mock2()
+        _rv3 = await async_mock_create_cat()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'create_category', return_value=_rv3) as patch_create_cat:
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_cat_all_item:
@@ -1000,13 +827,7 @@ class TestConfiguration:
         payload = {config_item_name: "8082"}
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(async_mock(None))
-        
+        _rv = await async_mock(None)       
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', return_value=_rv) as patch_get_cat_item:
                 resp = await client.put('/fledge/category/{}'.format(category_name), data=json.dumps(payload))
@@ -1027,13 +848,7 @@ class TestConfiguration:
         c_mgr = ConfigurationManager(storage_client_mock)
         storage_value_entry = {'description': 'Port to accept HTTP connections on', 'displayName': 'HTTP Port',
                                'value': '8081', 'default': '8081', 'order': '2', 'type': 'integer', optional_item: 'true'}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(storage_value_entry)
-        else:
-            _rv = asyncio.ensure_future(async_mock(storage_value_entry))
-        
+        _rv = await async_mock(storage_value_entry)     
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', return_value=_rv) as patch_get_cat_item:
                 resp = await client.put('/fledge/category/{}'.format(category_name), data=json.dumps(payload))
@@ -1058,19 +873,10 @@ class TestConfiguration:
         c_mgr = ConfigurationManager(storage_client_mock)
         storage_value_entry1 = {'description': 'Port to accept HTTP connections on', 'displayName': 'HTTP Port', 'value': '8081', 'default': '8081', 'order': '2', 'type': 'integer'}
         storage_value_entry2 = {'options': ['mandatory', 'optional'], 'description': 'API Call Authentication', 'displayName': 'Authentication', 'value': 'optional', 'default': 'optional', 'order': '5', 'type': 'enumeration'}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(response)
-            _rv2 = await async_mock(result)
-            _se1 = await async_mock(storage_value_entry1)
-            _se2 = await async_mock(storage_value_entry2)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock(response))
-            _rv2 = asyncio.ensure_future(async_mock(result))
-            _se1 = asyncio.ensure_future(async_mock(storage_value_entry1))
-            _se2 = asyncio.ensure_future(async_mock(storage_value_entry2))    
-        
+        _rv1 = await async_mock(response)
+        _rv2 = await async_mock(result)
+        _se1 = await async_mock(storage_value_entry1)
+        _se2 = await async_mock(storage_value_entry2)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', side_effect=[_se1, _se2]) as patch_get_cat_item:
                 with patch.object(c_mgr, 'update_configuration_item_bulk', return_value=_rv1) as patch_update_bulk:
@@ -1094,13 +900,7 @@ class TestConfiguration:
         result = {'result': 'Category {} deleted successfully.'.format(category_name)}
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await asyncio.sleep(.1)
-        else:
-            _rv = asyncio.ensure_future(asyncio.sleep(.1))
-        
+        _rv = await asyncio.sleep(.1)       
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'delete_category_and_children_recursively', return_value=_rv) as patch_delete_cat:
                 resp = await client.delete('/fledge/category/{}'.format(category_name))
@@ -1128,13 +928,8 @@ class TestConfiguration:
                                'minimum': '1', 'maximum': '1000', 'value': '30'}
 
         cat_items = {config_item: storage_value_entry}
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            rv = await async_mock(storage_value_entry)
-            rv2 = await async_mock(cat_items)
-        else:
-            rv = asyncio.ensure_future(async_mock(storage_value_entry))
-            rv2 = asyncio.ensure_future(async_mock(cat_items))
-
+        rv = await async_mock(storage_value_entry)
+        rv2 = await async_mock(cat_items)
         expected_message = "For config item cacheSize you cannot set the new value, beyond the range (1,1000)"
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', return_value=rv) as patch_get_cat_item:

--- a/tests/unit/python/fledge/services/core/api/test_filters.py
+++ b/tests/unit/python/fledge/services/core/api/test_filters.py
@@ -9,8 +9,6 @@ import json
 from unittest.mock import MagicMock, patch, call
 from aiohttp import web
 import pytest
-import sys
-
 from fledge.common.configuration_manager import ConfigurationManager
 from fledge.common.storage_client.exceptions import StorageServerError
 from fledge.common.storage_client.storage_client import StorageClientAsync
@@ -42,13 +40,7 @@ class TestFilters:
             return {"rows": []}
 
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await get_filters()
-        else:
-            _rv = asyncio.ensure_future(get_filters())
-        
+        _rv = await get_filters()        
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=_rv) as query_tbl_patch:
                 resp = await client.get('/fledge/filter')
@@ -77,13 +69,7 @@ class TestFilters:
             return {"count": 1}
 
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await get_filters()
-        else:
-            _rv = asyncio.ensure_future(get_filters())
-        
+        _rv = await get_filters()        
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=_rv) as query_tbl_patch:
                 with patch.object(_LOGGER, 'error') as patch_logger:
@@ -114,13 +100,7 @@ class TestFilters:
         result = {"filter": {"config": cat_info, "name": filter_name, "plugin": "python35", "users": []}}
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(cat_info)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(cat_info))
-        
+        _rv = await self.async_mock(cat_info)       
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv) as get_cat_info_patch:
                 with patch.object(storage_client_mock, 'query_tbl_with_payload', side_effect=q_result):
@@ -140,15 +120,8 @@ class TestFilters:
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
         filter_result = {'count': 0, 'rows': []}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(cat_info)
-            _rv2 = await self.async_mock(filter_result)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(cat_info))
-            _rv2 = asyncio.ensure_future(self.async_mock(filter_result))
-        
+        _rv1 = await self.async_mock(cat_info)
+        _rv2 = await self.async_mock(filter_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv1) as get_cat_info_patch:
                 with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv2) as query_tbl_with_payload_patch:
@@ -162,13 +135,7 @@ class TestFilters:
         filter_name = "AssetFilter"
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-        
+        _rv = await self.async_mock(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv) as get_cat_info_patch:
                 resp = await client.get('/fledge/filter/{}'.format(filter_name))
@@ -233,12 +200,7 @@ class TestFilters:
     async def test_create_filter_value_error_1(self, client):
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock({"result": "test"})
-        else:
-            _rv = asyncio.ensure_future(self.async_mock({"result": "test"}))        
+        _rv = await self.async_mock({"result": "test"})
         msg = "This 'test' filter already exists"
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv) as get_cat_info_patch:
@@ -252,12 +214,7 @@ class TestFilters:
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
         plugin_name = 'benchmark'
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
+        _rv = await self.async_mock(None)
         msg = "Can not get 'plugin_info' detail from plugin '{}'".format(plugin_name)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv) as get_cat_info_patch:
@@ -275,12 +232,7 @@ class TestFilters:
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
         plugin_name = 'benchmark'
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
+        _rv = await self.async_mock(None)
         msg = "Loaded plugin 'python35', type 'south', doesn't match the specified one '{}', type 'filter'".format(
             plugin_name)
         ret_val = {"config": {'plugin': {'description': 'Python 3.5 filter plugin', 'type': 'string',
@@ -301,14 +253,8 @@ class TestFilters:
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
         plugin_name = 'filter'
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(None)
-            _rv2 = await self.async_mock({'count': 0, 'rows': []})
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(None))
-            _rv2 = asyncio.ensure_future(self.async_mock({'count': 0, 'rows': []}))
+        _rv1 = await self.async_mock(None)
+        _rv2 = await self.async_mock({'count': 0, 'rows': []})
         msg = "filter_config must be a JSON object"
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv1) as get_cat_info_patch:
@@ -343,13 +289,7 @@ class TestFilters:
         cf_mgr = ConfigurationManager(storage_client_mock)
         plugin_name = 'filter'
         name = 'test'
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-        
+        _rv = await self.async_mock(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv) as get_cat_info_patch:
                 with patch.object(apiutils, 'get_plugin_info', return_value={
@@ -393,19 +333,10 @@ class TestFilters:
         cf_mgr = ConfigurationManager(storage_client_mock)
         plugin_name = 'filter'
         name = 'test'
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(None)
-            _rv2 = await self.async_mock({'count': 0, 'rows': []})
-            _se1 = await self.async_mock(None)
-            _se2 = await self.async_mock({})
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(None))
-            _rv2 = asyncio.ensure_future(self.async_mock({'count': 0, 'rows': []}))
-            _se1 = asyncio.ensure_future(self.async_mock(None))
-            _se2 = asyncio.ensure_future(self.async_mock({}))
-        
+        _rv1 = await self.async_mock(None)
+        _rv2 = await self.async_mock({'count': 0, 'rows': []})
+        _se1 = await self.async_mock(None)
+        _se2 = await self.async_mock({})
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', side_effect=[_se1, _se2]) as get_cat_info_patch:
                 with patch.object(apiutils, 'get_plugin_info', return_value={"config": {'plugin': {'description': 'Python 3.5 filter plugin', 'type': 'string', 'default': 'filter'}}, "type": "filter"}) as api_utils_patch:
@@ -456,17 +387,9 @@ class TestFilters:
         delete_result = {'response': 'deleted', 'rows_affected': 1}
         update_result = {'rows_affected': 1, "response": "updated"}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(None)
-            _rv2 = await self.async_mock(delete_result)
-            _rv3 = await self.async_mock(update_result)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(None))
-            _rv2 = asyncio.ensure_future(self.async_mock(delete_result))
-            _rv3 = asyncio.ensure_future(self.async_mock(update_result))
-
+        _rv1 = await self.async_mock(None)
+        _rv2 = await self.async_mock(delete_result)
+        _rv3 = await self.async_mock(update_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', side_effect=q_result):
                 with patch.object(storage_client_mock, 'delete_from_tbl', return_value=_rv2) as delete_tbl_patch:
@@ -488,12 +411,7 @@ class TestFilters:
         filter_name = "AssetFilter"
         storage_client_mock = MagicMock(StorageClientAsync)
         message = "No such filter '{}' found".format(filter_name)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock({'count': 0, 'rows': []})
-        else:
-            _rv = asyncio.ensure_future(self.async_mock({'count': 0, 'rows': []}))
-        
+        _rv = await self.async_mock({'count': 0, 'rows': []})
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv):
                 resp = await client.delete('/fledge/filter/{}'.format(filter_name))
@@ -507,11 +425,8 @@ class TestFilters:
         filter_name = "AssetFilter"
         storage_client_mock = MagicMock(StorageClientAsync)
         message = 'string indices must be integers'
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            rv1 = await self.async_mock("blah")
-        else:
-            rv1 = asyncio.ensure_future(self.async_mock("blah"))
+        
+        rv1 = await self.async_mock("blah")
 
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=rv1):
@@ -527,14 +442,8 @@ class TestFilters:
         storage_client_mock = MagicMock(StorageClientAsync)
         message = ("The filter '{}' is currently being used within a pipeline. "
                    "To delete the filter, you must first remove it from the pipeline.").format(filter_name)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _se1 = await self.async_mock({'count': 1, 'rows': [{'name': filter_name, 'plugin': 'python35'}]})
-            _se2 = await self.async_mock({'count': 0, 'rows': ["Random"]})
-        else:
-            _se1 = asyncio.ensure_future(self.async_mock({'count': 1, 'rows': [{'name': filter_name, 'plugin': 'python35'}]}))
-            _se2 = asyncio.ensure_future(self.async_mock({'count': 0, 'rows': ["Random"]}))
-        
+        _se1 = await self.async_mock({'count': 1, 'rows': [{'name': filter_name, 'plugin': 'python35'}]})
+        _se2 = await self.async_mock({'count': 0, 'rows': ["Random"]})
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               side_effect=[_se1, _se2]):
@@ -609,12 +518,7 @@ class TestFilters:
         user = "bench"
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
+        _rv = await self.async_mock(None)
         msg = "No such '{}' category found.".format(user)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv) as get_cat_info_patch:
@@ -628,12 +532,7 @@ class TestFilters:
         user = "bench"
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
+        _rv = await self.async_mock(None)
         msg = "No such '{}' category found.".format(user)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv) as get_cat_info_patch:
@@ -650,14 +549,8 @@ class TestFilters:
         user = "bench"
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(cat_info)
-            _rv2 = await self.async_mock({'count': 1, 'rows': []})
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(cat_info))
-            _rv2 = asyncio.ensure_future(self.async_mock({'count': 1, 'rows': []}))
+        _rv1 = await self.async_mock(cat_info)
+        _rv2 = await self.async_mock({'count': 1, 'rows': []})
         msg = "No such 'AssetFilter' filter found in filters table."
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv1) as get_cat_info_patch:
@@ -689,14 +582,8 @@ class TestFilters:
         filter_name = "AssetFilter"
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(cat_info)
-            _rv3 = await self.async_mock(None)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(cat_info))
-            _rv3 = asyncio.ensure_future(self.async_mock(None))
+        _rv1 = await self.async_mock(cat_info)
+        _rv3 = await self.async_mock(None)
         msg = 'No detail found for user: {} and filter: filter'.format(user)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items',
@@ -748,14 +635,7 @@ class TestFilters:
         filter_name = "AssetFilter"
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(cat_info)
-            _rv3 = await self.async_mock(None)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(cat_info))
-            _rv3 = asyncio.ensure_future(self.async_mock(None))
+        _rv1 = await self.async_mock(cat_info)
         msg = ("The filter '{}' is currently in use. To update the filter pipeline, "
                "you must first remove it from the '{}' instance.").format(filter_name, 'S1')
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -777,13 +657,7 @@ class TestFilters:
         user = "bench"
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(cat_info)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(cat_info))
-        
+        _rv = await self.async_mock(cat_info)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv) as get_cat_info_patch:
                 with patch.object(storage_client_mock, 'query_tbl_with_payload',  side_effect=StorageServerError(None, None, error='something went wrong')):
@@ -816,17 +690,10 @@ class TestFilters:
         cf_mgr = ConfigurationManager(storage_client_mock)
         cat_child = {'children': ['Benchmark Filters', 'BenchmarkAdvanced', 'Benchmark_{}'.format(filter_name),
                                   filter_name]}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(cat_info)
-            _rv3 = await self.async_mock(None)
-            _rv4 = await self.async_mock(update_filter_val['filter'])
-            _rv5 = await self.async_mock(cat_child)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(cat_info))
-            _rv3 = asyncio.ensure_future(self.async_mock(None))
-            _rv4 = asyncio.ensure_future(self.async_mock(update_filter_val['filter']))
-            _rv5 = asyncio.ensure_future(self.async_mock(cat_child))
+        _rv1 = await self.async_mock(cat_info)
+        _rv3 = await self.async_mock(None)
+        _rv4 = await self.async_mock(update_filter_val['filter'])
+        _rv5 = await self.async_mock(cat_child)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv1) as get_cat_info_patch:
                 with patch.object(storage_client_mock, 'query_tbl_with_payload', side_effect=query_result):
@@ -880,19 +747,10 @@ class TestFilters:
         cf_mgr = ConfigurationManager(storage_client_mock)
         cat_child = {'children': ['Benchmark Filters', 'BenchmarkAdvanced', 'Benchmark_{}'.format(filter_name),
                                   filter_name]}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(cat_info)
-            _rv3 = await self.async_mock(None)
-            _rv4 = await self.async_mock(new_item_val['filter'])
-            _rv5 = await self.async_mock(cat_child)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(cat_info))
-            _rv3 = asyncio.ensure_future(self.async_mock(None))
-            _rv4 = asyncio.ensure_future(self.async_mock(new_item_val['filter']))
-            _rv5 = asyncio.ensure_future(self.async_mock(cat_child))
-
+        _rv1 = await self.async_mock(cat_info)
+        _rv3 = await self.async_mock(None)
+        _rv4 = await self.async_mock(new_item_val['filter'])
+        _rv5 = await self.async_mock(cat_child)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv1) as get_cat_info_patch:
                 with patch.object(storage_client_mock, 'query_tbl_with_payload', side_effect=query_result):
@@ -927,13 +785,7 @@ class TestFilters:
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
         user = "Coap"
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(d)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(d))
-        
+        _rv = await self.async_mock(d)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv) as get_cat_info_patch:
                 resp = await client.get('/fledge/filter/{}/pipeline'.format(user))
@@ -947,13 +799,7 @@ class TestFilters:
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
         user = "Blah"
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-        
+        _rv = await self.async_mock(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv) as get_cat_info_patch:
                 resp = await client.get('/fledge/filter/{}/pipeline'.format(user))
@@ -965,12 +811,7 @@ class TestFilters:
         storage_client_mock = MagicMock(StorageClientAsync)
         cf_mgr = ConfigurationManager(storage_client_mock)
         user = "Blah"
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock({})
-        else:
-            _rv = asyncio.ensure_future(self.async_mock({}))
+        _rv = await self.async_mock({})
         msg = "No filter pipeline exists for {}.".format(user)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(cf_mgr, 'get_category_all_items', return_value=_rv) as get_cat_info_patch:
@@ -1026,13 +867,7 @@ class TestFilters:
         }
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = MagicMock(ConfigurationManager)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await asyncio.sleep(.1)
-        else:
-            _rv = asyncio.ensure_future(asyncio.sleep(.1))
-        
+        _rv = await asyncio.sleep(.1)
         mock_connect = mocker.patch.object(connect, 'get_storage_async', return_value=storage_client_mock)
         delete_tbl_patch = mocker.patch.object(storage_client_mock, 'delete_from_tbl', return_value=_rv)
         cache_manager = mocker.patch.object(c_mgr, '_cacheManager')
@@ -1148,15 +983,8 @@ class TestFilters:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr_mock = ConfigurationManager(storage_client_mock)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-            _rv2 = await self.async_mock({'count': 0, 'rows': []})
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-            _rv2 = asyncio.ensure_future(self.async_mock({'count': 0, 'rows': []}))
-
+        _rv = await self.async_mock(None)
+        _rv2 = await self.async_mock({'count': 0, 'rows': []})
         mocker.patch.object(connect, 'get_storage_async', return_value=storage_client_mock)
         delete_child_category_mock = mocker.patch.object(c_mgr_mock, 'delete_child_category',
                                                          return_value=(await self.async_mock(None)))
@@ -1236,15 +1064,8 @@ class TestFilters:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr_mock = MagicMock(ConfigurationManager)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await asyncio.sleep(.1)
-            _rv2 = await mock()
-        else:
-            _rv = asyncio.ensure_future(asyncio.sleep(.1))
-            _rv2 = asyncio.ensure_future(mock())
-
+        _rv = await asyncio.sleep(.1)
+        _rv2 = await mock()
         connect_mock = mocker.patch.object(connect, 'get_storage_async', return_value=storage_client_mock)
         get_category_mock = mocker.patch.object(c_mgr_mock, 'get_category_all_items', side_effect=get_cat)
         create_category_mock = mocker.patch.object(c_mgr_mock, 'create_category', return_value=_rv2)

--- a/tests/unit/python/fledge/services/core/api/test_notification.py
+++ b/tests/unit/python/fledge/services/core/api/test_notification.py
@@ -11,7 +11,6 @@ import uuid
 import aiohttp.web_exceptions
 import pytest
 import json
-import sys
 from aiohttp import web
 from unittest.mock import call, patch
 
@@ -351,15 +350,8 @@ class TestNotification:
 
     async def test_get_plugin(self, mocker, client):
         rules_and_delivery = {'rules': rule_config, 'delivery': delivery_config}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _se1 = await mock_get_url("/notification/rules")
-            _se2 = await mock_get_url("/notification/delivery")
-        else:
-            _se1 = asyncio.ensure_future(mock_get_url("/notification/rules"))
-            _se2 = asyncio.ensure_future(mock_get_url("/notification/delivery"))
-        
+        _se1 = await mock_get_url("/notification/rules")
+        _se2 = await mock_get_url("/notification/delivery")
         mocker.patch.object(ServiceRegistry, 'get', return_value=mock_registry)
         mocker.patch.object(notification, '_hit_get_url', side_effect=[_se1, _se2])
 
@@ -396,23 +388,10 @@ class TestNotification:
             "retriggerTime": notification_config['retrigger_time']['value'],
             "enable": notification_config['enable']['value'],
         }
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _se1 = await mock_read_category_val("Test Notification")
-            _se2 = await mock_read_category_val("ruleTest Notification")
-            _se3 = await mock_read_category_val("deliveryTest Notification")
-            mocker.patch.object(notification,
-                        '_get_channels_type',
-                        return_value=await mock_get_channel_type())
-        else:
-            _se1 = asyncio.ensure_future(mock_read_category_val("Test Notification"))
-            _se2 = asyncio.ensure_future(mock_read_category_val("ruleTest Notification"))
-            _se3 = asyncio.ensure_future(mock_read_category_val("deliveryTest Notification"))         
-            mocker.patch.object(notification,
-                        '_get_channels_type',
-                        return_value = asyncio.ensure_future(mock_get_channel_type()))
-        
+        _se1 = await mock_read_category_val("Test Notification")
+        _se2 = await mock_read_category_val("ruleTest Notification")
+        _se3 = await mock_read_category_val("deliveryTest Notification")
+        mocker.patch.object(notification, '_get_channels_type', return_value=await mock_get_channel_type())
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(ConfigurationManager, '__init__', return_value=None)
         mocker.patch.object(ConfigurationManager, '_read_category_val', side_effect=[_se1, _se2, _se3])
@@ -434,21 +413,9 @@ class TestNotification:
             "retriggerTime": notification_config['retrigger_time']['value'],
             "enable": notification_config['enable']['value'],
         }]
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_read_all_child_category_names()
-            _rv2 = await mock_read_category_val("Test Notification")
-            mocker.patch.object(notification,
-                        '_get_channels_type',
-                        return_value=await mock_get_channel_type())
-        else:
-            _rv1 = asyncio.ensure_future(mock_read_all_child_category_names())
-            _rv2 = asyncio.ensure_future(mock_read_category_val("Test Notification"))
-            mocker.patch.object(notification,
-                        '_get_channels_type',
-                        return_value = asyncio.ensure_future(mock_get_channel_type()))
-        
+        _rv1 = await mock_read_all_child_category_names()
+        _rv2 = await mock_read_category_val("Test Notification")
+        mocker.patch.object(notification, '_get_channels_type', return_value=await mock_get_channel_type())
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(ConfigurationManager, '__init__', return_value=None)
         mocker.patch.object(ConfigurationManager, '_read_all_child_category_names',
@@ -463,26 +430,14 @@ class TestNotification:
         assert notifications == json_response["notifications"]
 
     async def test_post_notification(self, mocker, client):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_get_url("/fledge/notification/plugin")
-            _rv2 = await mock_create_category()
-            _rv3 = await mock_read_category_val("")
-            _rv4 = await mock_check_category()
-            _rv5 = await asyncio.sleep(.1)
-            _se1 = await mock_post_url("/notification/Test Notification")
-            _se2 = await mock_post_url("/notification/Test Notification/rule/threshold")
-            _se3 = await mock_post_url("/notification/Test Notification/delivery/email")
-        else:
-            _rv1 = asyncio.ensure_future(mock_get_url("/fledge/notification/plugin"))
-            _rv2 = asyncio.ensure_future(mock_create_category())
-            _rv3 = asyncio.ensure_future(mock_read_category_val(""))
-            _rv4 = asyncio.ensure_future(mock_check_category())
-            _rv5 = asyncio.ensure_future(asyncio.sleep(.1))
-            _se1 = asyncio.ensure_future(mock_post_url("/notification/Test Notification"))
-            _se2 = asyncio.ensure_future(mock_post_url("/notification/Test Notification/rule/threshold"))
-            _se3 = asyncio.ensure_future(mock_post_url("/notification/Test Notification/delivery/email"))        
-        
+        _rv1 = await mock_get_url("/fledge/notification/plugin")
+        _rv2 = await mock_create_category()
+        _rv3 = await mock_read_category_val("")
+        _rv4 = await mock_check_category()
+        _rv5 = await asyncio.sleep(.1)
+        _se1 = await mock_post_url("/notification/Test Notification")
+        _se2 = await mock_post_url("/notification/Test Notification/rule/threshold")
+        _se3 = await mock_post_url("/notification/Test Notification/delivery/email")
         mocker.patch.object(ServiceRegistry, 'get', return_value=mock_registry)
         mocker.patch.object(notification, '_hit_get_url', return_value=_rv1)
         mocker.patch.object(notification, '_hit_post_url',
@@ -506,12 +461,7 @@ class TestNotification:
         update_configuration_item_bulk.assert_has_calls(update_configuration_item_bulk_calls, any_order=True)
 
     async def test_post_notification_duplicate_name(self, mocker, client):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_check_category(True)
-        else:
-            _rv = asyncio.ensure_future(mock_check_category(True))
-        
+        _rv = await mock_check_category(True)
         mocker.patch.object(ServiceRegistry, 'get', return_value=mock_registry)
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(ConfigurationManager, '__init__', return_value=None)
@@ -526,26 +476,14 @@ class TestNotification:
         assert "400: A Category with name Test Notification already exists." == result
 
     async def test_post_notification2(self, mocker, client):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_get_url("/fledge/notification/plugin")
-            _rv2 = await mock_create_category()
-            _rv3 = await mock_read_category_val("")
-            _rv4 = await mock_check_category()
-            _rv5 = await asyncio.sleep(.1)
-            _se1 = await mock_post_url("/notification/Test Notification")
-            _se2 = await mock_post_url("/notification/Test Notification/rule/threshold")
-            _se3 = await mock_post_url("/notification/Test Notification/delivery/email")
-        else:
-            _rv1 = asyncio.ensure_future(mock_get_url("/fledge/notification/plugin"))
-            _rv2 = asyncio.ensure_future(mock_create_category())
-            _rv3 = asyncio.ensure_future(mock_read_category_val(""))
-            _rv4 = asyncio.ensure_future(mock_check_category())
-            _rv5 = asyncio.ensure_future(asyncio.sleep(.1))
-            _se1 = asyncio.ensure_future(mock_post_url("/notification/Test Notification"))
-            _se2 = asyncio.ensure_future(mock_post_url("/notification/Test Notification/rule/threshold"))
-            _se3 = asyncio.ensure_future(mock_post_url("/notification/Test Notification/delivery/email"))      
-        
+        _rv1 = await mock_get_url("/fledge/notification/plugin")
+        _rv2 = await mock_create_category()
+        _rv3 = await mock_read_category_val("")
+        _rv4 = await mock_check_category()
+        _rv5 = await asyncio.sleep(.1)
+        _se1 = await mock_post_url("/notification/Test Notification")
+        _se2 = await mock_post_url("/notification/Test Notification/rule/threshold")
+        _se3 = await mock_post_url("/notification/Test Notification/delivery/email")
         mocker.patch.object(ServiceRegistry, 'get', return_value=mock_registry)
         mocker.patch.object(notification, '_hit_get_url', return_value=_rv1)
         mocker.patch.object(notification, '_hit_post_url',
@@ -572,28 +510,15 @@ class TestNotification:
         update_configuration_item_bulk.assert_has_calls(update_configuration_item_bulk_calls, any_order=True)
 
     async def test_post_notification_exception(self, mocker, client):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_get_url("/fledge/notification/plugin")
-            _rv2 = await mock_create_category()
-            _rv3 = await mock_read_category_val("")
-            _rv4 = await mock_check_category()
-            _rv5 = await asyncio.sleep(.1)
-            _rv6 = await mock_create_child_category()
-            _se1 = await mock_post_url("/notification/Test Notification")
-            _se2 = await mock_post_url("/notification/Test Notification/rule/threshold")
-            _se3 = await mock_post_url("/notification/Test Notification/delivery/email")
-        else:
-            _rv1 = asyncio.ensure_future(mock_get_url("/fledge/notification/plugin"))
-            _rv2 = asyncio.ensure_future(mock_create_category())
-            _rv3 = asyncio.ensure_future(mock_read_category_val(""))
-            _rv4 = asyncio.ensure_future(mock_check_category())
-            _rv5 = asyncio.ensure_future(asyncio.sleep(.1))
-            _rv6 = asyncio.ensure_future(mock_create_child_category())
-            _se1 = asyncio.ensure_future(mock_post_url("/notification/Test Notification"))
-            _se2 = asyncio.ensure_future(mock_post_url("/notification/Test Notification/rule/threshold"))
-            _se3 = asyncio.ensure_future(mock_post_url("/notification/Test Notification/delivery/email"))
-        
+        _rv1 = await mock_get_url("/fledge/notification/plugin")
+        _rv2 = await mock_create_category()
+        _rv3 = await mock_read_category_val("")
+        _rv4 = await mock_check_category()
+        _rv5 = await asyncio.sleep(.1)
+        _rv6 = await mock_create_child_category()
+        _se1 = await mock_post_url("/notification/Test Notification")
+        _se2 = await mock_post_url("/notification/Test Notification/rule/threshold")
+        _se3 = await mock_post_url("/notification/Test Notification/delivery/email")
         mocker.patch.object(ServiceRegistry, 'get', return_value=mock_registry)
         mocker.patch.object(notification, '_hit_get_url', return_value=_rv1)
         mocker.patch.object(notification, '_hit_post_url',
@@ -696,8 +621,7 @@ class TestNotification:
 
     async def test_post_notification_plugin_fetch_error(self, mocker, client):
         expected_message = "Failed to fetch notification plugins."
-        _rv = await mock_check_category() if sys.version_info.major == 3 and sys.version_info.minor >= 8 else (
-            asyncio.ensure_future(mock_check_category()))
+        _rv = await mock_check_category()
         mocker.patch.object(ServiceRegistry, 'get', return_value=mock_registry)
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(ConfigurationManager, '__init__', return_value=None)
@@ -717,16 +641,9 @@ class TestNotification:
             assert 'Failed to create notification instance.' == args[1]
 
     async def test_put_notification(self, mocker, client):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_get_url("/fledge/notification/plugin")
-            _rv2 = await mock_create_category()
-            _rv3 = await mock_read_category_val("Test Notification")
-        else:
-            _rv1 = asyncio.ensure_future(mock_get_url("/fledge/notification/plugin"))
-            _rv2 = asyncio.ensure_future(mock_create_category())
-            _rv3 = asyncio.ensure_future(mock_read_category_val("Test Notification"))
-        
+        _rv1 = await mock_get_url("/fledge/notification/plugin")
+        _rv2 = await mock_create_category()
+        _rv3 = await mock_read_category_val("Test Notification")
         mocker.patch.object(ServiceRegistry, 'get', return_value=mock_registry)
         mocker.patch.object(notification, '_hit_get_url', return_value=_rv1)
         mocker.patch.object(connect, 'get_storage_async')
@@ -751,16 +668,9 @@ class TestNotification:
         update_configuration_item_bulk.assert_has_calls(update_configuration_item_bulk_calls, any_order=True)
 
     async def test_put_notification_exception(self, mocker, client):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_get_url("/fledge/notification/plugin")
-            _rv2 = await mock_create_category()
-            _rv3 = await mock_read_category_val("Test Notification")
-        else:
-            _rv1 = asyncio.ensure_future(mock_get_url("/fledge/notification/plugin"))
-            _rv2 = asyncio.ensure_future(mock_create_category())
-            _rv3 = asyncio.ensure_future(mock_read_category_val("Test Notification"))
-        
+        _rv1 = await mock_get_url("/fledge/notification/plugin")
+        _rv2 = await mock_create_category()
+        _rv3 = await mock_read_category_val("Test Notification")
         mocker.patch.object(ServiceRegistry, 'get', return_value=mock_registry)
         mocker.patch.object(notification, '_hit_get_url', return_value=_rv1)
         mocker.patch.object(connect, 'get_storage_async')
@@ -830,9 +740,7 @@ class TestNotification:
     async def test_put_notification_plugin_fetch_error(self, mocker, client):
         name = "Test Notification"
         expected_message = "Failed to fetch notification plugins."
-
-        _rv2 = await mock_read_category_val(name) if sys.version_info.major == 3 and sys.version_info.minor >= 8 else (
-            asyncio.ensure_future(mock_read_category_val(name)))
+        _rv2 = await mock_read_category_val(name)
         mocker.patch.object(ServiceRegistry, 'get', return_value=mock_registry)
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(ConfigurationManager, '__init__', return_value=None)
@@ -854,18 +762,10 @@ class TestNotification:
             assert 'Failed to update {} notification instance.'.format(name) == args[1]
 
     async def test_delete_notification(self, mocker, client):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_get_url("/fledge/notification/plugin")
-            _rv2 = await asyncio.sleep(.1)
-            _rv3 = await mock_read_category_val("Test Notification")
-            _se = await mock_delete_url("/notification/Test Notification")
-        else:
-            _rv1 = asyncio.ensure_future(mock_get_url("/fledge/notification/plugin"))
-            _rv2 = asyncio.ensure_future(asyncio.sleep(.1))
-            _rv3 = asyncio.ensure_future(mock_read_category_val("Test Notification"))
-            _se = asyncio.ensure_future(mock_delete_url("/notification/Test Notification"))
-            
+        _rv1 = await mock_get_url("/fledge/notification/plugin")
+        _rv2 = await asyncio.sleep(.1)
+        _rv3 = await mock_read_category_val("Test Notification")
+        _se = await mock_delete_url("/notification/Test Notification")
         mocker.patch.object(ServiceRegistry, 'get', return_value=mock_registry)
         mocker.patch.object(notification, '_hit_get_url', return_value=_rv1)
         storage_client_mock = mocker.patch.object(connect, 'get_storage_async')
@@ -939,17 +839,10 @@ class TestNotification:
     ])
     async def test_good_post_delivery_channel(self, mocker, client, name, config, description):
         notification_instance_name = "overspeed"
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info >= (3, 8):
-            _se = await mock_read_category_val(notification_instance_name)
-            _rv1 = await mock_create_category()
-            _rv2 = await mock_check_category(delivery_channel_config)
-            _rv3 = await mock_create_child_category()
-        else:
-            _se = asyncio.ensure_future(mock_read_category_val(notification_instance_name))
-            _rv1 = asyncio.ensure_future(mock_create_category())
-            _rv2 = asyncio.ensure_future(mock_check_category(delivery_channel_config))
-            _rv3 = asyncio.ensure_future(mock_create_child_category())
+        _se = await mock_read_category_val(notification_instance_name)
+        _rv1 = await mock_create_category()
+        _rv2 = await mock_check_category(delivery_channel_config)
+        _rv3 = await mock_create_child_category()
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(ConfigurationManager, '__init__', return_value=None)
         mocker.patch.object(ConfigurationManager, '_read_category_val', side_effect=[_se])
@@ -973,9 +866,7 @@ class TestNotification:
     async def test_bad_get_delivery_channel(self, mocker, client):
         notification_instance_name = "blah"
         message = "{} notification instance does not exist".format(notification_instance_name)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _se = await mock_read_category_val(notification_instance_name) if sys.version_info >= (3, 8) else \
-            asyncio.ensure_future(mock_read_category_val(notification_instance_name))
+        _se = await mock_read_category_val(notification_instance_name)
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(ConfigurationManager, '__init__', return_value=None)
         mocker.patch.object(ConfigurationManager, '_read_category_val', side_effect=[_se])
@@ -997,23 +888,10 @@ class TestNotification:
     async def test_good_get_delivery_channel(self, mocker, client, notification_instance_name, categories, exp_channel, plugin_type):
         async def async_mock(cat):
             return cat
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info >= (3, 8):
-            _se = await mock_read_category_val(notification_instance_name)
-            _rv = await async_mock(categories)
-            _rv2 = await async_mock(plugin_type)
-            mocker.patch.object(notification,
-                                '_get_all_delivery_channels',
-                                return_value=await async_mock(exp_channel))
-        else:
-            _se = asyncio.ensure_future(mock_read_category_val(notification_instance_name))
-            _rv = asyncio.ensure_future(async_mock(categories))
-            _rv2 = asyncio.ensure_future(async_mock(plugin_type))
-            mocker.patch.object(notification,
-                                '_get_all_delivery_channels',
-                                return_value=asyncio.ensure_future(async_mock(exp_channel)))
-
+        _se = await mock_read_category_val(notification_instance_name)
+        _rv = await async_mock(categories)
+        _rv2 = await async_mock(plugin_type)
+        mocker.patch.object(notification, '_get_all_delivery_channels', return_value=await async_mock(exp_channel))
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(ConfigurationManager, '__init__', return_value=None)
         mocker.patch.object(ConfigurationManager, '_read_category_val', side_effect=[_se])
@@ -1031,13 +909,8 @@ class TestNotification:
     ])
     async def test_bad_get_delivery_channel_configuration(self, mocker, client, notification_instance_name,
                                                           channel_name, message):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info >= (3, 8):
-            _se1 = await mock_read_category_val(notification_instance_name)
-            _se2 = await mock_read_category_val(channel_name)
-        else:
-            _se1 = asyncio.ensure_future(mock_read_category_val(notification_instance_name))
-            _se2 = asyncio.ensure_future(mock_read_category_val(channel_name))
+        _se1 = await mock_read_category_val(notification_instance_name)
+        _se2 = await mock_read_category_val(channel_name)
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(ConfigurationManager, '__init__', return_value=None)
         mocker.patch.object(ConfigurationManager, '_read_category_val', side_effect=[_se1])
@@ -1052,14 +925,8 @@ class TestNotification:
     async def test_good_get_delivery_channel_configuration(self, mocker, client):
         notification_instance_name = "overspeed"
         channel_name = "coolant"
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info >= (3, 8):
-            _se1 = await mock_read_category_val(notification_instance_name)
-            _se2 = await mock_read_category_val(channel_name)
-        else:
-            _se1 = asyncio.ensure_future(mock_read_category_val(notification_instance_name))
-            _se2 = asyncio.ensure_future(mock_read_category_val(channel_name))
-            _rv = asyncio.ensure_future(asyncio.sleep(.1))
+        _se1 = await mock_read_category_val(notification_instance_name)
+        _se2 = await mock_read_category_val(channel_name)
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(ConfigurationManager, '__init__', return_value=None)
         mocker.patch.object(ConfigurationManager, '_read_category_val', side_effect=[_se1, _se1])
@@ -1075,14 +942,9 @@ class TestNotification:
         ("foo", "bar", "No Notification service available."),
         ("Test Notification", "bar", "No Notification service available.")
     ])
-    async def test_bad_delete_delivery_channel(self, mocker, client, notification_instance_name, channel_name, message):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info >= (3, 8):
-            _se1 = await mock_read_category_val(notification_instance_name)
-            _se2 = await mock_read_category_val(channel_name)
-        else:
-            _se1 = asyncio.ensure_future(mock_read_category_val(notification_instance_name))
-            _se2 = asyncio.ensure_future(mock_read_category_val(channel_name))
+    async def test_bad_delete_delivery_channel(self, mocker, client, notification_instance_name, channel_name, message): 
+        _se1 = await mock_read_category_val(notification_instance_name)
+        _se2 = await mock_read_category_val(channel_name)
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(ConfigurationManager, '__init__', return_value=None)
         mocker.patch.object(ConfigurationManager, '_read_category_val', side_effect=[_se1])
@@ -1099,17 +961,10 @@ class TestNotification:
     async def test_good_delete_delivery_channel(self, mocker, client):
         notification_instance_name = "overspeed"
         channel_name = "coolant"
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info >= (3, 8):
-            _se1 = await mock_read_category_val(notification_instance_name)
-            _se2 = await mock_read_category_val(channel_name)
-            _se3 = await mock_read_category_val("bar")
-            _rv = await asyncio.sleep(.1)
-        else:
-            _se1 = asyncio.ensure_future(mock_read_category_val(notification_instance_name))
-            _se2 = asyncio.ensure_future(mock_read_category_val(channel_name))
-            _se3 = asyncio.ensure_future(mock_read_category_val("bar"))
-            _rv = asyncio.ensure_future(asyncio.sleep(.1))
+        _se1 = await mock_read_category_val(notification_instance_name)
+        _se2 = await mock_read_category_val(channel_name)
+        _se3 = await mock_read_category_val("bar")
+        _rv = await asyncio.sleep(.1)
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(ConfigurationManager, '__init__', return_value=None)
         mocker.patch.object(ConfigurationManager, '_read_category_val', side_effect=[_se1])

--- a/tests/unit/python/fledge/services/core/api/test_package_log.py
+++ b/tests/unit/python/fledge/services/core/api/test_package_log.py
@@ -7,10 +7,7 @@
 import os
 import json
 import pathlib
-import asyncio
 from pathlib import PosixPath
-import sys
-
 from unittest.mock import Mock, MagicMock, patch, mock_open
 from aiohttp import web
 
@@ -160,12 +157,7 @@ class TestPackageLog:
         async def mock_coro():
             return {"rows": []}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-        
+        _rv = await mock_coro()
         storage_client_mock = MagicMock(StorageClientAsync)
         msg = "'No record found'"
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -209,12 +201,7 @@ class TestPackageLog:
             del old['log_file_uri']
             return new
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-        
+        _rv = await mock_coro()
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv) as tbl_patch:
@@ -266,12 +253,7 @@ class TestPackageLog:
             del old['log_file_uri']
             return new
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-        
+        _rv = await mock_coro()
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv) as tbl_patch:

--- a/tests/unit/python/fledge/services/core/api/test_scheduler_api.py
+++ b/tests/unit/python/fledge/services/core/api/test_scheduler_api.py
@@ -4,14 +4,11 @@
 # See: http://fledge-iot.readthedocs.io/
 # FLEDGE_END
 
-
-import asyncio
 import json
 from datetime import timedelta, datetime
 from unittest.mock import MagicMock, patch, call
 from uuid import UUID
 
-import sys
 import uuid
 import pytest
 
@@ -61,12 +58,7 @@ class TestScheduledProcesses:
             processes.append(process)
             return processes
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(server.Server.scheduler, 'get_scheduled_processes', return_value=_rv):
             resp = await client.get('/fledge/schedule/process')
             assert 200 == resp.status
@@ -78,13 +70,7 @@ class TestScheduledProcesses:
         storage_client_mock = MagicMock(StorageClientAsync)
         payload = '{"return": ["name"], "where": {"column": "name", "condition": "in", "value": ["purge"]}}'
         response = {'rows': [{'name': 'purge'}], 'count': 1}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro_response(response)
-        else:
-            _rv = asyncio.ensure_future(mock_coro_response(response))
-        
+        _rv = await mock_coro_response(response)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(storage_client_mock, 'query_tbl_with_payload',
                                   return_value=_rv) as mock_storage_call:
@@ -98,13 +84,7 @@ class TestScheduledProcesses:
     async def test_get_scheduled_process_bad_data(self, client):
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'rows': [], 'count': 0}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro_response(response)
-        else:
-            _rv = asyncio.ensure_future(mock_coro_response(response))
-        
+        _rv = await mock_coro_response(response)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(storage_client_mock, 'query_tbl_with_payload',
                                   return_value=_rv):
@@ -117,17 +97,9 @@ class TestScheduledProcesses:
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'rows': [], 'count': 0}
         ret_val = {"response": "inserted", "rows_affected": 1}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro_response(response)
-            _rv2 = await mock_coro_response(ret_val)
-            _rv3 = await mock_coro_response(None)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro_response(response))
-            _rv2 = asyncio.ensure_future(mock_coro_response(ret_val))
-            _rv3 = asyncio.ensure_future(mock_coro_response(None))
-        
+        _rv1 = await mock_coro_response(response)
+        _rv2 = await mock_coro_response(ret_val)
+        _rv3 = await mock_coro_response(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=(_rv1)
                               ) as query_tbl_patch:
@@ -166,13 +138,7 @@ class TestScheduledProcesses:
     async def test_post_scheduled_process_bad_data(self, client, request_data, response_code, error_message):
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'rows': [{"name": "purge"}], 'count': 1}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro_response(response)
-        else:
-            _rv = asyncio.ensure_future(mock_coro_response(response))
-        
+        _rv = await mock_coro_response(response)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv):
                 resp = await client.post('/fledge/schedule/process', data=json.dumps(request_data))
@@ -213,13 +179,7 @@ class TestSchedules:
             schedule.day = None
             schedules.append(schedule)
             return schedules
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(server.Server.scheduler, 'get_schedules', return_value=_rv):
             resp = await client.get('/fledge/schedule')
             assert 200 == resp.status
@@ -243,12 +203,8 @@ class TestSchedules:
             schedule.day = None
             return schedule
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        
+        _rv = await mock_coro()
         with patch.object(server.Server.scheduler, 'get_schedule', return_value=_rv):
             resp = await client.get('/fledge/schedule/{}'.format(self._random_uuid))
             assert 200 == resp.status
@@ -278,12 +234,8 @@ class TestSchedules:
         async def mock_coro():
             return True, "Schedule successfully enabled"
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        
+        _rv = await mock_coro()
         with patch.object(server.Server.scheduler, 'enable_schedule', return_value=_rv):
             resp = await client.put('/fledge/schedule/{}/enable'.format(self._random_uuid))
             assert 200 == resp.status
@@ -311,12 +263,8 @@ class TestSchedules:
         async def mock_coro():
             return True, "Schedule successfully disabled"
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        
+        _rv = await mock_coro()
         with patch.object(server.Server.scheduler, 'disable_schedule', return_value=_rv):
             resp = await client.put('/fledge/schedule/{}/disable'.format(self._random_uuid))
             assert 200 == resp.status
@@ -351,14 +299,8 @@ class TestSchedules:
         async def patch_queue_task(_resp):
             return _resp
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro()
-            _rv2 = await patch_queue_task(return_queue_task)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro())
-            _rv2 = asyncio.ensure_future(patch_queue_task(return_queue_task))
-
+        _rv1 = await mock_coro()
+        _rv2 = await patch_queue_task(return_queue_task)
         with patch.object(server.Server.scheduler, 'get_schedule', return_value=_rv1) as mock_get_schedule:
             with patch.object(server.Server.scheduler, 'queue_task', return_value=_rv2) \
                     as mock_queue_task:
@@ -452,19 +394,10 @@ class TestSchedules:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'rows': [{'name': 'p1'}], 'count': 1}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro_response(response)
-            _rv2 = await mock_schedules()
-            _rv3 = await mock_schedule(request_data["type"])
-            _rv4 = await mock_coro()
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro_response(response))
-            _rv2 = asyncio.ensure_future(mock_schedules())
-            _rv3 = asyncio.ensure_future(mock_schedule(request_data["type"]))
-            _rv4 = asyncio.ensure_future(mock_coro())
-
+        _rv1 = await mock_coro_response(response)
+        _rv2 = await mock_schedules()
+        _rv3 = await mock_schedule(request_data["type"])
+        _rv4 = await mock_coro()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1):
                 with patch.object(server.Server.scheduler, 'get_schedules',
@@ -514,13 +447,7 @@ class TestSchedules:
     async def test_post_schedule_bad_data(self, client, request_data, response_code, error_message, storage_return):
         storage_client_mock = MagicMock(StorageClientAsync)
         response = storage_return
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro_response(response)
-        else:
-            _rv = asyncio.ensure_future(mock_coro_response(response))
-
+        _rv = await mock_coro_response(response)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv):
                 resp = await client.post('/fledge/schedule', data=json.dumps(request_data))
@@ -562,15 +489,8 @@ class TestSchedules:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'rows': [{'name': 'purge'}, {'name': 'south_c'}, {'name': 'stats collector'}], 'count': 3}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro_response(response)
-            _rv2 = await mock_schedules()
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro_response(response))
-            _rv2 = asyncio.ensure_future(mock_schedules())
-
+        _rv1 = await mock_coro_response(response)
+        _rv2 = await mock_schedules()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1):
                 with patch.object(server.Server.scheduler, 'get_schedules',
@@ -631,17 +551,9 @@ class TestSchedules:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'rows': [{'name': 'p1'}], 'count': 1}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro_response(response)
-            _rv2 = await mock_schedules()
-            _rv3 = await mock_coro()
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro_response(response))
-            _rv2 = asyncio.ensure_future(mock_schedules())
-            _rv3 = asyncio.ensure_future(mock_coro())
-
+        _rv1 = await mock_coro_response(response)
+        _rv2 = await mock_schedules()
+        _rv3 = await mock_coro()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1):
                 with patch.object(server.Server.scheduler, 'get_schedules',
@@ -693,8 +605,7 @@ class TestSchedules:
             schedule.name = "South Service"
             return schedule
 
-        _rv1 = await mock_schedule() if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(mock_schedule())
+        _rv1 = await mock_schedule()
         with patch.object(server.Server.scheduler, 'get_schedule', return_value=_rv1) as patch_get_schedule:
             resp = await client.put('/fledge/schedule/{}'.format(uuid), data=json.dumps(payload))
             assert status_code == resp.status
@@ -763,20 +674,11 @@ class TestSchedules:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'rows': [{'name': 'SCH'}], 'count': 1}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv0 = await mock_coro_response(response)
-            _rv1 = await mock_schedule()
-            _rv11 = await final_schedule()
-            _rv2 = await mock_coro()
-            _rv3 = await mock_schedules()
-        else:
-            _rv0 = asyncio.ensure_future(mock_coro_response(response))
-            _rv1 = asyncio.ensure_future(mock_schedule())
-            _rv11 = asyncio.ensure_future(final_schedule())
-            _rv2 = asyncio.ensure_future(mock_coro())
-            _rv3 = asyncio.ensure_future(mock_schedules())
-
+        _rv0 = await mock_coro_response(response)
+        _rv1 = await mock_schedule()
+        _rv11 = await final_schedule()
+        _rv2 = await mock_coro()
+        _rv3 = await mock_schedules()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv0):
                 with patch.object(server.Server.scheduler, 'get_schedule', side_effect=[_rv1, _rv11]):
@@ -799,13 +701,7 @@ class TestSchedules:
     async def test_update_schedule_data_not_exist(self, client):
         async def mock_coro():
             return ""
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(server.Server.scheduler, 'get_schedule',
                           return_value=_rv) as patch_get_schedule:
             error_message = 'Schedule not found: {}'.format(self._random_uuid)
@@ -853,15 +749,8 @@ class TestSchedules:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         response = storage_return
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro_response(response)
-            _rv2 = await mock_coro()
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro_response(response))
-            _rv2 = asyncio.ensure_future(mock_coro())
-
+        _rv1 = await mock_coro_response(response)
+        _rv2 = await mock_coro()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1):
                 with patch.object(server.Server.scheduler, 'get_schedule',
@@ -913,15 +802,8 @@ class TestSchedules:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'rows': [{'name': 'purge'}], 'count': 1}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro_response(response)
-            _rv2 = await mock_schedules()
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro_response(response))
-            _rv2 = asyncio.ensure_future(mock_schedules())
-
+        _rv1 = await mock_coro_response(response)
+        _rv2 = await mock_schedules()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1):
                 with patch.object(server.Server.scheduler, 'get_schedule',
@@ -941,12 +823,7 @@ class TestSchedules:
         async def mock_coro():
             return True, "Schedule deleted successfully."
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(server.Server.scheduler, 'delete_schedule', return_value=_rv):
             resp = await client.delete('/fledge/schedule/{}'.format(self._random_uuid))
             assert 200 == resp.status
@@ -1015,14 +892,9 @@ class TestTasks:
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'count': 1, 'rows': [{'process_name': 'bla'}]}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro_response(response)
-            _rv2 = await mock_coro()
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro_response(response))
-            _rv2 = asyncio.ensure_future(mock_coro())
-
+        
+        _rv1 = await mock_coro_response(response)
+        _rv2 = await mock_coro()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1):
                 with patch.object(server.Server.scheduler, 'get_task', return_value=_rv2):
@@ -1074,15 +946,8 @@ class TestTasks:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'count': 1, 'rows': [{'process_name': 'bla'}]}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro_response(response)
-            _rv2 = await patch_get_tasks()
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro_response(response))
-            _rv2 = asyncio.ensure_future(patch_get_tasks())
-
+        _rv1 = await mock_coro_response(response)
+        _rv2 = await patch_get_tasks()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1):
                 with patch.object(server.Server.scheduler, 'get_tasks', return_value=_rv2):
@@ -1111,15 +976,8 @@ class TestTasks:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'count': 0, 'rows': []}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro_response(response)
-            _rv2 = await patch_get_tasks()
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro_response(response))
-            _rv2 = asyncio.ensure_future(patch_get_tasks())
-
+        _rv1 = await mock_coro_response(response)
+        _rv2 = await patch_get_tasks()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1):
                 with patch.object(server.Server.scheduler, 'get_tasks', return_value=_rv2):
@@ -1133,13 +991,7 @@ class TestTasks:
         response = {'count': 2, 'rows': [
             {'pid': '1', 'reason': '', 'exit_code': '0', 'id': '1',
              'process_name': 'bla', 'schedule_name': 'bla', 'end_time': '2018', 'start_time': '2018', 'state': '2'}]}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro_response(response)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro_response(response))
-        
+        _rv1 = await mock_coro_response(response)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1):
                 resp = await client.get('/fledge/task/latest{}'.format(request_params))
@@ -1154,13 +1006,7 @@ class TestTasks:
     async def test_get_tasks_latest_no_task_exception(self, client, request_params):
         storage_client_mock = MagicMock(StorageClientAsync)
         response = {'count': 0, 'rows': []}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro_response(response)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro_response(response))
-        
+        _rv1 = await mock_coro_response(response)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1):
                 resp = await client.get('/fledge/task/latest{}'.format(request_params))
@@ -1171,12 +1017,7 @@ class TestTasks:
         async def mock_coro():
             return "some valid values"
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-        
+        _rv = await mock_coro()
         with patch.object(server.Server.scheduler, 'get_task', return_value=_rv):
             with patch.object(server.Server.scheduler, 'cancel_task', return_value=_rv):
                 resp = await client.put('/fledge/task/{}/cancel'.format(self._random_uuid))
@@ -1199,13 +1040,7 @@ class TestTasks:
     async def test_cancel_task_exceptions(self, client, exception_name, response_code, response_message):
         async def mock_coro():
             return ""
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(server.Server.scheduler, 'get_task', return_value=_rv):
             with patch.object(server.Server.scheduler, 'cancel_task', side_effect=exception_name):
                 resp = await client.put('/fledge/task/{}/cancel'.format(self._random_uuid))

--- a/tests/unit/python/fledge/services/core/api/test_service.py
+++ b/tests/unit/python/fledge/services/core/api/test_service.py
@@ -10,8 +10,6 @@ from uuid import UUID
 from unittest.mock import MagicMock, patch, call
 import pytest
 from aiohttp import web
-import sys
-
 from fledge.services.core import routes
 from fledge.services.core import connect
 from fledge.common.storage_client.storage_client import StorageClientAsync
@@ -279,13 +277,7 @@ class TestService:
         }
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-        
+        _rv = await self.async_mock(None)
         with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[mock_plugin_info]):
             with patch.object(service._logger, 'error') as patch_logger:
                 with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -325,13 +317,7 @@ class TestService:
         data = {"name": "furnace4", "type": "south", "plugin": "dht11"}
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(mock_plugin_info)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(mock_plugin_info))
-        
+        _rv = await self.async_mock(mock_plugin_info)
         with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[mock_plugin_info]):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_cat_info:
@@ -368,12 +354,7 @@ class TestService:
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         msg = "A service with {} name already exists.".format(data['name'])
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-        
+        _rv = await self.async_mock(None)
         with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[mock_plugin_info]):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_cat_info:
@@ -433,19 +414,10 @@ class TestService:
         server.Server.scheduler = Scheduler(None, None)
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(None)
-            _rv2 = await self.async_mock(expected_insert_resp)
-            _rv3 = await self.async_mock("")
-            _rv4 = await async_mock_get_schedule()
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(None))
-            _rv2 = asyncio.ensure_future(self.async_mock(expected_insert_resp))
-            _rv3 = asyncio.ensure_future(self.async_mock(""))
-            _rv4 = asyncio.ensure_future(async_mock_get_schedule())
-        
+        _rv1 = await self.async_mock(None)
+        _rv2 = await self.async_mock(expected_insert_resp)
+        _rv3 = await self.async_mock("")
+        _rv4 = await async_mock_get_schedule()
         with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[mock_plugin_info]):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_cat_info:
@@ -536,23 +508,13 @@ class TestService:
                 return {'count': 0, 'rows': []}
 
         expected_insert_resp = {'rows_affected': 1, "response": "inserted"}
-
         server.Server.scheduler = Scheduler(None, None)
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(None)
-            _rv2 = await self.async_mock(expected_insert_resp)
-            _rv3 = await self.async_mock("")
-            _rv4 = await async_mock_get_schedule()
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(None))
-            _rv2 = asyncio.ensure_future(self.async_mock(expected_insert_resp))
-            _rv3 = asyncio.ensure_future(self.async_mock(""))
-            _rv4 = asyncio.ensure_future(async_mock_get_schedule())
-        
+        _rv1 = await self.async_mock(None)
+        _rv2 = await self.async_mock(expected_insert_resp)
+        _rv3 = await self.async_mock("")
+        _rv4 = await async_mock_get_schedule()
         with patch('os.path.exists', return_value=True):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_cat_info:
@@ -612,15 +574,8 @@ class TestService:
         server.Server.scheduler = Scheduler(None, None)
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(None)
-            _rv2 = await self.async_mock(expected_insert_resp)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(None))
-            _rv2 = asyncio.ensure_future(self.async_mock(expected_insert_resp))
-        
+        _rv1 = await self.async_mock(None)
+        _rv2 = await self.async_mock(expected_insert_resp)
         with patch('os.path.exists', return_value=True):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_cat_info:
@@ -692,19 +647,10 @@ class TestService:
         server.Server.scheduler = Scheduler(None, None)
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(None)
-            _rv2 = await self.async_mock(expected_insert_resp)
-            _rv3 = await self.async_mock("")
-            _rv4 = await async_mock_get_schedule()
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(None))
-            _rv2 = asyncio.ensure_future(self.async_mock(expected_insert_resp))
-            _rv3 = asyncio.ensure_future(self.async_mock(""))
-            _rv4 = asyncio.ensure_future(async_mock_get_schedule())
-        
+        _rv1 = await self.async_mock(None)
+        _rv2 = await self.async_mock(expected_insert_resp)
+        _rv3 = await self.async_mock("")
+        _rv4 = await async_mock_get_schedule()
         with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[mock_plugin_info]):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_cat_info:
@@ -767,18 +713,11 @@ class TestService:
         delete_result = {'response': 'deleted', 'rows_affected': 1}
         update_result = {'rows_affected': 1, "response": "updated"}
         query_result = [{'rows': [{'name': 'Delta #123'}], 'count': 1}]
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_result()
-            _rv3 = await self.async_mock(delete_result)
-            _rv4 = await self.async_mock(update_result)
-            _rv5 = await self.async_mock(query_result)
-        else:
-            _rv1 = asyncio.ensure_future(mock_result())
-            _rv3 = asyncio.ensure_future(self.async_mock(delete_result))
-            _rv4 = asyncio.ensure_future(self.async_mock(update_result))
-            _rv5 = asyncio.ensure_future(self.async_mock(query_result))
+        _rv1 = await mock_result()
         _rv2 = asyncio.ensure_future(asyncio.sleep(.1))
+        _rv3 = await self.async_mock(delete_result)
+        _rv4 = await self.async_mock(update_result)
+        _rv5 = await self.async_mock(query_result)
         mocker.patch.object(connect, 'get_storage_async')
         get_schedule = mocker.patch.object(service, "get_schedule", return_value=_rv1)
         scheduler = mocker.patch.object(server.Server, "scheduler", MagicMock())
@@ -859,12 +798,7 @@ class TestService:
         async def mock_bad_result():
             return {"count": 0, "rows": []}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_bad_result()
-        else:
-            _rv = asyncio.ensure_future(mock_bad_result())        
-        
+        _rv = await mock_bad_result()
         mock_registry[0]._status = ServiceRecord.Status.Shutdown
         mocker.patch.object(service, "get_schedule", return_value=_rv)
 
@@ -889,13 +823,7 @@ class TestService:
         }]}
         msg = '{} package installation already in progress'.format(pkg_name)
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(select_row_resp)
-        else:
-            _rv = asyncio.ensure_future(async_mock(select_row_resp)) 
-        
+        _rv = await async_mock(select_row_resp)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               return_value=_rv) as query_tbl_patch:
@@ -920,13 +848,7 @@ class TestService:
         svc_list = ["storage", "south", "notification"]
         msg = '{} package is already installed'.format(pkg_name)
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock({'count': 0, 'rows': []})
-        else:
-            _rv = asyncio.ensure_future(async_mock({'count': 0, 'rows': []})) 
-        
+        _rv = await async_mock({'count': 0, 'rows': []})
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               return_value=_rv) as query_tbl_patch:
@@ -961,17 +883,9 @@ class TestService:
                                                              "and": {"column": "name", "condition": "=",
                                                                      "value": pkg_name}}}
         svc_list = ["storage", "south"]
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock({'count': 0, 'rows': []})
-            _rv2 = await async_mock(([pkg_name, "fledge-north-http", "fledge-south-sinusoid"], 'log/190801-12-41-13.log'))
-            _rv3 = await async_mock({"response": "inserted", "rows_affected": 1})
-        else:
-            _rv1 = asyncio.ensure_future(async_mock({'count': 0, 'rows': []}))
-            _rv2 = asyncio.ensure_future(async_mock(([pkg_name, "fledge-north-http", "fledge-south-sinusoid"],
-                                    'log/190801-12-41-13.log'))) 
-            _rv3 = asyncio.ensure_future(async_mock({"response": "inserted", "rows_affected": 1}))
-        
+        _rv1 = await async_mock({'count': 0, 'rows': []})
+        _rv2 = await async_mock(([pkg_name, "fledge-north-http", "fledge-south-sinusoid"], 'log/190801-12-41-13.log'))
+        _rv3 = await async_mock({"response": "inserted", "rows_affected": 1})
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1
                               ) as query_tbl_patch:
@@ -1031,16 +945,8 @@ class TestService:
                                                    "and": {"column": "name", "condition": "=", "value": pkg_name}}}
         storage_client_mock = MagicMock(StorageClientAsync)
         svc_list = ["storage", "south"]
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock({'count': 0, 'rows': []})
-            _rv2 = await async_mock((
-                        [], 'log/190801-12-19-24'))
-        else:
-            _rv1 = asyncio.ensure_future(async_mock({'count': 0, 'rows': []}))
-            _rv2 = asyncio.ensure_future(async_mock(([], 'log/190801-12-19-24')))
-        
+        _rv1 = await async_mock({'count': 0, 'rows': []})
+        _rv2 = await async_mock(([], 'log/190801-12-19-24'))
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload',
                               return_value=_rv1) as query_tbl_patch:
@@ -1060,12 +966,7 @@ class TestService:
         async def async_mock(return_value):
             return return_value
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(([], 'log/190801-12-19-24'))
-        else:
-            _rv = asyncio.ensure_future(async_mock(([], 'log/190801-12-19-24')))
-        
+        _rv = await async_mock(([], 'log/190801-12-19-24'))
         with patch.object(common, 'fetch_available_packages', return_value=_rv) as patch_fetch_available_package:
             resp = await client.get('/fledge/service/available')
             assert 200 == resp.status
@@ -1158,23 +1059,13 @@ class TestService:
                 return {'count': 0, 'rows': []}
 
         expected_insert_resp = {'rows_affected': 1, "response": "inserted"}
-
         server.Server.scheduler = Scheduler(None, None)
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(None)
-            _rv2 = await self.async_mock(expected_insert_resp)
-            _rv3 = await self.async_mock("")
-            _rv4 = await async_mock_get_schedule()
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(None))
-            _rv2 = asyncio.ensure_future(self.async_mock(expected_insert_resp))
-            _rv3 = asyncio.ensure_future(self.async_mock(""))
-            _rv4 = asyncio.ensure_future(async_mock_get_schedule())        
-        
+        _rv1 = await self.async_mock(None)
+        _rv2 = await self.async_mock(expected_insert_resp)
+        _rv3 = await self.async_mock("")
+        _rv4 = await async_mock_get_schedule()
         with patch('os.path.exists', return_value=True):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_cat_info:
@@ -1222,19 +1113,11 @@ class TestService:
 
         expected_insert_resp = {'rows_affected': 1, "response": "inserted"}
         msg = "A Management service type schedule already exists."
-
         server.Server.scheduler = Scheduler(None, None)
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(None)
-            _rv2 = await self.async_mock(expected_insert_resp)
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(None))
-            _rv2 = asyncio.ensure_future(self.async_mock(expected_insert_resp))
-        
+        _rv1 = await self.async_mock(None)
+        _rv2 = await self.async_mock(expected_insert_resp)
         with patch('os.path.exists', return_value=True):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items',
@@ -1292,13 +1175,7 @@ class TestService:
         msg = '{} package update already in progress'.format(pkg_name)
         svc_list = ["south", "storage", name]
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(select_row_resp)
-        else:
-            _rv = asyncio.ensure_future(async_mock(select_row_resp))
-        
+        _rv = await async_mock(select_row_resp)
         with patch.object(service, 'get_service_installed', return_value=svc_list) as svc_list_patch:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(storage_client_mock, 'query_tbl_with_payload',
@@ -1340,21 +1217,11 @@ class TestService:
         server.Server.scheduler = Scheduler(None, None)
         storage_client_mock = MagicMock(StorageClientAsync)
         svc_list = ["south", "storage", name]
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(delete)
-            _rv2 = await async_mock((True, "Schedule successfully disabled"))
-            _rv3 = await async_mock(insert)
-            _se1 = await async_mock(select_row_resp)
-            _se2 = await async_mock(sch_info)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock(delete))
-            _rv2 = asyncio.ensure_future(async_mock((True, "Schedule successfully disabled")))
-            _rv3 = asyncio.ensure_future(async_mock(insert))
-            _se1 = asyncio.ensure_future(async_mock(select_row_resp))
-            _se2 = asyncio.ensure_future(async_mock(sch_info))
-        
+        _rv1 = await async_mock(delete)
+        _rv2 = await async_mock((True, "Schedule successfully disabled"))
+        _rv3 = await async_mock(insert)
+        _se1 = await async_mock(select_row_resp)
+        _se2 = await async_mock(sch_info)
         with patch.object(service, 'get_service_installed', return_value=svc_list
                           ) as svc_list_patch:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -1422,19 +1289,10 @@ class TestService:
         server.Server.scheduler = Scheduler(None, None)
         storage_client_mock = MagicMock(StorageClientAsync)
         svc_list = ["south", "storage", name]
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock(delete)
-            _rv2 = await async_mock(insert)
-            _se1 = await async_mock(select_row_resp)
-            _se2 = await async_mock(sch_info)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock(delete))
-            _rv2 = asyncio.ensure_future(async_mock(insert))
-            _se1 = asyncio.ensure_future(async_mock(select_row_resp))
-            _se2 = asyncio.ensure_future(async_mock(sch_info))
-        
+        _rv1 = await async_mock(delete)
+        _rv2 = await async_mock(insert)
+        _se1 = await async_mock(select_row_resp)
+        _se2 = await async_mock(sch_info)
         with patch.object(service, 'get_service_installed', return_value=svc_list
                           ) as svc_list_patch:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):

--- a/tests/unit/python/fledge/services/core/api/test_statistics_api.py
+++ b/tests/unit/python/fledge/services/core/api/test_statistics_api.py
@@ -6,10 +6,7 @@
 
 """ Test fledge/services/core/api/statistics.py """
 
-import asyncio
 import json
-import sys
-
 from unittest.mock import MagicMock, patch
 from aiohttp import web
 import pytest
@@ -41,12 +38,7 @@ class TestStatistics:
         async def mock_coro():
             return result
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-        
+        _rv = await mock_coro()
         mock_async_storage_client = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=mock_async_storage_client):
             with patch.object(mock_async_storage_client, 'query_tbl_with_payload', return_value=_rv) as query_patch:
@@ -65,12 +57,7 @@ class TestStatistics:
         async def mock_coro():
             return result
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-        
+        _rv = await mock_coro()
         mock_async_storage_client = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=mock_async_storage_client):
             with patch.object(mock_async_storage_client, 'query_tbl_with_payload', return_value=_rv):
@@ -268,12 +255,7 @@ class TestStatistics:
         async def mock_coro():
             return result
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-        
+        _rv = await mock_coro()
         with patch.object(connect, 'get_storage_async', return_value=mock_async_storage_client):
             with patch.object(mock_async_storage_client, 'query_tbl_with_payload', return_value=_rv):
                 resp = await client.get("/fledge/statistics/history?limit={}".format(request_limit))
@@ -494,13 +476,8 @@ class TestStatistics:
             return return_value
 
         storage_rows = {"rows": [{"value": 15}, {"value": 10}, {"value": 5}, {"value": 15}], "count": 4}
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await async_mock({"rows": [{"schedule_interval": "00:00:15"}]})
-            _rv2 = await async_mock(storage_rows)
-        else:
-            _rv1 = asyncio.ensure_future(async_mock({"rows": [{"schedule_interval": "00:00:15"}]}))
-            _rv2 = asyncio.ensure_future(async_mock(storage_rows))
-
+        _rv1 = await async_mock({"rows": [{"schedule_interval": "00:00:15"}]})
+        _rv2 = await async_mock(storage_rows)
         mock_async_storage_client = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=mock_async_storage_client):
             with patch.object(mock_async_storage_client, 'query_tbl_with_payload',

--- a/tests/unit/python/fledge/services/core/api/test_support.py
+++ b/tests/unit/python/fledge/services/core/api/test_support.py
@@ -169,8 +169,8 @@ class TestBundleSupport:
         def mock_syslog():
             return """
             echo "Sep 12 13:31:41 nerd-034 Fledge PI[9241] ERROR: sending_process: sending_process_PI: cannot complete the sending operation
-            Dec 18 15:15:10 aj-ub1804 Fledge OMF[12145]: FATAL: Signal 11 (Segmentation fault) trapped:
-            Dec 18 15:15:10 aj-ub1804 Fledge OMF[12145]: INFO: Signal 11 (Segmentation fault) trapped:"
+            Dec 18 15:15:10 aj-ub Fledge OMF[12145]: FATAL: Signal 11 (Segmentation fault) trapped:
+            Dec 18 15:15:10 aj-ub Fledge OMF[12145]: INFO: Signal 11 (Segmentation fault) trapped:"
             """
 
         with patch.object(support, "__GET_SYSLOG_CMD_WITH_ERROR_TEMPLATE", mock_syslog()):
@@ -320,34 +320,34 @@ class TestBundleSupport:
     async def test_get_syslog_entries_with_level(self, client, template_name, matched_lines, level, actual_count):
         def mock_syslog(_level):
             if _level == 'info':
-                return """echo "Dec 21 10:20:03 aj-ub1804 Fledge[14623] WARNING: server: fledge.services.core.server: A Fledge PID file has been found.
-                Dec 21 12:20:03 aj-ub1804 Fledge[14623] ERROR: change_callback: fledge.services.core.interest_registry.change_callback: Unable to notify microservice with uuid dc2b2f3a-0310-426f-8d1c-8bd3853fcf2f due to exception
-                Dec 12 13:31:41 aj-ub1804 Fledge PI[9241] ERROR: sending_process: sending_process_PI: cannot complete the sending operation
-                Dec 21 15:15:10 aj-ub1804 Fledge OMF[12145]: FATAL: Signal 11 (Segmentation fault) trapped:
-                Dec 21 16:52:48 aj-ub1804 Fledge[24953] INFO: scheduler: fledge.services.core.scheduler.scheduler: Service HTC records successfully removed
-                Dec 21 16:52:54 aj-ub1804 Fledge[24953] INFO: service_registry: fledge.services.core.service_registry.service_registry
-                Dec 21 25:15:10 aj-ub1804 Fledge OMF[12145]: FATAL: (0) 00x55ac77b9d1b9 handler(int) + 73---------"
+                return """echo "Dec 21 10:20:03 aj-ub Fledge[14623] WARNING: server: fledge.services.core.server: A Fledge PID file has been found.
+                Dec 21 12:20:03 aj-ub Fledge[14623] ERROR: change_callback: fledge.services.core.interest_registry.change_callback: Unable to notify microservice with uuid dc2b2f3a-0310-426f-8d1c-8bd3853fcf2f due to exception
+                Dec 12 13:31:41 aj-ub Fledge PI[9241] ERROR: sending_process: sending_process_PI: cannot complete the sending operation
+                Dec 21 15:15:10 aj-ub Fledge OMF[12145]: FATAL: Signal 11 (Segmentation fault) trapped:
+                Dec 21 16:52:48 aj-ub Fledge[24953] INFO: scheduler: fledge.services.core.scheduler.scheduler: Service HTC records successfully removed
+                Dec 21 16:52:54 aj-ub Fledge[24953] INFO: service_registry: fledge.services.core.service_registry.service_registry
+                Dec 21 25:15:10 aj-ub Fledge OMF[12145]: FATAL: (0) 00x55ac77b9d1b9 handler(int) + 73---------"
                 """
             elif _level == 'warning':
-                return """echo "Dec 21 10:20:03 aj-ub1804 Fledge[14623] WARNING: server: fledge.services.core.server: A Fledge PID file has been found.
-                Dec 21 12:20:03 aj-ub1804 Fledge[14623] ERROR: change_callback: fledge.services.core.interest_registry.change_callback: Unable to notify microservice with uuid dc2b2f3a-0310-426f-8d1c-8bd3853fcf2f due to exception
-                Dec 12 13:31:41 aj-ub1804 Fledge PI[9241] ERROR: sending_process: sending_process_PI: cannot complete the sending operation
-                Dec 21 15:15:10 aj-ub1804 Fledge OMF[12145]: FATAL: Signal 11 (Segmentation fault) trapped:
-                Dec 21 25:15:10 aj-ub1804 Fledge OMF[12145]: FATAL: (0) 00x55ac77b9d1b9 handler(int) + 73---------" """
+                return """echo "Dec 21 10:20:03 aj-ub Fledge[14623] WARNING: server: fledge.services.core.server: A Fledge PID file has been found.
+                Dec 21 12:20:03 aj-ub Fledge[14623] ERROR: change_callback: fledge.services.core.interest_registry.change_callback: Unable to notify microservice with uuid dc2b2f3a-0310-426f-8d1c-8bd3853fcf2f due to exception
+                Dec 12 13:31:41 aj-ub Fledge PI[9241] ERROR: sending_process: sending_process_PI: cannot complete the sending operation
+                Dec 21 15:15:10 aj-ub Fledge OMF[12145]: FATAL: Signal 11 (Segmentation fault) trapped:
+                Dec 21 25:15:10 aj-ub Fledge OMF[12145]: FATAL: (0) 00x55ac77b9d1b9 handler(int) + 73---------" """
             elif _level == 'error':
-                return """echo "Dec 21 12:20:03 aj-ub1804 Fledge[14623] ERROR: change_callback: fledge.services.core.interest_registry.change_callback: Unable to notify microservice with uuid dc2b2f3a-0310-426f-8d1c-8bd3853fcf2f due to exception
-                Dec 12 13:31:41 aj-ub1804 Fledge PI[9241] ERROR: sending_process: sending_process_PI: cannot complete the sending operation
-                Dec 21 15:15:10 aj-ub1804 Fledge OMF[12145]: FATAL: Signal 11 (Segmentation fault) trapped:
-                Dec 21 25:15:10 aj-ub1804 Fledge OMF[12145]: FATAL: (0) 00x55ac77b9d1b9 handler(int) + 73---------" """
+                return """echo "Dec 21 12:20:03 aj-ub Fledge[14623] ERROR: change_callback: fledge.services.core.interest_registry.change_callback: Unable to notify microservice with uuid dc2b2f3a-0310-426f-8d1c-8bd3853fcf2f due to exception
+                Dec 12 13:31:41 aj-ub Fledge PI[9241] ERROR: sending_process: sending_process_PI: cannot complete the sending operation
+                Dec 21 15:15:10 aj-ub Fledge OMF[12145]: FATAL: Signal 11 (Segmentation fault) trapped:
+                Dec 21 25:15:10 aj-ub Fledge OMF[12145]: FATAL: (0) 00x55ac77b9d1b9 handler(int) + 73---------" """
             else:
-                return """echo "Dec 21 10:20:03 aj-ub1804 Fledge[14623] WARNING: server: fledge.services.core.server: A Fledge PID file has been found.
-                Dec 21 12:20:03 aj-ub1804 Fledge[14623] ERROR: change_callback: fledge.services.core.interest_registry.change_callback: Unable to notify microservice with uuid dc2b2f3a-0310-426f-8d1c-8bd3853fcf2f due to exception
-                Dec 12 13:31:41 aj-ub1804 Fledge PI[9241] ERROR: sending_process: sending_process_PI: cannot complete the sending operation
-                Dec 21 15:15:10 aj-ub1804 Fledge OMF[12145]: FATAL: Signal 11 (Segmentation fault) trapped:
-                Dec 21 16:52:48 aj-ub1804 Fledge[24953] INFO: scheduler: fledge.services.core.scheduler.scheduler: Service HTC records successfully removed
-                Dec 21 16:52:54 aj-ub1804 Fledge[24953] INFO: service_registry: fledge.services.core.service_registry.service_registry
-                Dec 21 25:15:10 aj-ub1804 Fledge OMF[12145]: FATAL: (0) 00x55ac77b9d1b9 handler(int) + 73---------
-                Dec 21 25:15:10 aj-ub1804 Fledge sin[11011]: DEBUG: 'sinusoid' plugin reconfigure called" """
+                return """echo "Dec 21 10:20:03 aj-ub Fledge[14623] WARNING: server: fledge.services.core.server: A Fledge PID file has been found.
+                Dec 21 12:20:03 aj-ub Fledge[14623] ERROR: change_callback: fledge.services.core.interest_registry.change_callback: Unable to notify microservice with uuid dc2b2f3a-0310-426f-8d1c-8bd3853fcf2f due to exception
+                Dec 12 13:31:41 aj-ub Fledge PI[9241] ERROR: sending_process: sending_process_PI: cannot complete the sending operation
+                Dec 21 15:15:10 aj-ub Fledge OMF[12145]: FATAL: Signal 11 (Segmentation fault) trapped:
+                Dec 21 16:52:48 aj-ub Fledge[24953] INFO: scheduler: fledge.services.core.scheduler.scheduler: Service HTC records successfully removed
+                Dec 21 16:52:54 aj-ub Fledge[24953] INFO: service_registry: fledge.services.core.service_registry.service_registry
+                Dec 21 25:15:10 aj-ub Fledge OMF[12145]: FATAL: (0) 00x55ac77b9d1b9 handler(int) + 73---------
+                Dec 21 25:15:10 aj-ub Fledge sin[11011]: DEBUG: 'sinusoid' plugin reconfigure called" """
 
         with patch.object(support, template_name, mock_syslog(level)):
             with patch.object(support, matched_lines, """echo "{}" """.format(actual_count)):

--- a/tests/unit/python/fledge/services/core/api/test_support.py
+++ b/tests/unit/python/fledge/services/core/api/test_support.py
@@ -4,12 +4,11 @@
 # See: http://fledge-iot.readthedocs.io/
 # FLEDGE_END
 
-import json, os, pathlib, sys
+import json, os, pathlib
 from pathlib import PosixPath
 
 from unittest.mock import patch, mock_open, Mock, MagicMock
 
-import asyncio
 from aiohttp import web
 import pytest
 
@@ -116,12 +115,7 @@ class TestBundleSupport:
         async def mock_build():
             return 'support-180301-13-35-23.tar.gz'
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_build()
-        else:
-            _rv = asyncio.ensure_future(mock_build())
-            
+        _rv = await mock_build()
         with patch.object(SupportBuilder, "__init__", return_value=None):
             with patch.object(SupportBuilder, "build", return_value=_rv):
                 resp = await client.post('/fledge/support')

--- a/tests/unit/python/fledge/services/core/api/test_task.py
+++ b/tests/unit/python/fledge/services/core/api/test_task.py
@@ -10,7 +10,6 @@ import json
 from uuid import UUID
 from aiohttp import web
 import pytest
-import sys
 from unittest.mock import MagicMock, patch, call
 from fledge.services.core import routes
 from fledge.services.core import connect
@@ -95,13 +94,7 @@ class TestTask:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-        
+        _rv = await self.async_mock(None)
         with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[mock_plugin_info]):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(_logger, 'error') as patch_logger:
@@ -139,13 +132,7 @@ class TestTask:
         data = {"name": "north bound", "plugin": "omf", "type": "north", "schedule_type": 3, "schedule_repeat": 30}
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(mock_plugin_info)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(mock_plugin_info))
-        
+        _rv = await self.async_mock(mock_plugin_info)
         with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[mock_plugin_info]):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_cat_info:
@@ -184,13 +171,7 @@ class TestTask:
         data = {"name": "north bound", "plugin": "omf", "type": "north", "schedule_type": 3, "schedule_repeat": 30}
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await self.async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(self.async_mock(None))
-        
+        _rv = await self.async_mock(None)
         with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[mock_plugin_info]):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv) as patch_get_cat_info:
@@ -250,19 +231,10 @@ class TestTask:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(None)
-            _rv2 = await self.async_mock(expected_insert_resp)
-            _rv3 = await self.async_mock("")
-            _rv4 = await async_mock_get_schedule()
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(None))
-            _rv2 = asyncio.ensure_future(self.async_mock(expected_insert_resp))
-            _rv3 = asyncio.ensure_future(self.async_mock(""))
-            _rv4 = asyncio.ensure_future(async_mock_get_schedule())
-
+        _rv1 = await self.async_mock(None)
+        _rv2 = await self.async_mock(expected_insert_resp)
+        _rv3 = await self.async_mock("")
+        _rv4 = await async_mock_get_schedule()
         with patch.object(common, 'load_and_fetch_python_plugin_info', return_value=mock_plugin_info):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_cat_info:
@@ -416,19 +388,10 @@ class TestTask:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await self.async_mock(None)
-            _rv2 = await self.async_mock(expected_insert_resp)
-            _rv3 = await self.async_mock("")
-            _rv4 = await async_mock_get_schedule()
-        else:
-            _rv1 = asyncio.ensure_future(self.async_mock(None))
-            _rv2 = asyncio.ensure_future(self.async_mock(expected_insert_resp))
-            _rv3 = asyncio.ensure_future(self.async_mock(""))
-            _rv4 = asyncio.ensure_future(async_mock_get_schedule())
-        
+        _rv1 = await self.async_mock(None)
+        _rv2 = await self.async_mock(expected_insert_resp)
+        _rv3 = await self.async_mock("")
+        _rv4 = await async_mock_get_schedule()
         with patch.object(common, 'load_and_fetch_python_plugin_info', return_value=mock_plugin_info):
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(c_mgr, 'get_category_all_items', return_value=_rv1) as patch_get_cat_info:
@@ -490,17 +453,10 @@ class TestTask:
 
         delete_result = {'response': 'deleted', 'rows_affected': 1}
         update_result = {'rows_affected': 1, "response": "updated"}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_result()
-            _rv3 = await self.async_mock(delete_result)
-            _rv4 = await self.async_mock(update_result)
-        else:
-            _rv1 = asyncio.ensure_future(mock_result())
-            _rv3 = asyncio.ensure_future(self.async_mock(delete_result))
-            _rv4 = asyncio.ensure_future(self.async_mock(update_result))
+        _rv1 = await mock_result()
         _rv2 = asyncio.ensure_future(asyncio.sleep(.1))
+        _rv3 = await self.async_mock(delete_result)
+        _rv4 = await self.async_mock(update_result)
         storage_client_mock = MagicMock(StorageClientAsync)
         mocker.patch.object(connect, 'get_storage_async', storage_client_mock)
         get_schedule = mocker.patch.object(task, "get_schedule", return_value=_rv1)
@@ -575,13 +531,8 @@ class TestTask:
 
         async def mock_bad_result():
             return {"count": 0, "rows": []}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_bad_result()
-        else:
-            _rv = asyncio.ensure_future(mock_bad_result())
-
+        
+        _rv = await mock_bad_result()
         mocker.patch.object(task, "get_schedule", return_value=_rv)
         resp = await client.delete("/fledge/scheduled/task/Test")
         assert 404 == resp.status

--- a/tests/unit/python/fledge/services/core/asset_tracker/test_asset_tracker.py
+++ b/tests/unit/python/fledge/services/core/asset_tracker/test_asset_tracker.py
@@ -7,9 +7,6 @@
 import json
 from unittest.mock import MagicMock, patch
 import pytest
-import sys
-import asyncio
-
 from fledge.services.core.asset_tracker.asset_tracker import AssetTracker
 from fledge.common.storage_client.storage_client import StorageClientAsync
 from fledge.common.configuration_manager import ConfigurationManager
@@ -40,12 +37,7 @@ class TestAssetTracker:
         async def mock_coro():
             return result
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(asset_tracker._storage, 'query_tbl_with_payload', return_value=_rv) as patch_query_tbl:
             await asset_tracker.load_asset_records()
             assert asset_list == asset_tracker._registered_asset_records
@@ -64,14 +56,8 @@ class TestAssetTracker:
         async def mock_coro2():
             return {"response": "inserted", "rows_affected": 1}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro()
-            _rv2 = await mock_coro2()
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro())
-            _rv2 = asyncio.ensure_future(mock_coro2())
-
+        _rv1 = await mock_coro()
+        _rv2 = await mock_coro2()
         with patch.object(cfg_manager, 'get_category_item', return_value=_rv1) as patch_get_cat_item:
             with patch.object(asset_tracker._storage, 'insert_into_tbl', return_value=_rv2) as patch_insert_tbl:
                 result = await asset_tracker.add_asset_record(asset='sinusoid', event='Ingest', service='sine', plugin='sinusoid', jsondata='{}')

--- a/tests/unit/python/fledge/services/core/interest_registry/test_change_callback.py
+++ b/tests/unit/python/fledge/services/core/interest_registry/test_change_callback.py
@@ -1,8 +1,5 @@
 from unittest.mock import MagicMock, patch, Mock, call
 import pytest
-import sys
-import asyncio
-
 import aiohttp
 from fledge.common.configuration_manager import ConfigurationManager
 from fledge.services.core.service_registry.service_registry import ServiceRegistry
@@ -66,12 +63,7 @@ class TestChangeCallback:
             async def __aexit__(self, *args):
                 return None
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(async_mock(None))
-        
+        _rv = await async_mock(None)
         with patch.object(ConfigurationManager, 'get_category_all_items', return_value=_rv) as cm_get_patch:
             with patch.object(aiohttp.ClientSession, 'post', return_value=AsyncSessionContextManagerMock()) as post_patch:
                 await cb.run('catname1')
@@ -212,12 +204,7 @@ class TestChangeCallback:
             async def __aexit__(self, *args):
                 return None
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(async_mock(None))
-
+        _rv = await async_mock(None)
         with patch.object(ConfigurationManager, 'get_category_all_items', return_value=_rv) as cm_get_patch:
             with patch.object(aiohttp.ClientSession, 'post', return_value=AsyncSessionContextManagerMock()) as post_patch:
                 with patch.object(cb._LOGGER, 'exception') as exception_patch:
@@ -247,12 +234,7 @@ class TestChangeCallback:
         async def async_mock(return_value):
             return return_value
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock(None)
-        else:
-            _rv = asyncio.ensure_future(async_mock(None))
-
+        _rv = await async_mock(None)
         with patch.object(ConfigurationManager, 'get_category_all_items', return_value=_rv) as cm_get_patch:
             with patch.object(aiohttp.ClientSession, 'post', side_effect=Exception) as post_patch:
                 with patch.object(cb._LOGGER, 'exception') as patch_logger:

--- a/tests/unit/python/fledge/services/core/scheduler/test_scheduler.py
+++ b/tests/unit/python/fledge/services/core/scheduler/test_scheduler.py
@@ -11,8 +11,6 @@ import uuid
 import time
 import json
 from unittest.mock import MagicMock, call
-import sys
-
 import copy
 import pytest
 from fledge.services.core.scheduler.scheduler import Scheduler, AuditLogger, ConfigurationManager
@@ -40,12 +38,7 @@ async def mock_process():
 class TestScheduler:
 
     async def scheduler_fixture(self, mocker):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_process()
-        else:
-            _rv = asyncio.ensure_future(mock_process())
-        
+        _rv = await mock_process()
         scheduler = Scheduler()
         scheduler._logger.level = logging.INFO
         scheduler._storage = MockStorage(core_management_host=None, core_management_port=None)
@@ -187,13 +180,7 @@ class TestScheduler:
         # Now queue task and assert that the task has been queued
         await scheduler.queue_task(schedule.id)
         assert isinstance(scheduler._schedule_executions[schedule.id], scheduler._ScheduleExecution)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_process()
-        else:
-            _rv = asyncio.ensure_future(mock_process())
-
+        _rv = await mock_process()
         mocker.patch.object(asyncio, 'create_subprocess_exec', return_value=_rv)
         mocker.patch.object(asyncio, 'ensure_future', return_value=asyncio.ensure_future(mock()))
         mocker.patch.object(scheduler, '_resume_check_schedules')
@@ -512,12 +499,7 @@ class TestScheduler:
                     },
             }
         
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await get_cat()
-        else:
-            _rv = asyncio.ensure_future(get_cat())
-        
+        _rv = await get_cat()
         # GIVEN
         scheduler = Scheduler()
         scheduler._storage = MockStorage(core_management_host=None, core_management_port=None)

--- a/tests/unit/python/fledge/services/core/service_registry/test_monitor.py
+++ b/tests/unit/python/fledge/services/core/service_registry/test_monitor.py
@@ -39,11 +39,7 @@ class TestMonitor:
                 super().__init__(*args, **kwargs)                       
 
             async def __aenter__(self):
-                # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-                if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-                    _rv = await async_mock('{"uptime": "bla"}')
-                else:
-                    _rv = asyncio.ensure_future(async_mock('{"uptime": "bla"}'))
+                _rv = await async_mock('{"uptime": "bla"}')
                 
                 client_response_mock = MagicMock(spec=aiohttp.ClientResponse)
                 # mock response (good)
@@ -80,17 +76,13 @@ class TestMonitor:
                     assert excinfo.type is TestMonitorException
         # service is good, so it should remain in the service registry
         assert len(ServiceRegistry.get(idx=s_id_1)) is 1
-        
-        if sys.version_info < (3, 8):
-            assert ServiceRegistry.get(idx=s_id_1)[0]._status is ServiceRecord.Status.Running
-        else:
-            # TODO: Investigate in py3.8 ServiceRecord.Status is Unresponsive on exception
-            """ =============================== warnings summary ===============================
-            tests/unit/python/fledge/services/core/service_registry/test_monitor.py::TestMonitor::()::test__monitor_good_uptime
-            /usr/lib/python3.8/unittest/mock.py:2076: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited 
-            See: https://bugs.python.org/issue40406
-            """
-            print(ServiceRegistry.get(idx=s_id_1)[0]._status)
+        # TODO: Investigate in py3.8 ServiceRecord.Status is Unresponsive on exception
+        """ =============================== warnings summary ===============================
+        tests/unit/python/fledge/services/core/service_registry/test_monitor.py::TestMonitor::()::test__monitor_good_uptime
+        /usr/lib/python3.8/unittest/mock.py:2076: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited 
+        See: https://bugs.python.org/issue40406
+        """
+        print(ServiceRegistry.get(idx=s_id_1)[0]._status)
 
     @pytest.mark.asyncio
     async def test__monitor_exceed_attempts(self, mocker):
@@ -121,13 +113,7 @@ class TestMonitor:
         monitor = Monitor()
         monitor._sleep_interval = Monitor._DEFAULT_SLEEP_INTERVAL
         monitor._max_attempts = Monitor._DEFAULT_MAX_ATTEMPTS
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await asyncio.sleep(0.1)
-        else:
-            _rv = asyncio.ensure_future(asyncio.sleep(0.1))        
-        
+        _rv = await asyncio.sleep(0.1)
         sleep_side_effect_list = list()
         # _MAX_ATTEMPTS is 15
         # throw exception on the 16th time sleep is called - the first 15 sleeps are used during retries

--- a/tests/unit/python/fledge/services/core/test_server.py
+++ b/tests/unit/python/fledge/services/core/test_server.py
@@ -15,7 +15,6 @@ from aiohttp.test_utils import make_mocked_request
 from aiohttp.streams import StreamReader
 from multidict import CIMultiDict
 import pytest
-import sys
 
 from fledge.services.common.microservice_management import routes as management_routes
 from fledge.services.core import server
@@ -85,13 +84,7 @@ class TestServer:
 
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         Server._configuration_manager = ConfigurationManager(storage_client_mock)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock([])
-        else:
-            _rv = asyncio.ensure_future(async_mock([]))
-        
+        _rv = await async_mock([])
         with patch.object(Server._configuration_manager, 'create_category',
                           return_value=_rv) as patch_create_cat:
             with patch.object(Server._configuration_manager, 'get_category_all_items',
@@ -110,9 +103,7 @@ class TestServer:
         value = {'cacheSize': {'description': 'To control the caching size of Core Configuration Manager',
                                'type': 'integer', 'displayName': 'Cache Size', 'default': '30', 'value': '30',
                                'order': '1', 'minimum': '1', 'maximum': '1000'}}
-
-        rv = await async_mock(value) if sys.version_info.major == 3 and sys.version_info.minor >= 8 else (
-            asyncio.ensure_future(async_mock(value)))
+        rv = await async_mock(value)
         with patch.object(Server._configuration_manager, 'create_category',
                           return_value=rv) as patch_create_cat:
             with patch.object(Server._configuration_manager, 'get_category_all_items',
@@ -218,23 +209,12 @@ class TestServer:
         async def return_async_value(val):
             return val
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await return_async_value(None)
-            _rv2 = await return_async_value('stopping scheduler..')
-            _rv3 = await return_async_value('stopping msvc..')
-            _rv4 = await return_async_value('stopping svc monitor..')
-            _rv5 = await return_async_value('stopping REST server..')
-            _rv6 = await return_async_value('stopping storage..')
-        else:
-            _rv1 = asyncio.ensure_future(return_async_value(None))
-            _rv2 = asyncio.ensure_future(return_async_value('stopping scheduler..'))
-            _rv3 = asyncio.ensure_future(return_async_value('stopping msvc..'))
-            _rv4 = asyncio.ensure_future(return_async_value('stopping svc monitor..'))
-            _rv5 = asyncio.ensure_future(return_async_value('stopping REST server..'))
-            _rv6 = asyncio.ensure_future(return_async_value('stopping storage..'))
-            
-        
+        _rv1 = await return_async_value(None)
+        _rv2 = await return_async_value('stopping scheduler..')
+        _rv3 = await return_async_value('stopping msvc..')
+        _rv4 = await return_async_value('stopping svc monitor..')
+        _rv5 = await return_async_value('stopping REST server..')
+        _rv6 = await return_async_value('stopping storage..')
         mocked__stop_scheduler.return_value = _rv2
         mocked_stop_microservices.return_value = _rv3
         mocked_stop_service_monitor.return_value = _rv4
@@ -295,12 +275,7 @@ class TestServer:
         async def async_mock():
             return web.json_response({'categories': "test"})
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         result = {'categories': "test"}
         with patch.object(conf_api, 'get_categories', return_value=_rv) as patch_get_all_categories:
             resp = await client.get('/fledge/service/category')
@@ -314,12 +289,7 @@ class TestServer:
         async def async_mock():
             return web.json_response("test")
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         result = "test"
         with patch.object(conf_api, 'get_category', return_value=_rv) as patch_category:
             resp = await client.get('/fledge/service/category/{}'.format("test_category"))
@@ -335,12 +305,7 @@ class TestServer:
                                       "description": "test_category_desc",
                                       "value": "test_category_info"})
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         result = {"key": "test_name", "description": "test_category_desc", "value": "test_category_info"}
         with patch.object(conf_api, 'create_category', return_value=_rv) as patch_create_category:
             resp = await client.post('/fledge/service/category')
@@ -354,12 +319,7 @@ class TestServer:
         async def async_mock():
             return web.json_response("test")
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         result = "test"
         with patch.object(conf_api, 'get_category_item', return_value=_rv) as patch_category_item:
             resp = await client.get('/fledge/service/category/{}/{}'.format("test_category", "test_item"))
@@ -373,12 +333,7 @@ class TestServer:
         async def async_mock():
             return web.json_response("test")
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         result = "test"
         with patch.object(conf_api, 'set_configuration_item', return_value=_rv) as patch_update_category_item:
             resp = await client.put('/fledge/service/category/{}/{}'.format("test_category", "test_item"))
@@ -392,12 +347,7 @@ class TestServer:
         async def async_mock():
             return web.json_response("ok")
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await async_mock()
-        else:
-            _rv = asyncio.ensure_future(async_mock())
-        
+        _rv = await async_mock()
         result = "ok"
         with patch.object(conf_api, 'delete_configuration_item_value', return_value=_rv) as patch_del_category_item:
             resp = await client.delete('/fledge/service/category/{}/{}/value'.format("test_category", "test_item"))
@@ -659,8 +609,7 @@ class TestServer:
         Server._storage_client_async = MagicMock(StorageClientAsync)
         request_data = {"type": "Storage", "name": "Storage Services", "address": "127.0.0.1", "service_port": 8090,
                         "management_port": 1090}
-        _rv = await async_mock() if sys.version_info.major == 3 and sys.version_info.minor >= 8 else \
-            asyncio.ensure_future(async_mock())
+        _rv = await async_mock()
         with patch.object(ServiceRegistry, 'getStartupToken', return_value=None):
             with patch.object(ServiceRegistry, 'register', return_value='1') as patch_register:
                 with patch.object(AuditLogger, '__init__', return_value=None):
@@ -701,8 +650,7 @@ class TestServer:
         data.append(record)
         Server._storage_client = MagicMock(StorageClientAsync)
         Server._storage_client_async = MagicMock(StorageClientAsync)
-        _rv = await async_mock() if sys.version_info.major == 3 and sys.version_info.minor >= 8 else\
-            asyncio.ensure_future(async_mock())
+        _rv = await async_mock()
         with patch.object(ServiceRegistry, 'get', return_value=data) as patch_get_unregister:
             with patch.object(ServiceRegistry, 'unregister') as patch_unregister:
                 with patch.object(AuditLogger, '__init__', return_value=None):
@@ -736,12 +684,7 @@ class TestServer:
         async def return_async_value(val):
             return val
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await return_async_value('stopping...')
-        else:
-            _rv = asyncio.ensure_future(return_async_value('stopping...'))
-        
+        _rv = await return_async_value('stopping...')
         mocked__stop = mocker.patch.object(Server, "_stop")
         mocked__stop.return_value = _rv
         mocked_log_info = mocker.patch.object(server._logger, "info")

--- a/tests/unit/python/fledge/services/core/test_user_model.py
+++ b/tests/unit/python/fledge/services/core/test_user_model.py
@@ -7,7 +7,6 @@ import copy
 import json
 import asyncio
 from unittest.mock import MagicMock, patch
-import sys
 import pytest
 from datetime import datetime
 
@@ -56,13 +55,7 @@ class TestUserModel:
     async def test_get_roles(self):
         expected = {'rows': [], 'count': 0}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(expected)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(expected))
-        
+        _rv = await mock_coro(expected)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=_rv) as query_tbl_patch:
                 actual = await User.Objects.get_roles()
@@ -73,13 +66,7 @@ class TestUserModel:
         expected = {'rows': [{'id': '1'}], 'count': 1}
         payload = '{"return": ["id"], "where": {"column": "name", "condition": "=", "value": "admin"}}'
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(expected)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(expected))
-        
+        _rv = await mock_coro(expected)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv) as query_tbl_patch:
                 actual = await User.Objects.get_role_id_by_name("admin")
@@ -90,8 +77,7 @@ class TestUserModel:
         expected = {'rows': [{'name': 'user'}], 'count': 1}
         payload = '{"return": ["name"], "where": {"column": "id", "condition": "=", "value": 2}, "limit": 1}'
         storage_client_mock = MagicMock(StorageClientAsync)
-        _rv = await mock_coro(expected) if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(mock_coro(expected))
+        _rv = await mock_coro(expected)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv
                               ) as query_tbl_patch:
@@ -102,13 +88,7 @@ class TestUserModel:
     async def test_get_all(self):
         expected = {'rows': [], 'count': 0}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(expected)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(expected))
-        
+        _rv = await mock_coro(expected)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=_rv) as query_tbl_patch:
                 actual = await User.Objects.all()
@@ -124,13 +104,7 @@ class TestUserModel:
     async def test_get_filter(self, kwargs, payload):
         expected = {'rows': [], 'count': 0}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(expected)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(expected))
-        
+        _rv = await mock_coro(expected)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv) as query_tbl_patch:
                 actual = await User.Objects.filter(**kwargs)
@@ -144,12 +118,7 @@ class TestUserModel:
         ({'username': 'aj', 'uid': 1}, 'User with id:<1> and name:<aj> does not exist')
     ])
     async def test_get_exception(self, exp_kwargs, error_msg):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro([])
-        else:
-            _rv = asyncio.ensure_future(mock_coro([]))
-
+        _rv = await mock_coro([])
         with patch.object(User.Objects, 'filter', return_value=_rv) as filter_patch:
             with pytest.raises(Exception) as excinfo:
                 await User.Objects.get(uid=exp_kwargs['uid'], username=exp_kwargs['username'])
@@ -162,13 +131,7 @@ class TestUserModel:
     async def test_get(self):
         expected = [{'role_id': '1', 'id': '1', 'uname': 'admin'}]
         exp_kwargs = {'uid': 1, 'username': 'admin'}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(expected)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(expected))
-
+        _rv = await mock_coro(expected)
         with patch.object(User.Objects, 'filter', return_value=_rv) as filter_patch:
             actual = await User.Objects.get(uid=exp_kwargs['uid'], username=exp_kwargs['username'])
             assert actual == expected[0]
@@ -191,15 +154,8 @@ class TestUserModel:
         audit_details['message'] = "'{}' username created for '{}' user.".format(payload['uname'],
                                                                                  payload['real_name'])
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(expected)
-            _rv2 = await mock_coro(None)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(expected))
-            _rv2 = asyncio.ensure_future(mock_coro(None))
-        
+        _rv = await mock_coro(expected)
+        _rv2 = await mock_coro(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(User.Objects, 'hash_password', return_value=hashed_password) as hash_pwd_patch:
                 with patch.object(storage_client_mock, 'insert_into_tbl', return_value=_rv) as insert_tbl_patch:
@@ -222,13 +178,7 @@ class TestUserModel:
         payload = {"pwd": "dd7171406eaf4baa8bc805857f719bca", "role_id": 1, "uname": "aj", 'access_method': 'any',
                    'description': '', 'real_name': ''}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())        
-        
+        _rv = await mock_coro()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(User.Objects, 'hash_password', return_value=hashed_password) as hash_pwd_patch:
                 with patch.object(storage_client_mock, 'insert_into_tbl', return_value=_rv, side_effect=StorageServerError(code=400, reason="blah", error=expected)) as insert_tbl_patch:
@@ -250,16 +200,9 @@ class TestUserModel:
         storage_client_mock = MagicMock(StorageClientAsync)
         user_id = 2
         audit_details = {"user_id": user_id, "message": "User ID: <{}> has been disabled.".format(user_id)}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro(r1)
-            _rv2 = await mock_coro(r2)
-            _rv3 = await mock_coro(None)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro(r1))
-            _rv2 = asyncio.ensure_future(mock_coro(r2))
-            _rv3 = asyncio.ensure_future(mock_coro(None))
-
+        _rv1 = await mock_coro(r1)
+        _rv2 = await mock_coro(r2)
+        _rv3 = await mock_coro(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'delete_from_tbl', return_value=_rv1) as delete_tbl_patch:
                 with patch.object(storage_client_mock, 'update_tbl', return_value=_rv2) as update_tbl_patch:
@@ -280,13 +223,7 @@ class TestUserModel:
         expected = {'message': 'Something went wrong', 'retryable': False, 'entryPoint': 'delete'}
         payload = '{"values": {"enabled": "f"}, "where": {"column": "id", "condition": "=", "value": 2, "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro()) 
-        
+        _rv = await mock_coro()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'delete_from_tbl', return_value=_rv) as delete_tbl_patch:
                 with patch.object(storage_client_mock, 'update_tbl', side_effect=StorageServerError(code=400, reason="blah",
@@ -302,13 +239,8 @@ class TestUserModel:
         user_info = {'id': user_id, 'uname': 'dianomic', 'role_id': 4, 'access_method': 'cert', 'real_name': 'D System',
          'description': 'Company', 'hash_algorithm': 'SHA512', 'block_until': '', 'failed_attempts': 0}
         storage_client_mock = MagicMock(StorageClientAsync)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv0 = await mock_coro(user_info)
-            _rv1 = await mock_coro({'rows': [{'pwd': ''}], 'count': 1})
-        else:
-            _rv0 = asyncio.ensure_future(mock_coro(user_info))
-            _rv1 = asyncio.ensure_future(mock_coro({'rows': [{'pwd': ''}], 'count': 1}))
+        _rv0 = await mock_coro(user_info)
+        _rv1 = await mock_coro({'rows': [{'pwd': ''}], 'count': 1})
         with patch.object(User.Objects, 'get', return_value=_rv0) as patch_get:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1
@@ -337,18 +269,10 @@ class TestUserModel:
                      'description': ''}
         audit_details = {'user_id': user_id, 'old_value': {'role_id': 4},
                          'message': "'dianomic' user has been changed.", 'new_value': user_data}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv0 = await mock_coro(user_info)
-            _rv1 = await mock_coro()
-            _rv2 = await mock_coro(expected)
-            _rv3 = await mock_coro(None)
-        else:
-            _rv0 = asyncio.ensure_future(mock_coro(user_info))
-            _rv1 = asyncio.ensure_future(mock_coro())
-            _rv2 = asyncio.ensure_future(mock_coro(expected))
-            _rv3 = asyncio.ensure_future(mock_coro(None))
-
+        _rv0 = await mock_coro(user_info)
+        _rv1 = await mock_coro()
+        _rv2 = await mock_coro(expected)
+        _rv3 = await mock_coro(None)
         with patch.object(User.Objects, 'get', return_value=_rv0) as patch_get:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(storage_client_mock, 'update_tbl', return_value=_rv2) as update_tbl_patch:
@@ -379,20 +303,11 @@ class TestUserModel:
                          'new_value': {'pwd': 'Password has been updated.'},
                          'message': "'dianomic' user has been changed."}
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv0 = await mock_coro(user_info)
-            _rv1 = await mock_coro()
-            _rv2 = await mock_coro(expected)
-            _rv3 = await mock_coro(['HASHED_PWD'])
-            _rv4 = await mock_coro(None)
-        else:
-            _rv0 = asyncio.ensure_future(mock_coro(user_info))
-            _rv1 = asyncio.ensure_future(mock_coro())
-            _rv2 = asyncio.ensure_future(mock_coro(expected))
-            _rv3 = asyncio.ensure_future(mock_coro(['HASHED_PWD']))
-            _rv4 = asyncio.ensure_future(mock_coro(None))
-        
+        _rv0 = await mock_coro(user_info)
+        _rv1 = await mock_coro()
+        _rv2 = await mock_coro(expected)
+        _rv3 = await mock_coro(['HASHED_PWD'])
+        _rv4 = await mock_coro(None)
         with patch.object(User.Objects, 'get', return_value=_rv0) as patch_get:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(User.Objects, 'hash_password', return_value='HASHED_PWD') as hash_pwd_patch:
@@ -429,8 +344,7 @@ class TestUserModel:
         user_id = 2
         user_info = {'id': user_id, 'uname': 'dianomic', 'role_id': 4, 'access_method': 'cert', 'real_name': 'D System',
                      'description': ''}
-        _rv0 = await mock_coro(user_info) if sys.version_info.major == 3 and sys.version_info.minor >= 8 else \
-            asyncio.ensure_future(mock_coro(user_info))
+        _rv0 = await mock_coro(user_info)
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(User.Objects, 'get', return_value=_rv0) as patch_get:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -450,8 +364,7 @@ class TestUserModel:
         user_id = 2
         user_info = {'id': user_id, 'uname': 'dianomic', 'role_id': 4, 'access_method': 'cert', 'real_name': 'D System',
                      'description': ''}
-        _rv0 = await mock_coro(user_info) if sys.version_info.major == 3 and sys.version_info.minor >= 8 else \
-            asyncio.ensure_future(mock_coro(user_info))
+        _rv0 = await mock_coro(user_info)
         with patch.object(User.Objects, 'get', return_value=_rv0) as patch_get:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(storage_client_mock, 'update_tbl', side_effect=ValueError(msg)) as update_tbl_patch:
@@ -483,20 +396,11 @@ class TestUserModel:
         for u in user_data.keys():
             temp[u] = user_info[u]
         audit_details['old_value'] = temp
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv0 = await mock_coro(user_info)
-            _rv1 = await mock_coro()
-            _rv2 = await mock_coro(expected)
-            _rv3 = await mock_coro(None)
-            _rv4 = await mock_coro({'rows': [{'pwd': '2Xc34'}], 'count': 1})
-        else:
-            _rv0 = asyncio.ensure_future(mock_coro(user_info))
-            _rv1 = asyncio.ensure_future(mock_coro())
-            _rv2 = asyncio.ensure_future(mock_coro(expected))
-            _rv3 = asyncio.ensure_future(mock_coro(None))
-            _rv4 = asyncio.ensure_future(mock_coro({'rows': [{'pwd': '2Xc34'}], 'count': 1}))
-
+        _rv0 = await mock_coro(user_info)
+        _rv1 = await mock_coro()
+        _rv2 = await mock_coro(expected)
+        _rv3 = await mock_coro(None)
+        _rv4 = await mock_coro({'rows': [{'pwd': '2Xc34'}], 'count': 1})
         with patch.object(User.Objects, 'get', return_value=_rv0) as patch_get:
             with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
                 with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv4
@@ -534,15 +438,8 @@ class TestUserModel:
                    "where": {"column": "uname", "condition": "=", "value": "admin",
                              "and": {"column": "enabled", "condition": "=", "value": "t"}}}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_get_category_item()
-            _rv2 = await mock_coro({'rows': [], 'count': 0})
-        else:
-            _rv1 = asyncio.ensure_future(mock_get_category_item())
-            _rv2 = asyncio.ensure_future(mock_coro({'rows': [], 'count': 0}))
-        
+        _rv1 = await mock_get_category_item()
+        _rv2 = await mock_coro({'rows': [], 'count': 0})
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=_rv1
                               ) as mock_get_cat_patch:
@@ -573,17 +470,9 @@ class TestUserModel:
                              "and": {"column": "enabled", "condition": "=", "value": "t"}}}
         storage_client_mock = MagicMock(StorageClientAsync)
         found_user = pwd_result['rows'][0]
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_get_category_item()
-            _rv2 = await mock_coro(pwd_result)
-            _rv3 = await mock_coro(None)
-        else:
-            _rv1 = asyncio.ensure_future(mock_get_category_item())
-            _rv2 = asyncio.ensure_future(mock_coro(pwd_result))
-            _rv3 = asyncio.ensure_future(mock_coro(None))
-        
+        _rv1 = await mock_get_category_item()
+        _rv2 = await mock_coro(pwd_result)
+        _rv3 = await mock_coro(None)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=_rv1
                               ) as mock_get_cat_patch:
@@ -618,15 +507,8 @@ class TestUserModel:
                    "where": {"column": "uname", "condition": "=", "value": "user",
                              "and": {"column": "enabled", "condition": "=", "value": "t"}}}
         storage_client_mock = MagicMock(StorageClientAsync)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_get_category_item()
-            _rv2 = await mock_coro(pwd_result)
-        else:
-            _rv1 = asyncio.ensure_future(mock_get_category_item())
-            _rv2 = asyncio.ensure_future(mock_coro(pwd_result))
-
+        _rv1 = await mock_get_category_item()
+        _rv2 = await mock_coro(pwd_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item",
                               return_value=_rv1) as mock_get_cat_patch:
@@ -655,15 +537,8 @@ class TestUserModel:
                    "where": {"column": "uname", "condition": "=", "value": "user", "and":
                        {"column": "enabled", "condition": "=", "value": "t"}}}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_get_category_item()
-            _rv2 = await mock_coro(pwd_result)
-        else:
-            _rv1 = asyncio.ensure_future(mock_get_category_item())
-            _rv2 = asyncio.ensure_future(mock_coro(pwd_result))
-        
+        _rv1 = await mock_get_category_item()
+        _rv2 = await mock_coro(pwd_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=_rv1
                               ) as mock_get_cat_patch:
@@ -696,17 +571,9 @@ class TestUserModel:
                    "where": {"column": "uname", "condition": "=", "value": "user", "and":
                        {"column": "enabled", "condition": "=", "value": "t"}}}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_get_category_item()
-            _rv2 = await mock_coro(user_data)
-            _rv3 = await mock_coro(True)
-        else:
-            _rv1 = asyncio.ensure_future(mock_get_category_item())
-            _rv2 = asyncio.ensure_future(mock_coro(user_data))
-            _rv3 = asyncio.ensure_future(mock_coro(True))
-        
+        _rv1 = await mock_get_category_item()
+        _rv2 = await mock_coro(user_data)
+        _rv3 = await mock_coro(True)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=_rv1
                               ) as mock_get_cat_patch:
@@ -748,15 +615,8 @@ class TestUserModel:
                    "where": {"column": "uname", "condition": "=", "value": "user",
                              "and": {"column": "enabled", "condition": "=", "value": "t"}}}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_get_category_item()
-            _rv2 = await mock_coro(pwd_result)
-        else:
-            _rv1 = asyncio.ensure_future(mock_get_category_item())
-            _rv2 = asyncio.ensure_future(mock_coro(pwd_result))
-        
+        _rv1 = await mock_get_category_item()
+        _rv2 = await mock_coro(pwd_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=_rv1
                               ) as mock_get_cat_patch:
@@ -781,13 +641,7 @@ class TestUserModel:
         expected = {'response': 'deleted', 'rows_affected': 1}
         payload = '{"where": {"column": "user_id", "condition": "=", "value": 2}}'
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(expected)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(expected))
-        
+        _rv = await mock_coro(expected)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'delete_from_tbl', return_value=_rv) as delete_tbl_patch:
                 actual = await User.Objects.delete_user_tokens(2)
@@ -810,13 +664,7 @@ class TestUserModel:
         token = "RDSlaEtgXuxbYHlDgJURbEeBua2ccwvHeB7MVDeIHq4"
         payload = {"values": {"token_expiration": "2018-03-13 15:33:25.959408"}, "where": {"column": "token", "condition": "=", "value": "RDSlaEtgXuxbYHlDgJURbEeBua2ccwvHeB7MVDeIHq4"}}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(expected)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(expected))
-        
+        _rv = await mock_coro(expected)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'update_tbl', return_value=_rv) as update_tbl_patch:
                 await User.Objects.refresh_token_expiry(token)
@@ -827,13 +675,7 @@ class TestUserModel:
     async def test_invalid_token(self):
         storage_client_mock = MagicMock(StorageClientAsync)
         payload = {"return": [{"column": "token_expiration", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias": "token_expiration"}], "where": {"column": "token", "condition": "=", "value": "blah"}}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro({'rows': [], 'count': 0})
-        else:
-            _rv = asyncio.ensure_future(mock_coro({'rows': [], 'count': 0}))
-        
+        _rv = await mock_coro({'rows': [], 'count': 0})
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv) as query_tbl_patch:
                 with pytest.raises(Exception) as excinfo:
@@ -853,9 +695,7 @@ class TestUserModel:
         storage_client_mock = MagicMock(StorageClientAsync)
         payload = {"return": [{"column": "token_expiration", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias":
             "token_expiration"}], "where": {"column": "token", "condition": "=", "value": token}}
-        _rv = await mock_coro(valid_token_result) if sys.version_info.major == 3 and sys.version_info.minor >= 8 \
-            else asyncio.ensure_future(mock_coro(valid_token_result))
-        
+        _rv = await mock_coro(valid_token_result)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv
                               ) as query_tbl_patch:
@@ -876,13 +716,7 @@ class TestUserModel:
         expected = {'response': 'deleted', 'rows_affected': 1}
         payload = '{"where": {"column": "token", "condition": "=", "value": "eyz"}}'
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(expected)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(expected))
-        
+        _rv = await mock_coro(expected)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'delete_from_tbl', return_value=_rv) as delete_tbl_patch:
                 actual = await User.Objects.delete_token("eyz")
@@ -902,13 +736,7 @@ class TestUserModel:
 
     async def test_delete_all_user_tokens(self):
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-        
+        _rv = await mock_coro()
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'delete_from_tbl', return_value=_rv) as delete_tbl_patch:
                 await User.Objects.delete_all_user_tokens()
@@ -919,13 +747,7 @@ class TestUserModel:
                             '"where": {"column": "id", "condition": "=", "value": 2, '
                             '"and": {"column": "enabled", "condition": "=", "value": "t"}}}')
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro({'rows': []})
-        else:
-            _rv = asyncio.ensure_future(mock_coro({'rows': []}))
-        
+        _rv = await mock_coro({'rows': []})
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv
                               ) as query_tbl_patch:
@@ -940,13 +762,7 @@ class TestUserModel:
                             '"condition": "=", "value": "t"}}}')
         storage_client_mock = MagicMock(StorageClientAsync)
         ret_val = {'rows': [{'id': 1, 'pwd': 'HASHED_PWD', "hash_algorithm": "SHA512"}]}
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(ret_val)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(ret_val))
-        
+        _rv = await mock_coro(ret_val)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv
                               ) as query_tbl_patch:
@@ -963,13 +779,7 @@ class TestUserModel:
         user_data = {'password': 'HASHED_PWD'}
         ret_val = {'rows': [{'id': 1, 'user_id': 2, 'pwd': 'HASHED_PWD', "hash_algorithm": "SHA512"}]}
         row = ret_val['rows'][0]
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(ret_val)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(ret_val))
-
+        _rv = await mock_coro(ret_val)
         with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv) as query_tbl_patch:
             with patch.object(User.Objects, 'check_password', return_value=False) as check_pwd_patch:
                 result = await User.Objects._get_password_history(storage_client_mock, row['user_id'], user_data,
@@ -984,13 +794,7 @@ class TestUserModel:
         user_data = {'password': 'HASHED_PWD'}
         ret_val = {'rows': [{'id': 1, 'user_id': 2, 'pwd': 'HASHED_PWD', "hash_algorithm": "SHA256"}]}
         row = ret_val['rows'][0]
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(ret_val)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(ret_val))
-
+        _rv = await mock_coro(ret_val)
         with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv) as query_tbl_patch:
             with patch.object(User.Objects, 'check_password', return_value=True) as check_pwd_patch:
                 with pytest.raises(Exception) as excinfo:
@@ -1009,13 +813,7 @@ class TestUserModel:
     ])
     async def test__insert_pwd_history(self, hashed_pwd, pwd_history_list, payload):
         storage_client_mock = MagicMock(StorageClientAsync)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())        
-
+        _rv = await mock_coro()
         with patch.object(storage_client_mock, 'insert_into_tbl', return_value=_rv) as insert_tbl_patch:
             await User.Objects._insert_pwd_history_with_oldest_pwd_deletion_if_count_exceeds(storage_client_mock, 2, hashed_pwd, pwd_history_list)
         args, kwargs = insert_tbl_patch.call_args
@@ -1029,13 +827,7 @@ class TestUserModel:
     async def test__insert_pwd_history_and_delete_oldest_pwd_if_count_exceeds(self, hashed_pwd, pwd_history_list):
         storage_client_mock = MagicMock(StorageClientAsync)
         payload = {"where": {"column": "user_id", "condition": "=", "value": 2, "and": {"column": "pwd", "condition": "=", "value": "HASHED_PWD_1"}}}
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
-
+        _rv = await mock_coro()
         with patch.object(storage_client_mock, 'delete_from_tbl', return_value=_rv) as delete_tbl_patch:
             with patch.object(storage_client_mock, 'insert_into_tbl', return_value=_rv) as insert_tbl_patch:
                 await User.Objects._insert_pwd_history_with_oldest_pwd_deletion_if_count_exceeds(storage_client_mock, 2, hashed_pwd, pwd_history_list)
@@ -1055,15 +847,8 @@ class TestUserModel:
     async def test_certficate_login(self, user_data):
         payload = {"return": ["id", "role_id"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}
         storage_client_mock = MagicMock(StorageClientAsync)
-        
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro(user_data)
-            _rv2 = await mock_coro(True)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro(user_data))
-            _rv2 = asyncio.ensure_future(mock_coro(True))        
-        
+        _rv1 = await mock_coro(user_data)
+        _rv2 = await mock_coro(True)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=_rv1) as query_tbl_patch:
                 with patch.object(storage_client_mock, 'insert_into_tbl', return_value=_rv2) as insert_tbl_patch:

--- a/tests/unit/python/fledge/services/south/test_ingest.py
+++ b/tests/unit/python/fledge/services/south/test_ingest.py
@@ -9,7 +9,6 @@
 """
 import copy
 import pytest
-import sys
 import asyncio
 from unittest.mock import MagicMock, call
 from fledge.services.south.ingest import *
@@ -199,14 +198,8 @@ class TestIngest:
         async def mock_create(storage):
             return mock_stat()
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro()
-            _rv2 = await mock_create(None)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro())
-            _rv2 = asyncio.ensure_future(mock_create(None))
-        
+        _rv1 = await mock_coro()
+        _rv2 = await mock_create(None)
         # GIVEN
         mocker.patch.object(StorageClientAsync, "__init__", return_value=None)
         mocker.patch.object(ReadingsStorageClientAsync, "__init__", return_value=None)
@@ -251,14 +244,8 @@ class TestIngest:
         async def mock_create(storage):
             return mock_stat()
 
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_coro()
-            _rv2 = await mock_create(None)
-        else:
-            _rv1 = asyncio.ensure_future(mock_coro())
-            _rv2 = asyncio.ensure_future(mock_create(None))
-        
+        _rv1 = await mock_coro()
+        _rv2 = await mock_create(None)
         # GIVEN
         mocker.patch.object(StorageClientAsync, "__init__", return_value=None)
         mocker.patch.object(ReadingsStorageClientAsync, "__init__", return_value=None)

--- a/tests/unit/python/fledge/tasks/purge/test_purge.py
+++ b/tests/unit/python/fledge/tasks/purge/test_purge.py
@@ -7,7 +7,6 @@
 import json
 import pytest
 import asyncio
-import sys
 from unittest.mock import patch, call, MagicMock
 from fledge.common.audit_logger import AuditLogger
 from fledge.common.configuration_manager import ConfigurationManager
@@ -58,11 +57,7 @@ class TestPurge:
 
         mock_storage_client_async = MagicMock(spec=StorageClientAsync)
         mock_audit_logger = AuditLogger(mock_storage_client_async)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_value("") if sys.version_info.major == 3 and sys.version_info.minor >= 8 else \
-            asyncio.ensure_future(mock_value(""))
-
+        _rv = await mock_value("")
         with patch.object(FledgeProcess, '__init__'):
             with patch.object(Statistics, '_load_keys', return_value=_rv):
                 with patch.object(Statistics, 'update', return_value=_rv) as mock_stats_update:
@@ -76,10 +71,7 @@ class TestPurge:
         """Test that purge's set_configuration returns configuration item with key 'PURGE_READ' """
         mock_storage_client_async = MagicMock(spec=StorageClientAsync)
         mock_audit_logger = AuditLogger(mock_storage_client_async)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_value("") if sys.version_info.major == 3 and sys.version_info.minor >= 8 else \
-            asyncio.ensure_future(mock_value(""))
+        _rv = await mock_value("")
         with patch.object(FledgeProcess, '__init__'):
             with patch.object(mock_audit_logger, "__init__", return_value=None):
                 p = Purge()
@@ -131,22 +123,11 @@ class TestPurge:
         payload = {"aggregate": {"operation": "min", "column": "last_object"}}
         if expected_calls["flag"] == "retainany":
             payload = {"aggregate": {"operation": "max", "column": "last_object"}}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            if expected_calls["flag"] == "retainany":
-                _rv1 = await q_result('streams', 'any')
-            else:
-                _rv1 = await q_result('streams')
-            _rv2 = await mock_value("")
-            _rv3 = await self.store_purge()
+            _rv1 = await q_result('streams', 'any')
         else:
-            if expected_calls["flag"] == "retainany":
-                _rv1 = asyncio.ensure_future(q_result('streams', 'any'))
-            else:
-                _rv1 = asyncio.ensure_future(q_result('streams'))
-            _rv2 = asyncio.ensure_future(mock_value(""))
-            _rv3 = asyncio.ensure_future(self.store_purge())
-
+            _rv1 = await q_result('streams')
+        _rv2 = await mock_value("")
+        _rv3 = await self.store_purge()
         with patch.object(FledgeProcess, '__init__'):
             with patch.object(mock_audit_logger, "__init__", return_value=None):
                 p = Purge()
@@ -182,16 +163,9 @@ class TestPurge:
         mock_storage_client_async = MagicMock(spec=StorageClientAsync)
         mock_audit_logger = AuditLogger(mock_storage_client_async)
         payload = {"aggregate": {"operation": "min", "column": "last_object"}}
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await q_result('streams')
-            _rv2 = await mock_value("")
-            _rv3 = await self.store_purge()
-        else:
-            _rv1 = asyncio.ensure_future(q_result('streams'))
-            _rv2 = asyncio.ensure_future(mock_value(""))
-            _rv3 = asyncio.ensure_future(self.store_purge())
-
+        _rv1 = await q_result('streams')
+        _rv2 = await mock_value("")
+        _rv3 = await self.store_purge()
         with patch.object(FledgeProcess, '__init__'):
             with patch.object(mock_audit_logger, "__init__", return_value=None):
                 p = Purge()
@@ -229,17 +203,9 @@ class TestPurge:
         """Test that purge_data logs message when no data was purged"""
         mock_storage_client_async = MagicMock(spec=StorageClientAsync)
         mock_audit_logger = AuditLogger(mock_storage_client_async)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await q_result('streams')
-            _rv2 = await mock_value("")
-            _rv3 = await self.store_purge()
-        else:
-            _rv1 = asyncio.ensure_future(q_result('streams'))
-            _rv2 = asyncio.ensure_future(mock_value(""))
-            _rv3 = asyncio.ensure_future(self.store_purge())
-
+        _rv1 = await q_result('streams')
+        _rv2 = await mock_value("")
+        _rv3 = await self.store_purge()
         with patch.object(FledgeProcess, '__init__'):
             with patch.object(mock_audit_logger, "__init__", return_value=None):
                 p = Purge()
@@ -268,17 +234,9 @@ class TestPurge:
         """Test that purge_data logs error when storage purge returns an error response"""
         mock_storage_client_async = MagicMock(spec=StorageClientAsync)
         mock_audit_logger = AuditLogger(mock_storage_client_async)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await q_result('streams')
-            _rv2 = await mock_value("")
-            _rv3 = await self.store_purge()
-        else:
-            _rv1 = asyncio.ensure_future(q_result('streams'))
-            _rv2 = asyncio.ensure_future(mock_value(""))
-            _rv3 = asyncio.ensure_future(self.store_purge())
-
+        _rv1 = await q_result('streams')
+        _rv2 = await mock_value("")
+        _rv3 = await self.store_purge()
         with patch.object(FledgeProcess, '__init__'):
             with patch.object(mock_audit_logger, "__init__", return_value=None):
                 p = Purge()
@@ -308,14 +266,8 @@ class TestPurge:
         mock_storage_client_async = MagicMock(spec=StorageClientAsync)
         mock_audit_logger = AuditLogger(mock_storage_client_async)
         expected_error_message = 'purge_data - Configuration item {} bla should be integer!'.format(expected_error_key)
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await q_result('streams')
-            _rv2 = await mock_value("")
-        else:
-            _rv1 = asyncio.ensure_future(q_result('streams'))
-            _rv2 = asyncio.ensure_future(mock_value(""))
-
+        _rv1 = await q_result('streams')
+        _rv2 = await mock_value("")
         with patch.object(FledgeProcess, '__init__'):
             with patch.object(mock_audit_logger, "__init__", return_value=None):
                 p = Purge()
@@ -338,17 +290,9 @@ class TestPurge:
         """Test that run calls all units of purge process"""
         mock_storage_client_async = MagicMock(spec=StorageClientAsync)
         mock_audit_logger = AuditLogger(mock_storage_client_async)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv1 = await mock_value("Some config")
-            _rv2 = await mock_value((1, 2))
-            _rv3 = await mock_value(None)
-        else:
-            _rv1 = asyncio.ensure_future(mock_value("Some config"))
-            _rv2 = asyncio.ensure_future(mock_value((1, 2)))
-            _rv3 = asyncio.ensure_future(mock_value(None))
-
+        _rv1 = await mock_value("Some config")
+        _rv2 = await mock_value((1, 2))
+        _rv3 = await mock_value(None)
         with patch.object(FledgeProcess, '__init__'):
             with patch.object(mock_audit_logger, "__init__", return_value=None):
                 p = Purge()
@@ -375,11 +319,7 @@ class TestPurge:
 
         mock_storage_client_async = MagicMock(spec=StorageClientAsync)
         mock_audit_logger = AuditLogger(mock_storage_client_async)
-
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        _rv = await mock_value("Some config") if sys.version_info.major == 3 and sys.version_info.minor >= 8 else \
-            asyncio.ensure_future(mock_value("Some config"))
-
+        _rv = await mock_value("Some config")
         with patch.object(FledgeProcess, '__init__'):
             with patch.object(mock_audit_logger, "__init__", return_value=None):
                 p = Purge()

--- a/tests/unit/python/fledge/tasks/purge/test_purge_main.py
+++ b/tests/unit/python/fledge/tasks/purge/test_purge_main.py
@@ -7,8 +7,6 @@
 """ Test tasks/purge/__main__.py entry point
 
 """
-import asyncio
-import sys
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -43,10 +41,7 @@ async def test_main(_purge_instance):
     
     with patch.object(purge, "__name__", "__main__"):
         purge.purge_process = _purge_instance
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
+        _rv = await mock_coro()
         with patch.object(Purge, 'run', return_value=_rv):
             await purge.purge_process.run()
             purge.purge_process.run.assert_called_once_with()

--- a/tests/unit/python/fledge/tasks/statistics/test_statistics_history.py
+++ b/tests/unit/python/fledge/tasks/statistics/test_statistics_history.py
@@ -6,11 +6,8 @@
 
 """Test tasks/statistics/statistics_history.py"""
 
-import asyncio
 from unittest.mock import patch, MagicMock
 import pytest
-import sys
-
 import ast
 from fledge.common.logger import FLCoreLogger
 from fledge.common.process import FledgeProcess
@@ -47,12 +44,7 @@ class TestStatisticsHistory:
         mock_process.assert_called_once_with()
 
     async def test_update_previous_value(self):
-        # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro(None)
-        else:
-            _rv = asyncio.ensure_future(mock_coro(None))
-        
+        _rv = await mock_coro(None)
         with patch.object(FledgeProcess, '__init__'):
             with patch.object(FLCoreLogger, "get_logger"):
                 sh = StatisticsHistory()
@@ -80,14 +72,8 @@ class TestStatisticsHistory:
                                     'ts': '2018-08-31 17:03:17.597055+05:30'
                                     }]
                           }
-                # Changed in version 3.8: patch() now returns an AsyncMock if the target is an async function.
-                if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-                    _rv1 = await mock_coro(retval)
-                    _rv2 = await mock_coro(None)
-                else:
-                    _rv1 = asyncio.ensure_future(mock_coro(retval))
-                    _rv2 = asyncio.ensure_future(mock_coro(None))
-
+                _rv1 = await mock_coro(retval)
+                _rv2 = await mock_coro(None)
                 with patch.object(sh._storage_async, "query_tbl", return_value=_rv1) as mock_keys:
                     with patch.object(sh, "_bulk_update_previous_value", return_value=_rv2) as mock_update:
                         with patch.object(sh._storage_async, "insert_into_tbl", return_value=_rv2) as mock_bulk_insert:

--- a/tests/unit/python/fledge/tasks/statistics/test_statistics_main.py
+++ b/tests/unit/python/fledge/tasks/statistics/test_statistics_main.py
@@ -6,8 +6,6 @@
 
 """Test tasks/statistics/__main__.py entry point"""
 
-import asyncio
-import sys
 from unittest.mock import patch, MagicMock
 import pytest
 
@@ -39,10 +37,7 @@ async def test_main(_stats_history_instance):
     async def mock_coro():
         return None
     with patch.object(statistics_history, "__name__", "__main__"):
-        if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-            _rv = await mock_coro()
-        else:
-            _rv = asyncio.ensure_future(mock_coro())
+        _rv = await mock_coro()
         with patch.object(StatisticsHistory, 'run', return_value=_rv):
             assert isinstance(_stats_history_instance, StatisticsHistory)
             await _stats_history_instance.run()


### PR DESCRIPTION
During asynchronous mocking, we previously handled two types of await mocks, which are no longer necessary. This removal also eliminates redundant code from the unit tests themselves.

