### PR TITLE
FOGL-10187 GET endpoint for retrieving service information

### DIFF
--- a/python/fledge/services/core/api/service.py
+++ b/python/fledge/services/core/api/service.py
@@ -11,6 +11,7 @@ import datetime
 import uuid
 import json
 import multiprocessing
+import subprocess
 from aiohttp import web
 
 from typing import Dict, List
@@ -34,7 +35,7 @@ from fledge.common.audit_logger import AuditLogger
 from fledge.common.web.middleware import has_permission
 
 
-__author__ = "Mark Riddoch, Ashwin Gopalakrishnan, Amarendra K Sinha"
+__author__ = "Mark Riddoch, Ashwin Gopalakrishnan, Amarendra K Sinha, Ashish Jabble"
 __copyright__ = "Copyright (c) 2018 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
@@ -44,12 +45,39 @@ _help = """
     | GET POST            | /fledge/service                                      |
     | GET                 | /fledge/service/available                            |
     | GET                 | /fledge/service/installed                            |
+    | GET                 | /fledge/service/info                                 |
+    | GET                 | /fledge/service/info/{service_name}                  |
     | PUT                 | /fledge/service/{type}/{name}/update                 |
     | DELETE              | /fledge/service/{service_name}                       |
     | POST                | /fledge/service/{service_name}/otp                   |
     ------------------------------------------------------------------------------
 """
 _logger = FLCoreLogger().get_logger(__name__)
+
+# Prebuilt services configuration
+_PREBUILT_SERVICES = {
+    "south": {
+        "name": "south",
+        "description": "Service used to interact with device, API and generic sources of data",
+        "type": "south",
+        "process": "south",
+        "process_script": "south_c"
+    },
+    "north": {
+        "name": "north",
+        "description": "Service used to interact with device, API and generic sources of data",
+        "type": "north",
+        "process": "north",
+        "process_script": "north_C"
+    },
+    "storage": {
+        "name": "storage",
+        "description": "The storage service buffers data within a single Fledge instance",
+        "type": "storage",
+        "process": "storage",
+        "process_script": "storage"
+    }
+}
 
 #################################
 #  Service
@@ -77,6 +105,121 @@ def get_service_records(_type=None):
     return recs
 
 
+async def _fetch_service_info(service_name: str) -> dict:
+    """
+    Fetch service information by attempting multiple service discovery methods.
+
+    Tries to get service info in the following order:
+    1. C service executable with --info flag
+    2. Python service module with info() function
+
+    Args:
+        service_name: Name of the service to fetch info for
+
+    Returns:
+        Service info dictionary with service details, or empty response if all methods fail
+    """
+    def _create_empty_service_response(name: str) -> dict:
+        return {
+            "name": name,
+            "description": "",
+            "type": "",
+            "process": "",
+            "process_script": ""
+        }
+
+    def _get_service_info_from_path(service_path: str, is_python: bool = False) -> dict:
+        """
+        Get service information from the specified path.
+
+        Args:
+            service_path: Path to the service (executable or Python __main__.py)
+            is_python: True if this is a Python service, False for C service
+
+        Returns:
+            Service information dictionary or None if failed
+        """
+        if is_python:
+            # For Python services, import the module and call info() function directly
+            try:
+                import importlib.util
+
+                # Load the Python module from the __main__.py file
+                spec = importlib.util.spec_from_file_location("service_module", service_path)
+                if spec is None or spec.loader is None:
+                    _logger.error(f"Could not load service module from path: {service_path}.")
+                    return None
+
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+
+                # Call the info() function if it exists
+                if hasattr(module, 'info') and callable(getattr(module, 'info')):
+                    return module.info()
+                else:
+                    _logger.error(f"Service module {service_name} does not have info() function.")
+                    return None
+            except Exception as ex:
+                _logger.error(f"Error loading service module {service_name}: {ex}")
+                return None
+        else:
+            # For C services, execute with --info flag
+            cmd_with_args = [service_path, "--info"]
+            try:
+                p = subprocess.Popen(cmd_with_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                out, err = p.communicate(timeout=10)
+                return_code = p.returncode
+                if return_code == 0 and out:
+                    res = out.decode("utf-8")
+                    return json.loads(res)
+                else:
+                    error_msg = err.decode("utf-8") if err else "Unknown error"
+                    _logger.error(f"Service execution failed for {service_name}: {error_msg}.")
+                    return None
+            except subprocess.TimeoutExpired:
+                p.kill()
+                p.communicate()
+                _logger.error(f"Service execution timeout for {service_name}.")
+                return None
+            except json.JSONDecodeError as ex:
+                _logger.error(f"Invalid JSON response from service {service_name}: {ex}")
+                return None
+
+    # First check C service path
+    service_path = f"{_FLEDGE_ROOT}/services/fledge.services.{service_name}"
+    if os.path.exists(service_path):
+        try:
+            service_info = _get_service_info_from_path(service_path)
+            if service_info:
+                return service_info
+            else:
+                # File found but unable to get info - return early
+                _logger.error(f"C service {service_name} found but unable to retrieve service info.")
+                return _create_empty_service_response(service_name)
+        except Exception as ex:
+            _logger.error(f"Error executing service {service_name}: {ex}")
+            return _create_empty_service_response(service_name)
+
+    # Fallback to Python service path (only if C service not found)
+    python_service = f"{_FLEDGE_ROOT}/python/fledge/services/{service_name}/__main__.py"
+    if os.path.exists(python_service):
+        try:
+            service_info = _get_service_info_from_path(python_service, is_python=True)
+            if service_info:
+                return service_info
+            else:
+                # File found but unable to get info - return early
+                _logger.error(f"Python service {service_name} found but unable to retrieve service info.")
+                return _create_empty_service_response(service_name)
+        except Exception as ex:
+            _logger.error(f"Error loading Python service {service_name}: {ex}")
+            return _create_empty_service_response(service_name)
+
+    # Both paths failed - log once and return empty response
+    _logger.error(f"Service {service_name} not found in both ({service_path}) and ({python_service}) paths.")
+    return _create_empty_service_response(service_name)
+
+
 def get_service_installed() -> List:
     paths = [_FLEDGE_ROOT + "/services", _FLEDGE_ROOT + "/python/fledge/services/management"]
     services = []
@@ -89,6 +232,75 @@ def get_service_installed() -> List:
                 elif _file == '__main__.py':
                     services.append('management')
     return services
+
+
+async def get_service_info(request):
+    """
+    Get information about all the services by calling each service
+
+    Args:
+        request: HTTP request object
+
+    Returns:
+        JSON response with information about all services including their configuration
+
+    :Example:
+        curl -sX GET http://localhost:8081/fledge/service/info
+    """
+    try:
+        # Get list of installed services
+        installed_services = get_service_installed()
+        services = []
+        for service_name in installed_services:
+            # Check if it's a prebuilt service
+            if service_name in _PREBUILT_SERVICES:
+                services.append(_PREBUILT_SERVICES[service_name])
+                continue
+            service_info = await _fetch_service_info(service_name)
+            services.append(service_info)
+        response = {"services": services}
+        return web.json_response(response)
+    except Exception as ex:
+        msg = str(ex)
+        raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
+
+
+async def get_service_info_by_name(request):
+    """
+    Get information about a specific service by name
+
+    Args:
+        request: HTTP request object with service name in URL path
+
+    Returns:
+        JSON response with information about the specified service
+
+    :Example:
+        curl -sX GET http://localhost:8081/fledge/service/info/MyService
+    """
+    try:
+        service_name = request.match_info.get('service_name', None)
+        if service_name is None:
+            msg = f"Service name is required in the URL path."
+            raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+
+        # Get list of installed services to validate the service exists
+        installed_services = get_service_installed()
+        if service_name not in installed_services:
+            msg = f"Service '{service_name}' not found in installed services."
+            raise web.HTTPNotFound(reason=msg, body=json.dumps({"message": msg}))
+
+        # Check if it's a prebuilt service
+        if service_name in _PREBUILT_SERVICES:
+            service_info = _PREBUILT_SERVICES[service_name]
+        else:
+            # Try to get service info from C or Python service
+            service_info = await _fetch_service_info(service_name)
+        response = {'services': [service_info]}
+        return web.json_response(response)
+    except Exception as ex:
+        msg = str(ex)
+        raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
 
 
 async def get_health(request):

--- a/python/fledge/services/core/api/service.py
+++ b/python/fledge/services/core/api/service.py
@@ -54,6 +54,88 @@ _help = """
 """
 _logger = FLCoreLogger().get_logger(__name__)
 
+
+class ServiceInfoCache(object):
+    """Service Information Cache Manager"""
+
+    def __init__(self, size=20):
+        """
+        cache: value stored in dictionary as per service_name
+        max_cache_size: Hold the recently requested service info in the cache. Default cache size is 20
+        hit: number of times an item is read from the cache
+        miss: number of times an item was not found in the cache and a read of the service was required
+        """
+        self.cache = {}
+        self.max_cache_size = size
+        self.hit = 0
+        self.miss = 0
+
+    def __contains__(self, service_name):
+        """Returns True or False depending on whether or not the service is in the cache
+        and update the hit and date_accessed"""
+        if service_name in self.cache:
+            try:
+                current_hit = self.cache[service_name]['hit']
+            except KeyError:
+                current_hit = 0
+
+            self.hit += 1
+            self.cache[service_name].update({'date_accessed': datetime.datetime.now(), 'hit': current_hit + 1})
+            return True
+        self.miss += 1
+        return False
+
+    def update(self, service_name, service_info):
+        """Update the cache dictionary and remove the oldest item if needed"""
+        if service_name not in self.cache and len(self.cache) >= self.max_cache_size:
+            self.remove_oldest()
+        self.cache[service_name] = {
+            'date_accessed': datetime.datetime.now(),
+            'service_info': service_info,
+            'hit': 0
+        }
+        _logger.debug("Updated Service Info Cache for service: %s", service_name)
+
+    def remove_oldest(self):
+        """Remove the entry that has the oldest accessed date"""
+        oldest_entry = None
+        for service_name in self.cache:
+            if oldest_entry is None:
+                oldest_entry = service_name
+            elif (self.cache[service_name].get('date_accessed') and
+                  self.cache[oldest_entry].get('date_accessed') and
+                  self.cache[service_name]['date_accessed'] < self.cache[oldest_entry]['date_accessed']):
+                oldest_entry = service_name
+        if oldest_entry:
+            self.cache.pop(oldest_entry)
+
+    def get(self, service_name):
+        """Get service info from cache"""
+        if service_name in self:  # This will update hit count and date_accessed
+            return self.cache[service_name]['service_info']
+        return None
+
+    def remove(self, service_name):
+        """Remove the entry with given service name"""
+        if service_name in self.cache:
+            self.cache.pop(service_name)
+
+    def clear(self):
+        """Clear all cached service info"""
+        self.cache.clear()
+        self.hit = 0
+        self.miss = 0
+
+    @property
+    def size(self):
+        """Return the size of the cache"""
+        return len(self.cache)
+
+
+# service info cache instance
+_service_info_cache = ServiceInfoCache()
+
+# TODO: FOGL-1022 - This is a temporary solution to get the service info for the prebuilt services.
 # Prebuilt services configuration
 _PREBUILT_SERVICES = {
     "south": {
@@ -109,9 +191,12 @@ async def _fetch_service_info(service_name: str) -> dict:
     """
     Fetch service information by attempting multiple service discovery methods.
 
+    Implements caching for non-prebuilt services to improve performance.
+
     Tries to get service info in the following order:
-    1. C service executable with --info argument
-    2. Python service module executed with --info argument
+    1. Check cache for non-prebuilt services
+    2. C service executable with --info argument
+    3. Python service module executed with --info argument
 
     Args:
         service_name: Name of the service to fetch info for
@@ -119,6 +204,13 @@ async def _fetch_service_info(service_name: str) -> dict:
     Returns:
         Service info dictionary with service details, or empty response if all methods fail
     """
+    # Check cache first for non-prebuilt services
+    if service_name not in _PREBUILT_SERVICES:
+        cached_info = _service_info_cache.get(service_name)
+        if cached_info is not None:
+            _logger.debug(f"Retrieved service info for {service_name} from cache")
+            return cached_info
+
     def _create_empty_service_response(name: str) -> dict:
         return {
             "name": name,
@@ -199,6 +291,10 @@ async def _fetch_service_info(service_name: str) -> dict:
         try:
             service_info = _get_service_info_from_path(service_path, service_name=service_name)
             if service_info:
+                # Cache successful result for non-prebuilt services
+                if service_name not in _PREBUILT_SERVICES:
+                    _service_info_cache.update(service_name, service_info)
+                    _logger.debug(f"Cached service info for {service_name}")
                 return service_info
             else:
                 # File found but unable to get info - return early
@@ -214,6 +310,10 @@ async def _fetch_service_info(service_name: str) -> dict:
         try:
             service_info = _get_service_info_from_path(python_service_path, is_python=True, service_name=service_name)
             if service_info:
+                # Cache successful result for non-prebuilt services
+                if service_name not in _PREBUILT_SERVICES:
+                    _service_info_cache.update(service_name, service_info)
+                    _logger.debug(f"Cached service info for {service_name}")
                 return service_info
             else:
                 # File found but unable to get info - return early
@@ -830,6 +930,9 @@ async def get_installed(request: web.Request) -> web.Response:
         :Example:
             curl -X GET http://localhost:8081/fledge/service/installed
     """
+    # Clear service info cache when checking installed services
+    # to ensure cache stays synchronized with actual installed services
+    _service_info_cache.clear()
     services = get_service_installed()
     return web.json_response({"services": services})
 

--- a/python/fledge/services/core/api/service.py
+++ b/python/fledge/services/core/api/service.py
@@ -110,8 +110,8 @@ async def _fetch_service_info(service_name: str) -> dict:
     Fetch service information by attempting multiple service discovery methods.
 
     Tries to get service info in the following order:
-    1. C service executable with --info flag
-    2. Python service module with info() function
+    1. C service executable with --info argument
+    2. Python service module executed with --info argument
 
     Args:
         service_name: Name of the service to fetch info for
@@ -128,42 +128,50 @@ async def _fetch_service_info(service_name: str) -> dict:
             "process_script": ""
         }
 
-    def _get_service_info_from_path(service_path: str, is_python: bool = False) -> dict:
+    def _get_service_info_from_path(service_path: str, is_python: bool = False, service_name: str = None) -> dict:
         """
         Get service information from the specified path.
 
         Args:
-            service_path: Path to the service (executable or Python __main__.py)
+            service_path: Path to the service (executable or Python service package)
             is_python: True if this is a Python service, False for C service
+            service_name: Name of the service (required for Python services, optional for C services)
 
         Returns:
             Service information dictionary or None if failed
         """
         if is_python:
-            # For Python services, import the module and call info() function directly
+            import sys
+            # service_name is required for Python services
+            if service_name is None:
+                _logger.error("service_name is required for Python services")
+                return None
+            # Execute Python service with --info argument
+            cmd_with_args = [sys.executable, "-m", f"fledge.services.{service_name}", "--info"]
             try:
-                import importlib.util
-
-                # Load the Python module from the __main__.py file
-                spec = importlib.util.spec_from_file_location("service_module", service_path)
-                if spec is None or spec.loader is None:
-                    _logger.error(f"Could not load service module from path: {service_path}.")
-                    return None
-
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-
-                # Call the info() function if it exists
-                if hasattr(module, 'info') and callable(getattr(module, 'info')):
-                    return module.info()
+                p = subprocess.Popen(cmd_with_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                out, err = p.communicate(timeout=10)
+                return_code = p.returncode
+                if return_code == 0 and out:
+                    res = out.decode("utf-8")
+                    return json.loads(res)
                 else:
-                    _logger.error(f"Service module {service_name} does not have info() function.")
+                    error_msg = err.decode("utf-8") if err else "Unknown error"
+                    _logger.error(f"Python service execution failed for {service_name}: {error_msg}")
                     return None
+            except subprocess.TimeoutExpired:
+                p.kill()
+                p.communicate()
+                _logger.error(f"Python service execution timeout for {service_name}")
+                return None
+            except json.JSONDecodeError as ex:
+                _logger.error(f"Invalid JSON response from Python service {service_name}: {ex}")
+                return None
             except Exception as ex:
-                _logger.error(f"Error loading service module {service_name}: {ex}")
+                _logger.error(f"Error executing Python service {service_name}: {ex}")
                 return None
         else:
-            # For C services, execute with --info flag
+            # For C services, execute with --info argument
             cmd_with_args = [service_path, "--info"]
             try:
                 p = subprocess.Popen(cmd_with_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -189,7 +197,7 @@ async def _fetch_service_info(service_name: str) -> dict:
     service_path = f"{_FLEDGE_ROOT}/services/fledge.services.{service_name}"
     if os.path.exists(service_path):
         try:
-            service_info = _get_service_info_from_path(service_path)
+            service_info = _get_service_info_from_path(service_path, service_name=service_name)
             if service_info:
                 return service_info
             else:
@@ -201,10 +209,10 @@ async def _fetch_service_info(service_name: str) -> dict:
             return _create_empty_service_response(service_name)
 
     # Fallback to Python service path (only if C service not found)
-    python_service = f"{_FLEDGE_ROOT}/python/fledge/services/{service_name}/__main__.py"
-    if os.path.exists(python_service):
+    python_service_path = f"{_FLEDGE_ROOT}/python/fledge/services/{service_name}"
+    if os.path.exists(python_service_path):
         try:
-            service_info = _get_service_info_from_path(python_service, is_python=True)
+            service_info = _get_service_info_from_path(python_service_path, is_python=True, service_name=service_name)
             if service_info:
                 return service_info
             else:
@@ -216,7 +224,7 @@ async def _fetch_service_info(service_name: str) -> dict:
             return _create_empty_service_response(service_name)
 
     # Both paths failed - log once and return empty response
-    _logger.error(f"Service {service_name} not found in both ({service_path}) and ({python_service}) paths.")
+    _logger.error(f"Service {service_name} not found in both ({service_path}) and ({python_service_path}) paths.")
     return _create_empty_service_response(service_name)
 
 
@@ -296,8 +304,7 @@ async def get_service_info_by_name(request):
         else:
             # Try to get service info from C or Python service
             service_info = await _fetch_service_info(service_name)
-        response = {'services': [service_info]}
-        return web.json_response(response)
+        return web.json_response(service_info)
     except Exception as ex:
         msg = str(ex)
         raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))

--- a/python/fledge/services/core/routes.py
+++ b/python/fledge/services/core/routes.py
@@ -110,6 +110,8 @@ def setup(app):
     app.router.add_route('DELETE', '/fledge/service/{service_name}', service.delete_service)
     app.router.add_route('GET', '/fledge/service/available', service.get_available)
     app.router.add_route('GET', '/fledge/service/installed', service.get_installed)
+    app.router.add_route('GET', '/fledge/service/info', service.get_service_info)
+    app.router.add_route('GET', '/fledge/service/info/{service_name}', service.get_service_info_by_name)
     app.router.add_route('PUT', '/fledge/service/{type}/{name}/update', service.update_service)
     app.router.add_route('POST', '/fledge/service/{service_name}/otp', service.issueOTPToken)
 


### PR DESCRIPTION
1. Get all services info
```
$ curl -sX GET localhost:8081/fledge/service/info | jq
{
  "services": [
    {
      "name": "storage",
      "description": "The storage service buffers data within a single Fledge instance",
      "type": "storage",
      "process": "storage",
      "process_script": "storage"
    },
    {
      "name": "Notification Service",
      "description": "Fledge Notification Service to send notifications",
      "package": "fledge-service-notification",
      "type": "notification",
      "process_name": "notification_c",
      "process_script": "services/notification_c"
    },
    {
      "name": "dispatcher",
      "description": "",
      "type": "",
      "process": "",
      "process_script": ""
    },
    {
      "name": "south",
      "description": "Service used to interact with device, API and generic sources of data",
      "type": "south",
      "process": "south",
      "process_script": "south_c"
    },
    {
      "name": "north",
      "description": "Service used to interact with device, API and generic sources of data",
      "type": "north",
      "process": "north",
      "process_script": "north_C"
    }
  ]
}
```

**Note**: 
a) notification service with `--info parameter` to fetch service information.
b) the dispatcher service is installed and record contains only empty values, as there is currently no `--info` entry point available for the service. Therefore, this demonstration is to show empty values for a service which have info is missing.
c) The services for south, north, and storage are prebuilt, thus providing a hardwired API response. It is unclear whether this information is also derived from the --info command, which posed a similar query in the documentation itself.
d) process_script is also unclear whether it with process name or with path like
`["services/south_c"], ["services/notification_c"], ["services/north_C"]`

2. Get service info by name
```
$ curl -sX GET localhost:8081/fledge/service/info/notification | jq
{
  "name": "Notification Service",
  "description": "Fledge Notification Service to send notifications",
  "package": "fledge-service-notification",
  "type": "notification",
  "process_name": "notification_c",
  "process_script": "services/notification_c"
}


```