### PR TITLE
FOGL-10108 Service login API core management route

### DIFF
--- a/python/fledge/services/common/microservice_management/routes.py
+++ b/python/fledge/services/common/microservice_management/routes.py
@@ -45,7 +45,7 @@ def setup(app, obj, is_core=False):
         app.router.add_route('DELETE', '/fledge/service/{service_id}', obj.unregister)
         app.router.add_route('PUT', '/fledge/service/{service_id}/restart', obj.restart_service)
         app.router.add_route('GET', '/fledge/service', obj.get_service)
-        app.router.add_route('GET', '/fledge/service/authtoken', obj.get_auth_token)
+        app.router.add_route('POST', '/fledge/service/login', obj.service_login)
 
         # Interest Registration
         app.router.add_route('POST', '/fledge/interest', obj.register_interest)

--- a/python/fledge/services/core/server.py
+++ b/python/fledge/services/core/server.py
@@ -1640,94 +1640,106 @@ class Server:
         return web.json_response({"services": services})
 
     @classmethod
-    async def get_auth_token(cls, request: web.Request) -> web.Response:
-        """ get auth token
+    async def service_login(cls, request: web.Request) -> web.Response:
+        """ service login
             :Example:
-                curl -sX GET -H "{'Authorization': 'Bearer ..'}" http://localhost:<core mgt port>/fledge/service/authtoken
+                curl -sX POST -H "{'Authorization': 'Bearer ..'}" -d '{"username": "Manager"}' http://localhost:<core mgt port>/fledge/service/login
         """
-        async def cert_login(ca_cert):
-            certs_dir = _FLEDGE_DATA + '/etc/certs' if _FLEDGE_DATA else _FLEDGE_ROOT + "/data/etc/certs"
-            ca_cert_file = "{}/{}.cert".format(certs_dir, ca_cert)
-            SSLVerifier.set_ca_cert(ca_cert_file)
-            # FIXME: allow to supply content and any cert name as placed with configured CA sign
-            with open('{}/{}'.format(certs_dir, "admin.cert"), 'r') as content_file:
-                cert_content = content_file.read()
-            SSLVerifier.set_user_cert(cert_content)
-            SSLVerifier.verify()
-            username = SSLVerifier.get_subject()['commonName']
-            _uid, _token, _is_admin = await User.Objects.certificate_login(username, host)
-            return _token
-
         try:
-            cfg_mgr = ConfigurationManager(cls._storage_client_async)
-            category_info = await cfg_mgr.get_category_all_items('rest_api')
-            is_auth_optional = True if category_info['authentication']['value'].lower() == 'optional' else False
-
-            if is_auth_optional:
-                raise api_exception.AuthenticationIsOptional
-
-            auth_method = category_info['authMethod']['value']
-            ca_cert_name = category_info['authCertificateName']['value']
-
             try:
-                auth_header = request.headers.get('Authorization', None)
-            except:
-                raise api_exception.VerificationFailed
-            else:
-                if auth_header is None:
-                    raise api_exception.VerificationFailed
-                if not "Bearer " in auth_header:
-                    raise api_exception.VerificationFailed
-                # check bearer token with service registry for given service
-                ##
-                # the lines below are repated many times, make it a def for common usage/check
-                parts = auth_header.split("Bearer ")
-                if len(parts) != 2:
-                    msg = "Bearer token is missing"
+                data = await request.json()
+                if not isinstance(data, dict):
+                    msg = 'Request body must be a valid JSON object.'
                     raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
-                bearer_token = parts[1]
-                # Validate token and get public claims
-                claims = cls.validate_token(bearer_token)
-                if claims.get('error'):
-                    msg = "Service '" + str(claims['sub']) + "' not registered"
-                    raise web.HTTPNotFound(reason=msg, body=json.dumps({"message": msg}))
+            except Exception:
+                msg = 'Request body must be valid JSON. Please provide a JSON object with username field.'
+                raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
 
-                if bearer_token != ServiceRegistry.getBearerToken(claims['sub']):
-                    # add WARN log (audit?) for this attempt?!
-                    raise api_exception.VerificationFailed
-                else:
-                    # add debug log for successful token verification
-                    pass
-                ##
+            username = data.get('username', None)
+
+            # Check if username is empty or whitespace
+            if not username or not username.strip():
+                msg = 'Username is required and cannot be empty.'
+                raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+            username = username.strip()
+            user_data = None
+            users = await User.Objects.all()
+            for user in users:
+                if user['uname'] == username and user['enabled'] == 't':
+                    if user['role_id'] in [3, 4]:
+                        msg = "User is not authorized to access the service."
+                        raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
+                    user_data = user
+                    break
+
+            if user_data is None:
+                msg = f"Username '{username}' does not exist."
+                raise web.HTTPNotFound(reason=msg, body=json.dumps({"message": msg}))
+
+            auth_header = request.headers.get('Authorization', None)
+            if auth_header is None:
+                msg = "Authorization header is missing."
+                raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
+
+            if "Bearer " not in auth_header:
+                msg = "Invalid Authorization token format."
+                raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
+
+            parts = auth_header.split("Bearer ")
+            if len(parts) != 2:
+                msg = "Bearer token is missing."
+                raise web.HTTPForbidden(reason=msg, body=json.dumps({"message": msg}))
+
+            bearer_token = parts[1]
+
+            claims = cls.validate_token(bearer_token)
+            if claims.get('error'):
+                msg = f"Service '{claims['sub']}' not registered"
+                raise web.HTTPNotFound(reason=msg, body=json.dumps({"message": msg}))
+
+            if bearer_token != ServiceRegistry.getBearerToken(claims['sub']):
+                msg = "Invalid bearer token."
+                raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
 
             peername = request.transport.get_extra_info('peername')
             host = '0.0.0.0'
             if peername is not None:
                 host, _ = peername
 
-            # TODO: restrict host to 0.0.0.0, 127.0.0.1 or localhost?
-
-            if auth_method == 'certificate':
-                token = await cert_login(ca_cert_name)
-            elif auth_method == 'password':
-                # Super admin user always exists on the system
-                # these can be configured diff for a/per services if required
-                payload = payload_builder.PayloadBuilder().SELECT("uname", "pwd").WHERE(['id', '=', 1]).payload()
-                result = await cls._storage_client_async.query_tbl_with_payload('users', payload)
-                uid, token, is_admin = await User.Objects.login("admin", result['rows'][0]['pwd'], host)
+            # Check user's access method and use appropriate login
+            access_method = user_data.get('access_method', 'any')
+            # Delete all user tokens
+            await User.Objects.delete_user_tokens(user_data['id'])
+            if access_method == 'cert':
+                # Use certificate login for users with cert access method
+                try:
+                    uid, token, is_admin = await User.Objects.certificate_login(user_data['uname'], host)
+                except Exception as ex:
+                    msg = f"Certificate login failed: {str(ex)}."
+                    raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
             else:
-                # For auth method "any" we can use either login with cert or password
-                token = await cert_login(ca_cert_name)
-                # TODO: if cert does not exist then may try with password
-        except api_exception.AuthenticationIsOptional as err:
-            msg = str(err)
-            raise web.HTTPPreconditionFailed(reason=msg, body=json.dumps({"message": msg}))
-        except api_exception.VerificationFailed:
-            raise web.HTTPUnauthorized(body=json.dumps({"message": 'Required authorization token is missing or invalid.'}))
+                # Use password login for other access methods (password, any)
+                try:
+                    uid, token, is_admin = await User.Objects.login(user_data['uname'], user_data['pwd'], host)
+                except User.PasswordNotSetError:
+                    msg = "Password is not set for this user."
+                    raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+                except Exception as ex:
+                    msg = f"Login failed: {str(ex)}"
+                    raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
+            return web.json_response(
+                {"token": token, "uid": uid, "admin": is_admin, 
+                "message": f"Logged in successfully for user '{user_data['uname']}'."})
+        except web.HTTPException:
+            # Re-raise HTTP exceptions as-is
+            raise
+        except ValueError as ex:
+            msg = f"Value error: {str(ex)}."
+            raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
         except Exception as ex:
-            msg = str(ex)
+            msg = f"Failed to process service login: {str(ex)}."
+            _logger.error(msg)
             raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
-        return web.json_response({"token": token})
 
     @classmethod
     async def shutdown(cls, request):

--- a/python/fledge/services/core/server.py
+++ b/python/fledge/services/core/server.py
@@ -15,6 +15,7 @@ import sys
 import ssl
 import time
 import uuid
+import hmac
 from aiohttp import web
 import aiohttp
 import json
@@ -1641,104 +1642,184 @@ class Server:
 
     @classmethod
     async def service_login(cls, request: web.Request) -> web.Response:
-        """ service login
-            :Example:
-                curl -sX POST -H "{'Authorization': 'Bearer ..'}" -d '{"username": "Manager"}' http://localhost:<core mgt port>/fledge/service/login
+        """Service login endpoint for authenticated services to obtain user tokens.
+
+        Allows registered services to authenticate users using bearer tokens.
+        The service must be registered and provide a valid bearer token.
+
+        Args:
+            request: HTTP request containing JSON body with username and Authorization header
+
+        Returns:
+            web.Response: JSON response with user token, uid, admin status, and success message
+
+        Raises:
+            web.HTTPBadRequest: Invalid JSON, missing username, or validation errors
+            web.HTTPUnauthorized: Invalid bearer token or authentication failures
+            web.HTTPForbidden: User not authorized for service access
+            web.HTTPNotFound: User or service not found
+            web.HTTPInternalServerError: Unexpected server errors
+
+        Example:
+            curl -sX POST -H "{'Authorization': 'Bearer ..'}" -d '{"username": "Manager"}' \\
+                http://localhost:<core mgt port>/fledge/service/login
         """
+        peername = None
+        client_host = '0.0.0.0'
         try:
+            # extraction of client info for logging purposes
+            peername = request.transport.get_extra_info('peername')
+            if peername is not None:
+                client_host, _ = peername
             try:
                 data = await request.json()
                 if not isinstance(data, dict):
                     msg = 'Request body must be a valid JSON object.'
                     raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
-            except Exception:
+            except json.JSONDecodeError as ex:
                 msg = 'Request body must be valid JSON. Please provide a JSON object with username field.'
                 raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
-
-            username = data.get('username', None)
-
-            # Check if username is empty or whitespace
-            if not username or not username.strip():
-                msg = 'Username is required and cannot be empty.'
+            except Exception as ex:
+                msg = 'Failed to parse request body. Please provide a valid JSON object with username field.'
                 raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+
+            # username validation
+            username = data.get('username', None)
+            if username is None:
+                msg = 'Username field is required in request body.'
+                raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+
+            if not isinstance(username, str):
+                msg = 'Username must be a string.'
+                raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+
+            if not username.strip():
+                msg = 'Username cannot be empty or contain only whitespace.'
+                raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+
             username = username.strip()
-            user_data = None
-            users = await User.Objects.all()
-            for user in users:
-                if user['uname'] == username and user['enabled'] == 't':
-                    if user['role_id'] in [3, 4]:
-                        msg = "User is not authorized to access the service."
-                        raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
-                    user_data = user
-                    break
+            if len(username) < 1:
+                msg = 'Username must be at least 1 character long.'
+                raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
 
-            if user_data is None:
-                msg = f"Username '{username}' does not exist."
-                raise web.HTTPNotFound(reason=msg, body=json.dumps({"message": msg}))
-
+            # bearer token validation
             auth_header = request.headers.get('Authorization', None)
             if auth_header is None:
                 msg = "Authorization header is missing."
                 raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
-
-            if "Bearer " not in auth_header:
-                msg = "Invalid Authorization token format."
+            if not isinstance(auth_header, str):
+                msg = "Authorization header must be a string."
+                raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
+            auth_header = auth_header.strip()
+            if not auth_header.startswith("Bearer "):
+                msg = "Authorization header must start with 'Bearer ' followed by a token."
                 raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
 
-            parts = auth_header.split("Bearer ")
-            if len(parts) != 2:
-                msg = "Bearer token is missing."
-                raise web.HTTPForbidden(reason=msg, body=json.dumps({"message": msg}))
+            bearer_token = auth_header[7:]
+            if not bearer_token:
+                msg = "Bearer token cannot be empty."
+                raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
 
-            bearer_token = parts[1]
+            # Token length validation (JWT tokens have reasonable length bounds)
+            if len(bearer_token) > 2048:
+                msg = "Bearer token exceeds maximum length."
+                raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
 
+            # Validate bearer token format and claims
             claims = cls.validate_token(bearer_token)
             if claims.get('error'):
-                msg = f"Service '{claims['sub']}' not registered"
-                raise web.HTTPNotFound(reason=msg, body=json.dumps({"message": msg}))
-
-            if bearer_token != ServiceRegistry.getBearerToken(claims['sub']):
-                msg = "Invalid bearer token."
+                error_detail = claims.get('error', 'Unknown token validation error')
+                if 'expired' in error_detail.lower():
+                    msg = "Bearer token has expired."
+                elif 'signature' in error_detail.lower():
+                    msg = "Bearer token signature is invalid."
+                else:
+                    msg = "Bearer token is invalid or malformed."
                 raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
 
-            peername = request.transport.get_extra_info('peername')
-            host = '0.0.0.0'
-            if peername is not None:
-                host, _ = peername
+            # Verify required claims
+            service_name = claims.get('sub')
+            if not service_name:
+                msg = "Bearer token missing service name claim."
+                raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
 
-            # Check user's access method and use appropriate login
+            # Verify service is registered and token matches
+            registered_token = ServiceRegistry.getBearerToken(service_name)
+            if registered_token is None:
+                msg = f"Service '{service_name}' is not registered."
+                raise web.HTTPNotFound(reason=msg, body=json.dumps({"message": msg}))
+            if not hmac.compare_digest(bearer_token, registered_token):
+                msg = "Bearer token does not match registered service token."
+                raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
+
+            # User lookup
+            user_data = None
+            users = await User.Objects.all()
+            for user in users:
+                if user.get('uname') and hmac.compare_digest(user['uname'], username):
+                    if user.get('enabled') == 't':
+                        # Check role authorization
+                        role_id = user.get('role_id')
+                        if role_id in [3, 4]:  # Viewer and Data View roles
+                            msg = "User is not authorized to access services."
+                            raise web.HTTPForbidden(reason=msg, body=json.dumps({"message": msg}))
+                        user_data = user
+                        break
+
+            if user_data is None:
+                # Don't reveal whether user exists or is disabled for security
+                msg = "Authentication failed. User not found or not enabled."
+                raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
+
+            # Clean up existing user tokens before creating new one
+            try:
+                await User.Objects.delete_user_tokens(user_data['id'])
+            except Exception as ex:
+                # Continue with login attempt as this is not critical
+                _logger.warning(f"Failed to delete existing tokens for user '{username}': {str(ex)}")
+
+            # Handle different authentication methods
             access_method = user_data.get('access_method', 'any')
-            # Delete all user tokens
-            await User.Objects.delete_user_tokens(user_data['id'])
-            if access_method == 'cert':
-                # Use certificate login for users with cert access method
-                try:
-                    uid, token, is_admin = await User.Objects.certificate_login(user_data['uname'], host)
-                except Exception as ex:
-                    msg = f"Certificate login failed: {str(ex)}."
-                    raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
-            else:
-                # Use password login for other access methods (password, any)
-                try:
-                    uid, token, is_admin = await User.Objects.login(user_data['uname'], user_data['pwd'], host)
-                except User.PasswordNotSetError:
-                    msg = "Password is not set for this user."
-                    raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
-                except Exception as ex:
-                    msg = f"Login failed: {str(ex)}"
-                    raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
-            return web.json_response(
-                {"token": token, "uid": uid, "admin": is_admin, 
-                "message": f"Logged in successfully for user '{user_data['uname']}'."})
+            try:
+                if access_method == 'cert':
+                    # Use certificate-based login
+                    uid, token, is_admin = await User.Objects.certificate_login(user_data['uname'], client_host)
+                    _logger.info(f"Successful certificate login for user '{username}' via service '{service_name}' from {client_host}")
+                else:
+                    # Use password-based login (covers 'password' and 'any' methods)
+                    password = user_data.get('pwd')
+                    if not password:
+                        msg = "User password is not configured."
+                        raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+                    uid, token, is_admin = await User.Objects.login(user_data['uname'], password, client_host)
+                    _logger.info(f"Successful password login for user '{username}' via service '{service_name}' from {client_host}")
+            except User.PasswordNotSetError:
+                msg = "Password is not set for this user."
+                raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
+            except User.DoesNotExist:
+                msg = "User authentication failed."
+                raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
+            except Exception as ex:
+                msg = f"Authentication failed: {str(ex)}"
+                raise web.HTTPUnauthorized(reason=msg, body=json.dumps({"message": msg}))
+
+            # Return successful login response
+            response_data = {
+                "token": token,
+                "uid": uid,
+                "admin": is_admin,
+                "message": f"User '{user_data['uname']}' logged in successfully via service."
+            }
+            return web.json_response(response_data)
         except web.HTTPException:
             # Re-raise HTTP exceptions as-is
             raise
         except ValueError as ex:
-            msg = f"Value error: {str(ex)}."
+            msg = f"Value error: {str(ex)}"
             raise web.HTTPBadRequest(reason=msg, body=json.dumps({"message": msg}))
         except Exception as ex:
-            msg = f"Failed to process service login: {str(ex)}."
-            _logger.error(msg)
+            msg = f"Internal server error during service login: {str(ex)}"
+            _logger.error(f"Service login internal error from {client_host}: {str(ex)}")
             raise web.HTTPInternalServerError(reason=msg, body=json.dumps({"message": msg}))
 
     @classmethod

--- a/tests/unit/python/fledge/services/core/test_server.py
+++ b/tests/unit/python/fledge/services/core/test_server.py
@@ -30,6 +30,7 @@ from fledge.services.core.api import configuration as conf_api
 from fledge.common.storage_client.storage_client import StorageClientAsync
 from fledge.common.configuration_manager import ConfigurationManager
 from fledge.common.audit_logger import AuditLogger
+from fledge.services.core.user_model import User
 
 
 __author__ = "Vaibhav Singhal, Ashish Jabble"
@@ -702,6 +703,337 @@ class TestServer:
         assert 'Stopping the Fledge Core event loop. Good Bye!' == args[0]
         assert 'message' in json_response
         assert 'Fledge stopped successfully. Wait for few seconds for process cleanup.' == json_response["message"]
+
+    ######################
+    # Service Login Tests
+    ######################
+
+    @pytest.mark.parametrize("data, expected_status, expected_message", [
+        (None, 400, "valid JSON"),
+        ("not a dict", 400, "valid JSON object"),
+        ({}, 400, "Username field is required"),
+        ({"username": 123}, 400, "Username must be a string"),
+        ({"username": "  "}, 400, "cannot be empty or contain only whitespace"),
+        ({"username": ""}, 400, "cannot be empty")
+    ])
+    async def test_service_login_input_validation(self, client, data, expected_status, expected_message):
+        resp = await client.post('/fledge/service/login', data=json.dumps(data))
+        assert expected_status == resp.status
+        assert expected_message in resp.reason
+        r = await resp.text()
+        json_response = json.loads(r)
+        assert 'message' in json_response
+        assert expected_message in json_response['message']
+
+    @pytest.mark.parametrize("headers, expected_status, expected_message", [
+        ({}, 401, "Authorization header is missing"),
+        ({"Authorization": "InvalidFormat token"}, 401, "must start with 'Bearer '"),
+        ({"Authorization": "Bearer "}, 401, "Authorization header must start with 'Bearer ' followed by a token"),
+        ({"Authorization": f"Bearer {'x' * 2049}"}, 401, "exceeds maximum length")
+    ])
+    async def test_service_login_bearer_token_validation(self, client, headers, expected_status, expected_message):
+        data = {"username": "testuser"}
+        resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+        assert expected_status == resp.status
+        assert expected_message in resp.reason
+        r = await resp.text()
+        json_response = json.loads(r)
+        assert 'message' in json_response
+        assert expected_message in json_response['message']
+
+    @pytest.mark.parametrize("token_error, expected_message", [
+        ("Invalid token", "Bearer token is invalid"),
+        ("Token has expired", "Bearer token has expired"),
+        ("Signature verification failed", "Bearer token signature is invalid")
+    ])
+    async def test_service_login_jwt_validation_errors(self, client, token_error, expected_message):
+        data = {"username": "testuser"}
+        headers = {"Authorization": "Bearer invalid.jwt.token"}
+        with patch.object(Server, 'validate_token', return_value={'error': token_error}) as mock_validate_token:
+            resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+            assert 401 == resp.status
+            assert expected_message in resp.reason
+            r = await resp.text()
+            json_response = json.loads(r)
+            assert 'message' in json_response
+            assert expected_message in json_response['message']
+        mock_validate_token.assert_called_once_with('invalid.jwt.token')
+
+    async def test_service_login_missing_sub_claim(self, client):
+        data = {"username": "testuser"}
+        headers = {"Authorization": "Bearer valid.jwt.token"}
+        with patch.object(Server, 'validate_token', return_value={}) as mock_validate_token:
+            resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+            assert 401 == resp.status
+            assert "missing service name claim" in resp.reason
+            r = await resp.text()
+            json_response = json.loads(r)
+            assert 'message' in json_response
+            assert "missing service name claim" in json_response['message']
+        mock_validate_token.assert_called_once_with('valid.jwt.token')
+
+    async def test_service_login_unregistered_service(self, client):
+        data = {"username": "testuser"}
+        headers = {"Authorization": "Bearer valid.jwt.token"}
+        with patch.object(Server, 'validate_token', return_value={'sub': 'unregistered-service'}) as mock_validate_token:
+            with patch.object(ServiceRegistry, 'getBearerToken', return_value=None) as mock_get_bearer_token:
+                resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+                assert 404 == resp.status
+                assert "is not registered" in resp.reason
+                r = await resp.text()
+                json_response = json.loads(r)
+                assert 'message' in json_response
+                assert "is not registered" in json_response['message']
+            mock_get_bearer_token.assert_called_once_with('unregistered-service')
+        mock_validate_token.assert_called_once_with('valid.jwt.token')
+
+    async def test_service_login_mismatched_bearer_token(self, client):
+        bearer_token = "valid.jwt.token"
+        data = {"username": "testuser"}
+        headers = {"Authorization": f"Bearer {bearer_token}"}
+        with patch.object(Server, 'validate_token', return_value={'sub': 'test-service'}) as mock_validate_token:
+            with patch.object(ServiceRegistry, 'getBearerToken', return_value='different-token') as mock_get_bearer_token:
+                resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+                assert 401 == resp.status
+                assert "does not match registered" in resp.reason
+                r = await resp.text()
+                json_response = json.loads(r)
+                assert 'message' in json_response
+                assert "does not match registered" in json_response['message']
+            mock_get_bearer_token.assert_called_once_with('test-service')
+        mock_validate_token.assert_called_once_with(bearer_token)
+
+    @pytest.mark.parametrize("user_data, expected_status, expected_message", [
+        ([], 401, "User not found or not enabled"),  # No users
+        ([{'id': 1, 'uname': 'testuser', 'enabled': 'f', 'role_id': 1}], 401, "User not found or not enabled"),
+        ([{'id': 1, 'uname': 'testuser', 'enabled': 't', 'role_id': 3}], 403, "not authorized to access services"),
+        ([{'id': 1, 'uname': 'testuser', 'enabled': 't', 'role_id': 4}], 403, "not authorized to access services")
+    ])
+    async def test_service_login_user_authorization(self, client, user_data, expected_status, expected_message):
+        bearer_token = "valid.jwt.token"
+        data = {"username": "testuser"}
+        headers = {"Authorization": f"Bearer {bearer_token}"}
+        with patch.object(Server, 'validate_token', return_value={'sub': 'test-service'}) as mock_validate_token:
+            with patch.object(ServiceRegistry, 'getBearerToken', return_value=bearer_token) as mock_get_bearer_token:
+                with patch.object(User.Objects, 'all', return_value=user_data) as mock_user_all:
+                    resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+                    assert expected_status == resp.status
+                    assert expected_message in resp.reason
+                    r = await resp.text()
+                    json_response = json.loads(r)
+                    assert 'message' in json_response
+                    assert expected_message in json_response['message']
+                mock_user_all.assert_called_once_with()
+            mock_get_bearer_token.assert_called_once_with('test-service')
+        mock_validate_token.assert_called_once_with(bearer_token)
+
+    async def test_service_login_missing_password(self, client):
+        bearer_token = "valid.jwt.token"
+        user_data = [{'id': 1, 'uname': 'testuser', 'enabled': 't', 'role_id': 1, 'access_method': 'any'}]
+        data = {"username": "testuser"}
+        headers = {"Authorization": f"Bearer {bearer_token}"}
+        with patch.object(Server, 'validate_token', return_value={'sub': 'test-service'}) as mock_validate_token:
+            with patch.object(ServiceRegistry, 'getBearerToken', return_value=bearer_token) as mock_get_bearer_token:
+                with patch.object(User.Objects, 'all', return_value=user_data) as mock_user_all:
+                    with patch.object(User.Objects, 'delete_user_tokens', return_value=None) as mock_delete_tokens:
+                        resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+                        assert 401 == resp.status
+                        assert "password is not configured" in resp.reason
+                        r = await resp.text()
+                        json_response = json.loads(r)
+                        assert 'message' in json_response
+                        assert "password is not configured" in json_response['message']
+                    mock_delete_tokens.assert_called_once_with(1)
+                mock_user_all.assert_called_once_with()
+            mock_get_bearer_token.assert_called_once_with('test-service')
+        mock_validate_token.assert_called_once_with(bearer_token)
+
+    @pytest.mark.parametrize("access_method, login_method, login_args", [
+        ('cert', 'certificate_login', ('testuser', '127.0.0.1')),
+        ('any', 'login', ('testuser', 'hashedpassword', '127.0.0.1')),
+        ('password', 'login', ('testuser', 'hashedpassword', '127.0.0.1'))
+    ])
+    async def test_service_login_authentication_success(self, client, access_method, login_method, login_args):
+        bearer_token = "valid.jwt.token"
+        user_data = [{
+            'id': 1, 'uname': 'testuser', 'enabled': 't', 'role_id': 1,
+            'access_method': access_method, 'pwd': 'hashedpassword'
+        }]
+        data = {"username": "testuser"}
+        headers = {"Authorization": f"Bearer {bearer_token}"}
+        with patch.object(server._logger, 'info') as mock_logger_info:
+            with patch.object(Server, 'validate_token', return_value={'sub': 'test-service'}) as mock_validate_token:
+                with patch.object(ServiceRegistry, 'getBearerToken', return_value=bearer_token) as mock_get_bearer_token:
+                    with patch.object(User.Objects, 'all', return_value=user_data) as mock_user_all:
+                        with patch.object(User.Objects, 'delete_user_tokens', return_value=None) as mock_delete_tokens:
+                            with patch.object(User.Objects, login_method, return_value=(1, 'mock-token', True)) as mock_login:
+                                resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+                                assert 200 == resp.status
+                                r = await resp.text()
+                                response_data = json.loads(r)
+                                assert response_data['token'] == 'mock-token'
+                                assert response_data['uid'] == 1
+                                assert response_data['admin'] is True
+                                assert "logged in successfully" in response_data['message']
+                            mock_login.assert_called_once_with(*login_args)
+                        mock_delete_tokens.assert_called_once_with(1)
+                    mock_user_all.assert_called_once_with()
+                mock_get_bearer_token.assert_called_once_with('test-service')
+            mock_validate_token.assert_called_once_with(bearer_token)
+        mock_logger_info.assert_called_once()
+        info_call_args = mock_logger_info.call_args[0]
+        expected_method = 'certificate' if access_method == 'cert' else 'password'
+        assert f"Successful {expected_method} login for user 'testuser' via service 'test-service'" in info_call_args[0]
+
+    @pytest.mark.parametrize("exception_type, expected_status, expected_message", [
+        (User.PasswordNotSetError, 400, "Password is not set"),
+        (User.DoesNotExist, 401, "User authentication failed"),
+        (Exception("Authentication failed"), 401, "Authentication failed"),
+    ])
+    async def test_service_login_authentication_errors(self, client, exception_type, expected_status, expected_message):
+        bearer_token = "valid.jwt.token"
+        user_data = [{'id': 1, 'uname': 'testuser', 'enabled': 't', 'role_id': 1, 'access_method': 'any', 'pwd': 'hashedpassword'}]
+        data = {"username": "testuser"}
+        headers = {"Authorization": f"Bearer {bearer_token}"}
+        with patch.object(Server, 'validate_token', return_value={'sub': 'test-service'}) as mock_validate_token:
+            with patch.object(ServiceRegistry, 'getBearerToken', return_value=bearer_token) as mock_get_bearer_token:
+                with patch.object(User.Objects, 'all', return_value=user_data) as mock_user_all:
+                    with patch.object(User.Objects, 'delete_user_tokens', return_value=None) as mock_delete_tokens:
+                        with patch.object(User.Objects, 'login', side_effect=exception_type) as mock_login:
+                            resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+                            assert expected_status == resp.status
+                            assert expected_message in resp.reason
+                            r = await resp.text()
+                            json_response = json.loads(r)
+                            assert 'message' in json_response
+                            assert expected_message in json_response['message']
+                        mock_login.assert_called_once_with('testuser', 'hashedpassword', '127.0.0.1') 
+                    mock_delete_tokens.assert_called_once_with(1)
+                mock_user_all.assert_called_once_with()
+            mock_get_bearer_token.assert_called_once_with('test-service')
+        mock_validate_token.assert_called_once_with(bearer_token)
+
+    async def test_service_login_token_cleanup_failure_continues(self, client):
+        bearer_token = "valid.jwt.token"
+        user_data = [{'id': 1, 'uname': 'testuser', 'enabled': 't', 'role_id': 1, 'access_method': 'any', 'pwd': 'hashedpassword'}]
+        data = {"username": "testuser"}
+        headers = {"Authorization": f"Bearer {bearer_token}"}
+        with patch.object(server._logger, 'warning') as mock_logger_warning:
+            with patch.object(server._logger, 'info') as mock_logger_info:
+                with patch.object(Server, 'validate_token', return_value={'sub': 'test-service'}) as mock_validate_token:
+                    with patch.object(ServiceRegistry, 'getBearerToken', return_value=bearer_token) as mock_get_bearer_token:
+                        with patch.object(User.Objects, 'all', return_value=user_data) as mock_user_all:
+                            with patch.object(User.Objects, 'delete_user_tokens', side_effect=Exception("Cleanup failed")) as mock_delete_tokens:
+                                with patch.object(User.Objects, 'login', return_value=(1, 'mock-token', True)) as mock_login:
+                                    resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+                                    assert 200 == resp.status
+                                    r = await resp.text()
+                                    response_data = json.loads(r)
+                                    assert response_data['token'] == 'mock-token'
+                                mock_login.assert_called_once_with('testuser', 'hashedpassword', '127.0.0.1')
+                            mock_delete_tokens.assert_called_once_with(1)
+                        mock_user_all.assert_called_once_with()
+                    mock_get_bearer_token.assert_called_once_with('test-service')
+                mock_validate_token.assert_called_once_with(bearer_token)
+            mock_logger_info.assert_called_once()
+            info_call_args = mock_logger_info.call_args[0]
+            assert "Successful password login for user 'testuser' via service 'test-service'" in info_call_args[0]
+        mock_logger_warning.assert_called_once()
+        warning_call_args = mock_logger_warning.call_args[0]
+        assert "Failed to delete existing tokens for user 'testuser'" in warning_call_args[0]
+
+    async def test_service_login_no_peername_uses_default_host(self, client):
+        bearer_token = "valid.jwt.token"
+        user_data = [{'id': 1, 'uname': 'testuser', 'enabled': 't', 'role_id': 1, 'access_method': 'any', 'pwd': 'hashedpassword'}]
+        data = {"username": "testuser"}
+        headers = {"Authorization": f"Bearer {bearer_token}"}
+        with patch.object(server._logger, 'info') as mock_logger_info:
+            with patch.object(Server, 'validate_token', return_value={'sub': 'test-service'}) as mock_validate_token:
+                with patch.object(ServiceRegistry, 'getBearerToken', return_value=bearer_token) as mock_get_bearer_token:
+                    with patch.object(User.Objects, 'all', return_value=user_data) as mock_user_all:
+                        with patch.object(User.Objects, 'delete_user_tokens', return_value=None) as mock_delete_tokens:
+                            with patch.object(User.Objects, 'login', return_value=(1, 'mock-token', True)) as mock_login:
+                                resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+                                assert 200 == resp.status
+                                r = await resp.text()
+                                response_data = json.loads(r)
+                                assert response_data['token'] == 'mock-token'
+                            mock_login.assert_called_once()
+                            args, kwargs = mock_login.call_args
+                            assert len(args) == 3
+                            assert args[0] == 'testuser'
+                            assert args[1] == 'hashedpassword'
+                            # args[2] is the host IP - could be 127.0.0.1 or similar
+                            assert kwargs == {}
+                        mock_delete_tokens.assert_called_once_with(1)
+                    mock_user_all.assert_called_once_with()
+                mock_get_bearer_token.assert_called_once_with('test-service')
+            mock_validate_token.assert_called_once_with(bearer_token)
+        mock_logger_info.assert_called_once()
+
+    async def test_service_login_error_handling_invalid_json(self, client):
+        resp = await client.post('/fledge/service/login', data='{"invalid": json}')
+        assert 400 == resp.status
+        assert "valid JSON" in resp.reason
+        r = await resp.text()
+        json_response = json.loads(r)
+        assert 'message' in json_response
+        assert "valid JSON" in json_response['message']
+
+    async def test_service_login_uses_constant_time_comparison(self, client):
+        bearer_token = "valid.jwt.token"
+        user_data = [{'id': 1, 'uname': 'testuser', 'enabled': 't', 'role_id': 1, 'access_method': 'any', 'pwd': 'hashedpassword'}]
+        data = {"username": "testuser"}
+        headers = {"Authorization": f"Bearer {bearer_token}"}
+        with patch.object(server._logger, 'info') as mock_logger_info:
+            with patch.object(Server, 'validate_token', return_value={'sub': 'test-service'}):
+                with patch.object(ServiceRegistry, 'getBearerToken', return_value=bearer_token):
+                    with patch('hmac.compare_digest', return_value=True) as mock_compare:
+                        with patch.object(User.Objects, 'all', return_value=user_data):
+                            with patch.object(User.Objects, 'delete_user_tokens', return_value=None):
+                                with patch.object(User.Objects, 'login', return_value=(1, 'mock-token', True)):
+                                    resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+                                    assert 200 == resp.status
+                                    r = await resp.text()
+                                    response_data = json.loads(r)
+                                    assert response_data['token'] == 'mock-token'
+                    assert mock_compare.call_count >= 2
+                    for call in mock_compare.call_args_list:
+                        args, kwargs = call
+                        assert len(args) == 2
+                        assert isinstance(args[0], str)
+                        assert isinstance(args[1], str)
+                        assert kwargs == {}
+        mock_logger_info.assert_called_once()
+
+    async def test_service_login_trims_whitespace_username(self, client):
+        bearer_token = "valid.jwt.token"
+        user_data = [{'id': 1, 'uname': 'testuser', 'enabled': 't', 'role_id': 1, 'access_method': 'any', 'pwd': 'hashedpassword'}]
+        data = {"username": "  testuser  "}
+        headers = {"Authorization": f"Bearer {bearer_token}"}
+        with patch.object(server._logger, 'info') as mock_logger_info:
+            with patch.object(Server, 'validate_token', return_value={'sub': 'test-service'}) as mock_validate_token:
+                with patch.object(ServiceRegistry, 'getBearerToken', return_value=bearer_token) as mock_get_bearer_token:
+                    with patch.object(User.Objects, 'all', return_value=user_data) as mock_user_all:
+                        with patch.object(User.Objects, 'delete_user_tokens', return_value=None) as mock_delete_tokens:
+                            with patch.object(User.Objects, 'login', return_value=(1, 'mock-token', True)) as mock_login:
+                                resp = await client.post('/fledge/service/login', data=json.dumps(data), headers=headers)
+                                assert 200 == resp.status
+                                r = await resp.text()
+                                response_data = json.loads(r)
+                                assert response_data['token'] == 'mock-token'
+                            mock_login.assert_called_once()
+                            args, kwargs = mock_login.call_args
+                            assert len(args) == 3
+                            assert args[0] == 'testuser'
+                            assert args[1] == 'hashedpassword'
+                            # args[2] is the host IP
+                            assert kwargs == {}
+                        mock_delete_tokens.assert_called_once_with(1)
+                    mock_user_all.assert_called_once_with()
+                mock_get_bearer_token.assert_called_once_with('test-service')
+            mock_validate_token.assert_called_once_with(bearer_token)
+        mock_logger_info.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_change(self):


### PR DESCRIPTION
Changes Made:
- [x] Removed the existing GET endpoint for authtoken, which previously used hardcoded admin credentials.
- [x] Introduced a new service-based login API route accessible via the core management port, with added flexibility to pass the username in the request payload.

🔍 Notes:

- Currently, only the Management Service consumes the removed GET endpoint. Therefore, its removal is safe.
- Updating the Management Service to use the new login API will be handled separately under JIRA-10237.